### PR TITLE
unordered map

### DIFF
--- a/src/decoders/common/api/jsonreader.hpp
+++ b/src/decoders/common/api/jsonreader.hpp
@@ -401,7 +401,7 @@ struct MessageDefinition
     uint32_t logID{0};
     std::string name;
     std::string description;
-    std::map<uint32_t, std::vector<novatel::edie::BaseField*>> fields; // map of crc keys to field defs
+    std::unordered_map<uint32_t, std::vector<novatel::edie::BaseField*>> fields; // map of crc keys to field defs
     uint32_t latestMessageCrc{0};
 
     MessageDefinition() = default;


### PR DESCRIPTION
std::map has a time complexity of O(log(N)). std::unordered_map has a time complexity of O(1). In cases like this where we are indexing by a hash, we don't care about order and can choose the more performant option.