### PR TITLE
remove intermediate message

### DIFF
--- a/examples/novatel/converter_components/converter_components.cpp
+++ b/examples/novatel/converter_components/converter_components.cpp
@@ -140,7 +140,7 @@ int main(int argc, char* argv[])
     auto eEncoderStatus = STATUS::UNKNOWN;
 
     IntermediateHeader stHeader;
-    IntermediateMessage stMessage;
+    std::vector<FieldContainer> stMessage;
 
     MetaDataStruct stMetaData;
     MessageDataStruct stMessageData;

--- a/examples/novatel/dynamic_components/dynamic_components.cpp
+++ b/examples/novatel/dynamic_components/dynamic_components.cpp
@@ -126,7 +126,7 @@ int main(int argc, char* argv[])
     auto eEncoderStatus = STATUS::UNKNOWN;
 
     IntermediateHeader stHeader;
-    IntermediateMessage stMessage;
+    std::vector<FieldContainer> stMessage;
 
     MetaDataStruct stMetaData;
     MessageDataStruct stMessageData;

--- a/examples/novatel/range_decompressor/range_decompressor.cpp
+++ b/examples/novatel/range_decompressor/range_decompressor.cpp
@@ -138,7 +138,7 @@ int main(int argc, char* argv[])
     auto eStatus = STATUS::UNKNOWN;
 
     IntermediateHeader stHeader;
-    IntermediateMessage stMessage;
+    std::vector<FieldContainer> stMessage;
 
     MetaDataStruct stMetaData;
     MessageDataStruct stMessageData;

--- a/src/decoders/common/api/encoder.hpp
+++ b/src/decoders/common/api/encoder.hpp
@@ -135,7 +135,7 @@ class EncoderBase
 
     // Encode binary
     template <bool Flatten, bool Align>
-    [[nodiscard]] bool EncodeBinaryBody(const IntermediateMessage& stInterMessage_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_);
+    [[nodiscard]] bool EncodeBinaryBody(const std::vector<FieldContainer>& stInterMessage_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_);
     [[nodiscard]] virtual bool FieldToBinary(const FieldContainer& fc_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_);
 
     // Encode ascii

--- a/src/decoders/common/api/message_decoder.hpp
+++ b/src/decoders/common/api/message_decoder.hpp
@@ -62,8 +62,6 @@ struct FieldContainer
     }
 };
 
-using IntermediateMessage = std::vector<FieldContainer>;
-
 //============================================================================
 //! \class MessageDecoderBase
 //! \brief Class to decode messages.
@@ -191,7 +189,7 @@ class MessageDecoderBase
     //!   UNSUPPORTED: Attempted to decode an unsupported format.
     //!   UNKNOWN: The header format provided is not known.
     //----------------------------------------------------------------------------
-    [[nodiscard]] STATUS Decode(unsigned char* pucMessage_, IntermediateMessage& stInterMessage_, MetaDataBase& stMetaData_) const;
+    [[nodiscard]] STATUS Decode(unsigned char* pucMessage_, std::vector<FieldContainer>& stInterMessage_, MetaDataBase& stMetaData_) const;
 };
 
 } // namespace novatel::edie

--- a/src/decoders/common/src/encoder.cpp
+++ b/src/decoders/common/src/encoder.cpp
@@ -83,7 +83,7 @@ void EncoderBase::ShutdownLogger() { Logger::Shutdown(); }
 
 // -------------------------------------------------------------------------------------------------------
 template <bool Flatten, bool Align>
-bool EncoderBase::EncodeBinaryBody(const IntermediateMessage& stInterMessage_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_)
+bool EncoderBase::EncodeBinaryBody(const std::vector<FieldContainer>& stInterMessage_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_)
 {
     unsigned char* pucTempStart;
 
@@ -213,10 +213,10 @@ bool EncoderBase::EncodeBinaryBody(const IntermediateMessage& stInterMessage_, u
 }
 
 // explicit template instantiations
-template bool EncoderBase::EncodeBinaryBody<false, false>(const IntermediateMessage&, unsigned char**, uint32_t&);
-template bool EncoderBase::EncodeBinaryBody<false, true>(const IntermediateMessage&, unsigned char**, uint32_t&);
-template bool EncoderBase::EncodeBinaryBody<true, false>(const IntermediateMessage&, unsigned char**, uint32_t&);
-template bool EncoderBase::EncodeBinaryBody<true, true>(const IntermediateMessage&, unsigned char**, uint32_t&);
+template bool EncoderBase::EncodeBinaryBody<false, false>(const std::vector<FieldContainer>&, unsigned char**, uint32_t&);
+template bool EncoderBase::EncodeBinaryBody<false, true>(const std::vector<FieldContainer>&, unsigned char**, uint32_t&);
+template bool EncoderBase::EncodeBinaryBody<true, false>(const std::vector<FieldContainer>&, unsigned char**, uint32_t&);
+template bool EncoderBase::EncodeBinaryBody<true, true>(const std::vector<FieldContainer>&, unsigned char**, uint32_t&);
 
 // -------------------------------------------------------------------------------------------------------
 bool EncoderBase::FieldToBinary(const FieldContainer& fc_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_)

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -687,7 +687,7 @@ void MessageDecoderBase::DecodeJsonField(const BaseField* pstMessageDataType_, c
 
 // -------------------------------------------------------------------------------------------------------
 STATUS
-MessageDecoderBase::Decode(unsigned char* pucMessage_, IntermediateMessage& stInterMessage_, MetaDataBase& stMetaData_) const
+MessageDecoderBase::Decode(unsigned char* pucMessage_, std::vector<FieldContainer>& stInterMessage_, MetaDataBase& stMetaData_) const
 {
     if (pucMessage_ == nullptr) { return STATUS::NULL_PROVIDED; }
 

--- a/src/decoders/common/test/message_decoder_unit_test.cpp
+++ b/src/decoders/common/test/message_decoder_unit_test.cpp
@@ -385,7 +385,7 @@ TEST_F(MessageDecoderTypesTest, SIMPLE_FIELD_WIDTH_VALID)
     MsgDefFields.emplace_back(new BaseField("", FIELD_TYPE::SIMPLE, "%f", 4, DATA_TYPE::FLOAT));
     MsgDefFields.emplace_back(new BaseField("", FIELD_TYPE::SIMPLE, "%lf", 8, DATA_TYPE::DOUBLE));
 
-    IntermediateMessage vIntermediateFormat;
+    std::vector<FieldContainer> vIntermediateFormat;
     vIntermediateFormat.reserve(MsgDefFields.size());
 
     auto testInput = "TRUE,0x63,227,56,2734,-3842,38283,54244,-4359,5293,79338432,-289834,2.54,5.44061788e+03";

--- a/src/decoders/dynamic_library/api/novatel_encoder.hpp
+++ b/src/decoders/dynamic_library/api/novatel_encoder.hpp
@@ -48,7 +48,7 @@ extern "C"
     // R/W
     DECODERS_EXPORT novatel::edie::STATUS NovatelEncoderEncode(novatel::edie::oem::Encoder* pclEncoder_, unsigned char* pucEncodeBuffer_,
                                                                uint32_t uiEncodeBufferSize_, novatel::edie::oem::IntermediateHeader* pstInterHeader_,
-                                                               novatel::edie::IntermediateMessage* pstInterMessage_,
+                                                               novatel::edie::std::vector<FieldContainer>* pstInterMessage_,
                                                                novatel::edie::MessageDataStruct* pstMessageData_,
                                                                novatel::edie::oem::MetaDataStruct* pstMetaData_,
                                                                novatel::edie::ENCODE_FORMAT uiEncodeFormat_);

--- a/src/decoders/dynamic_library/api/novatel_encoder.hpp
+++ b/src/decoders/dynamic_library/api/novatel_encoder.hpp
@@ -48,7 +48,7 @@ extern "C"
     // R/W
     DECODERS_EXPORT novatel::edie::STATUS NovatelEncoderEncode(novatel::edie::oem::Encoder* pclEncoder_, unsigned char* pucEncodeBuffer_,
                                                                uint32_t uiEncodeBufferSize_, novatel::edie::oem::IntermediateHeader* pstInterHeader_,
-                                                               novatel::edie::std::vector<FieldContainer>* pstInterMessage_,
+                                                               std::vector<novatel::edie::FieldContainer>* pstInterMessage_,
                                                                novatel::edie::MessageDataStruct* pstMessageData_,
                                                                novatel::edie::oem::MetaDataStruct* pstMetaData_,
                                                                novatel::edie::ENCODE_FORMAT uiEncodeFormat_);

--- a/src/decoders/dynamic_library/api/novatel_message_decoder.hpp
+++ b/src/decoders/dynamic_library/api/novatel_message_decoder.hpp
@@ -48,7 +48,8 @@ extern "C"
 
     // R/W
     DECODERS_EXPORT novatel::edie::STATUS NovatelMessageDecoderDecode(novatel::edie::oem::MessageDecoder* pclMessageDecoder_,
-                                                                      unsigned char* pucLogBuf_, std::vector<novatel::edie::FieldContainer>* pstInterMessage_,
+                                                                      unsigned char* pucLogBuf_,
+                                                                      std::vector<novatel::edie::FieldContainer>* pstInterMessage_,
                                                                       novatel::edie::oem::MetaDataStruct* pstMetaData_);
 
     // Intermediate Log handling.

--- a/src/decoders/dynamic_library/api/novatel_message_decoder.hpp
+++ b/src/decoders/dynamic_library/api/novatel_message_decoder.hpp
@@ -46,12 +46,12 @@ extern "C"
 
     // R/W
     DECODERS_EXPORT novatel::edie::STATUS NovatelMessageDecoderDecode(novatel::edie::oem::MessageDecoder* pclMessageDecoder_,
-                                                                      unsigned char* pucLogBuf_, novatel::edie::IntermediateMessage* pstInterMessage_,
+                                                                      unsigned char* pucLogBuf_, novatel::edie::std::vector<FieldContainer>* pstInterMessage_,
                                                                       novatel::edie::oem::MetaDataStruct* pstMetaData_);
 
     // Intermediate Log handling.
-    DECODERS_EXPORT novatel::edie::IntermediateMessage* NovatelIntermediateMessageInit();
-    DECODERS_EXPORT void NovatelIntermediateMessageDelete(novatel::edie::IntermediateMessage* pstInterMessage_);
+    DECODERS_EXPORT novatel::edie::std::vector<FieldContainer>* NovatelIntermediateMessageInit();
+    DECODERS_EXPORT void NovatelIntermediateMessageDelete(novatel::edie::std::vector<FieldContainer>* pstInterMessage_);
 }
 
 #endif // DYNAMIC_LIBRARY_NOVATEL_MESSAGE_DECODER_HPP

--- a/src/decoders/dynamic_library/api/novatel_message_decoder.hpp
+++ b/src/decoders/dynamic_library/api/novatel_message_decoder.hpp
@@ -27,6 +27,8 @@
 #ifndef DYNAMIC_LIBRARY_NOVATEL_MESSAGE_DECODER_HPP
 #define DYNAMIC_LIBRARY_NOVATEL_MESSAGE_DECODER_HPP
 
+#include <vector>
+
 #include "decoders/novatel/api/common.hpp"
 #include "decoders/novatel/api/message_decoder.hpp"
 #include "decoders_export.h"
@@ -46,12 +48,12 @@ extern "C"
 
     // R/W
     DECODERS_EXPORT novatel::edie::STATUS NovatelMessageDecoderDecode(novatel::edie::oem::MessageDecoder* pclMessageDecoder_,
-                                                                      unsigned char* pucLogBuf_, novatel::edie::std::vector<FieldContainer>* pstInterMessage_,
+                                                                      unsigned char* pucLogBuf_, std::vector<novatel::edie::FieldContainer>* pstInterMessage_,
                                                                       novatel::edie::oem::MetaDataStruct* pstMetaData_);
 
     // Intermediate Log handling.
-    DECODERS_EXPORT novatel::edie::std::vector<FieldContainer>* NovatelIntermediateMessageInit();
-    DECODERS_EXPORT void NovatelIntermediateMessageDelete(novatel::edie::std::vector<FieldContainer>* pstInterMessage_);
+    DECODERS_EXPORT std::vector<novatel::edie::FieldContainer>* NovatelIntermediateMessageInit();
+    DECODERS_EXPORT void NovatelIntermediateMessageDelete(std::vector<novatel::edie::FieldContainer>* pstInterMessage_);
 }
 
 #endif // DYNAMIC_LIBRARY_NOVATEL_MESSAGE_DECODER_HPP

--- a/src/decoders/dynamic_library/src/novatel_encoder.cpp
+++ b/src/decoders/dynamic_library/src/novatel_encoder.cpp
@@ -58,7 +58,7 @@ void NovatelEncoderLoadJson(Encoder* pclEncoder_, JsonReader* pclJsonDb_)
 }
 
 STATUS NovatelEncoderEncode(Encoder* pclEncoder_, unsigned char* pucEncodeBuffer_, uint32_t uiEncodeBufferSize_, IntermediateHeader* pstInterHeader_,
-                            IntermediateMessage* pstInterMessage_, MessageDataStruct* pstMessageData_, MetaDataStruct* pstMetaData_,
+                            std::vector<FieldContainer>* pstInterMessage_, MessageDataStruct* pstMessageData_, MetaDataStruct* pstMetaData_,
                             ENCODE_FORMAT eEncodeFormat_)
 {
     return pclEncoder_ && pucEncodeBuffer_ && pstInterHeader_ && pstInterMessage_ && pstMessageData_ && pstMetaData_

--- a/src/decoders/dynamic_library/src/novatel_message_decoder.cpp
+++ b/src/decoders/dynamic_library/src/novatel_message_decoder.cpp
@@ -56,16 +56,16 @@ void NovatelMessageDecoderLoadJson(oem::MessageDecoder* pclMessageDecoder_, Json
     if (pclMessageDecoder_ && pclJsonDb_) { pclMessageDecoder_->LoadJsonDb(pclJsonDb_); }
 }
 
-STATUS NovatelMessageDecoderDecode(oem::MessageDecoder* pclMessageDecoder_, unsigned char* pucLogBuf_, IntermediateMessage* pstInterMessage_,
+STATUS NovatelMessageDecoderDecode(oem::MessageDecoder* pclMessageDecoder_, unsigned char* pucLogBuf_, std::vector<FieldContainer>* pstInterMessage_,
                                    oem::MetaDataStruct* pstMetaData_)
 {
     return pclMessageDecoder_ && pstInterMessage_ && pstMetaData_ ? pclMessageDecoder_->Decode(pucLogBuf_, *pstInterMessage_, *pstMetaData_)
                                                                   : STATUS::NULL_PROVIDED;
 }
 
-IntermediateMessage* NovatelIntermediateMessageInit() { return new IntermediateMessage(); }
+std::vector<FieldContainer>* NovatelIntermediateMessageInit() { return new std::vector<FieldContainer>(); }
 
-void NovatelIntermediateMessageDelete(IntermediateMessage* pstInterMessage_)
+void NovatelIntermediateMessageDelete(std::vector<FieldContainer>* pstInterMessage_)
 {
     if (pstInterMessage_)
     {

--- a/src/decoders/novatel/api/encoder.hpp
+++ b/src/decoders/novatel/api/encoder.hpp
@@ -111,7 +111,7 @@ class Encoder : public EncoderBase
     //! encoding.
     //----------------------------------------------------------------------------
     [[nodiscard]] STATUS Encode(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
-                                const IntermediateMessage& stMessage_, MessageDataStruct& stMessageData_, const MetaDataStruct& stMetaData_,
+                                const std::vector<FieldContainer>& stMessage_, MessageDataStruct& stMessageData_, const MetaDataStruct& stMetaData_,
                                 ENCODE_FORMAT eFormat_);
 
     //----------------------------------------------------------------------------
@@ -174,7 +174,7 @@ class Encoder : public EncoderBase
     //!   UNSUPPORTED: eEncodeFormat_ contains a format that is not supported for
     //! encoding.
     //----------------------------------------------------------------------------
-    [[nodiscard]] STATUS EncodeBody(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateMessage& stMessage_,
+    [[nodiscard]] STATUS EncodeBody(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const std::vector<FieldContainer>& stMessage_,
                                     MessageDataStruct& stMessageData_, const MetaDataStruct& stMetaData_, ENCODE_FORMAT eFormat_);
 };
 

--- a/src/decoders/novatel/src/commander.cpp
+++ b/src/decoders/novatel/src/commander.cpp
@@ -124,7 +124,7 @@ STATUS Commander::Encode(const char* pcAbbrevAsciiCommand_, const uint32_t uiAbb
     MessageDataStruct stMessageData;
     MetaDataStruct stMetaData;
     IntermediateHeader stIntermediateHeader;
-    IntermediateMessage stIntermediateMessage;
+    std::vector<FieldContainer> stIntermediateMessage;
 
     // Prime the metadata with information we already know
     stMetaData.eFormat = HEADER_FORMAT::ABB_ASCII;
@@ -177,7 +177,7 @@ STATUS Commander::Encode(const JsonReader& clJsonDb_, const MessageDecoder& clMe
     MessageDataStruct stMessageData;
     MetaDataStruct stMetaData;
     IntermediateHeader stIntermediateHeader;
-    IntermediateMessage stIntermediateMessage;
+    std::vector<FieldContainer> stIntermediateMessage;
 
     // Prime the metadata with information we already know
     stMetaData.eFormat = HEADER_FORMAT::ABB_ASCII;

--- a/src/decoders/novatel/src/encoder.cpp
+++ b/src/decoders/novatel/src/encoder.cpp
@@ -332,8 +332,9 @@ bool Encoder::EncodeJsonShortHeader(const IntermediateHeader& stInterHeader_, ch
 
 // -------------------------------------------------------------------------------------------------------
 STATUS
-Encoder::Encode(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_, const IntermediateMessage& stMessage_,
-                MessageDataStruct& stMessageData_, const MetaDataStruct& stMetaData_, const ENCODE_FORMAT eFormat_)
+Encoder::Encode(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+                const std::vector<FieldContainer>& stMessage_, MessageDataStruct& stMessageData_, const MetaDataStruct& stMetaData_,
+                const ENCODE_FORMAT eFormat_)
 {
     if (ppucBuffer_ == nullptr || *ppucBuffer_ == nullptr) { return STATUS::NULL_PROVIDED; }
 
@@ -426,8 +427,8 @@ Encoder::EncodeHeader(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const
 
 // -------------------------------------------------------------------------------------------------------
 STATUS
-Encoder::EncodeBody(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateMessage& stMessage_, MessageDataStruct& stMessageData_,
-                    const MetaDataStruct& stMetaData_, ENCODE_FORMAT eFormat_)
+Encoder::EncodeBody(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const std::vector<FieldContainer>& stMessage_,
+                    MessageDataStruct& stMessageData_, const MetaDataStruct& stMetaData_, ENCODE_FORMAT eFormat_)
 {
     // TODO: this entire function should be in common, only header stuff and map redefinitions belong in this file
     if (ppucBuffer_ == nullptr || *ppucBuffer_ == nullptr) { return STATUS::NULL_PROVIDED; }

--- a/src/decoders/novatel/src/parser.cpp
+++ b/src/decoders/novatel/src/parser.cpp
@@ -195,7 +195,7 @@ STATUS
 Parser::Read(MessageDataStruct& stMessageData_, MetaDataStruct& stMetaData_, bool bDecodeIncompleteAbbreviated_)
 {
     IntermediateHeader stHeader;
-    IntermediateMessage stMessage;
+    std::vector<FieldContainer> stMessage;
 
     while (true)
     {

--- a/src/decoders/novatel/src/rangecmp/range_decompressor.cpp
+++ b/src/decoders/novatel/src/rangecmp/range_decompressor.cpp
@@ -993,7 +993,7 @@ RangeDecompressor::Decompress(unsigned char* pucRangeMessageBuffer_, uint32_t ui
 
     MessageDataStruct stMessageData;
     IntermediateHeader stHeader;
-    IntermediateMessage stMessage;
+    std::vector<FieldContainer> stMessage;
     auto eStatus = STATUS::UNKNOWN;
 
     unsigned char* pucTempMessagePointer = pucRangeMessageBuffer_;

--- a/src/decoders/novatel/src/rxconfig/rxconfig_handler.cpp
+++ b/src/decoders/novatel/src/rxconfig/rxconfig_handler.cpp
@@ -82,7 +82,7 @@ RxConfigHandler::Convert(MessageDataStruct& stRxConfigMessageData_, MetaDataStru
 {
     IntermediateHeader stRxConfigHeader;
     IntermediateHeader stEmbeddedHeader;
-    IntermediateMessage stEmbeddedMessage;
+    std::vector<FieldContainer> stEmbeddedMessage;
 
     unsigned char* pucTempMessagePointer = pcMyFrameBuffer.get();
 
@@ -113,7 +113,7 @@ RxConfigHandler::Convert(MessageDataStruct& stRxConfigMessageData_, MetaDataStru
     if (eStatus == STATUS::NO_DEFINITION) { return STATUS::NO_DEFINITION_EMBEDDED; }
     if (eStatus != STATUS::SUCCESS) { return eStatus; }
 
-    // Put an IntermediateMessage struct into the RXCONFIG IntermediateMessage, then
+    // Put a std::vector<FieldContainer> into the RXCONFIG IntermediateMessage, then
     // pass it to the message decoder as a destination for the embedded message.
     eStatus = clMyMessageDecoder.Decode((pucTempMessagePointer + stEmbeddedMetaData_.uiHeaderLength), stEmbeddedMessage, stEmbeddedMetaData_);
     if (eStatus == STATUS::NO_DEFINITION) { return STATUS::NO_DEFINITION_EMBEDDED; }

--- a/src/decoders/novatel/test/novatel_test.cpp
+++ b/src/decoders/novatel/test/novatel_test.cpp
@@ -27,6 +27,7 @@
 #include <chrono>
 #include <codecvt>
 #include <filesystem>
+#include <gtest/gtest.h>
 #include <iostream>
 #include <locale>
 #include <nlohmann/json.hpp>
@@ -42,7 +43,6 @@
 #include "hw_interface/stream_interface/api/inputfilestream.hpp"
 #include "hw_interface/stream_interface/api/inputstreaminterface.hpp"
 #include "resources/novatel_message_definitions.hpp"
-#include <gtest/gtest.h>
 
 using json = nlohmann::json;
 
@@ -964,7 +964,7 @@ public:
    int32_t DecodeEncode(ENCODE_FORMAT eFormat_, unsigned char* pucMessageBuffer_, unsigned char* pucEncodeBuffer_, uint32_t uiEncodeBufferSize_, MetaDataStruct& stMetaData_, MessageDataStruct& stMessageData_)
    {
       IntermediateHeader stHeader;
-      IntermediateMessage stMessage;
+      std::vector<FieldContainer> stMessage;
 
       unsigned char* pucTempPtr = pucMessageBuffer_;
       STATUS eStatus = pclMyHeaderDecoder->Decode(pucTempPtr, stHeader, stMetaData_);
@@ -1847,7 +1847,7 @@ TEST_F(DecodeEncodeTest, ENCODEFORMAT_UNSPECIFIED)
    MessageDataStruct stMessageData;
 
    IntermediateHeader stHeader;
-   IntermediateMessage stMessage;
+   std::vector<FieldContainer> stMessage;
 
    unsigned char acEncodeBuffer[MAX_ASCII_MESSAGE_LENGTH];
    unsigned char* pucEncodeBuffer = acEncodeBuffer;
@@ -2284,7 +2284,7 @@ void BenchmarkHelper(BenchmarkTest& test, unsigned char* aucLog)
       unsigned char* pucEncodeBuffer = aucEncodeBuffer;
 
       IntermediateHeader stHeader;
-      IntermediateMessage stMessage;
+      std::vector<FieldContainer> stMessage;
 
       MetaDataStruct stMetaData;
       MessageDataStruct stMessageData;
@@ -2936,7 +2936,7 @@ protected:
    public:
       EncoderTester(JsonReader* pclJsonDb_) : Encoder(pclJsonDb_) {}
 
-      bool TestEncodeBinaryBody(const IntermediateMessage& stInterMessage_, unsigned char** ppcOutBuf_, uint32_t uiBytes)
+      bool TestEncodeBinaryBody(const std::vector<FieldContainer>& stInterMessage_, unsigned char** ppcOutBuf_, uint32_t uiBytes)
       {
          return EncodeBinaryBody<false, true>(stInterMessage_, ppcOutBuf_, uiBytes);
       }


### PR DESCRIPTION
IntermediateMessage is obfuscating something that is a simple vector of fieldcontainers and it has caused more trouble than any convenience it provides.