### PR TITLE
Replace FileExists() with std::filesystem, avoid src/ prefix in includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The FileParser class provides an interface for parsing GPS files.
 ```cpp
 #include <iostream>
 
-#include "src/decoders/novatel/api/fileparser.hpp"
+#include "decoders/novatel/api/fileparser.hpp"
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
@@ -206,7 +206,7 @@ Note that all fields must be provided in the abbreviated ASCII string command in
 ```cpp
 #include <iostream>
 
-#include "src/decoders/novatel/api/commander.hpp"
+#include "decoders/novatel/api/commander.hpp"
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;

--- a/examples/novatel/command_encoding/command_encoding.cpp
+++ b/examples/novatel/command_encoding/command_encoding.cpp
@@ -25,18 +25,15 @@
 // ===============================================================================
 
 #include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
 
-#include "src/decoders/novatel/api/commander.hpp"
-#include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
+#include <decoders/novatel/api/commander.hpp>
+#include <hw_interface/stream_interface/api/outputfilestream.hpp>
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -50,14 +47,14 @@ int main(int argc, char* argv[])
 
     if (argc < 3)
     {
-        logger->error("Format: command_encoding.exe <path to Json DB> <output format> <abbreviated ascii command>\n");
-        logger->error("Example: command_encoding.exe database/messages_public.json ASCII \"RTKTIMEOUT 30\"\n");
+        logger->error("Format: command_encoding <path to Json DB> <output format> <abbreviated ascii command>\n");
+        logger->error("Example: command_encoding database/messages_public.json ASCII \"RTKTIMEOUT 30\"\n");
         return 1;
     }
 
     // Json DB
-    std::string strJsonDb = argv[1];
-    if (!FileExists(strJsonDb))
+    std::string sJsonDb = argv[1];
+    if (!std::filesystem::exists(sJsonDb))
     {
         logger->error("File \"{}\" does not exist", argv[1]);
         return 1;
@@ -75,7 +72,7 @@ int main(int argc, char* argv[])
     JsonReader clJsonDb;
     auto tStart = std::chrono::high_resolution_clock::now();
     logger->info("Loading Database... ");
-    clJsonDb.LoadFile(strJsonDb);
+    clJsonDb.LoadFile(sJsonDb);
     logger->info("Done in {}ms", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
 
     Commander clCommander(&clJsonDb);

--- a/examples/novatel/converter_components/converter_components.cpp
+++ b/examples/novatel/converter_components/converter_components.cpp
@@ -25,26 +25,23 @@
 // ===============================================================================
 
 #include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
 
-#include "logger/logger.hpp"
-#include "src/decoders/common/api/json_reader.hpp"
-#include "src/decoders/novatel/api/encoder.hpp"
-#include "src/decoders/novatel/api/filter.hpp"
-#include "src/decoders/novatel/api/framer.hpp"
-#include "src/decoders/novatel/api/header_decoder.hpp"
-#include "src/decoders/novatel/api/message_decoder.hpp"
-#include "src/hw_interface/stream_interface/api/inputfilestream.hpp"
-#include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
-#include "src/version.h"
+#include <decoders/common/api/logger.hpp>
+#include <decoders/common/api/json_reader.hpp>
+#include <decoders/novatel/api/encoder.hpp>
+#include <decoders/novatel/api/filter.hpp>
+#include <decoders/novatel/api/framer.hpp>
+#include <decoders/novatel/api/header_decoder.hpp>
+#include <decoders/novatel/api/message_decoder.hpp>
+#include <hw_interface/stream_interface/api/inputfilestream.hpp>
+#include <hw_interface/stream_interface/api/outputfilestream.hpp>
+#include <version.h>
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -64,21 +61,21 @@ int main(int argc, char* argv[])
     if (argc < 3)
     {
         pclLogger->error("ERROR: Need to specify a JSON message definitions DB, an input file and an output format.");
-        pclLogger->error("Example: converter.exe <path to Json DB> <path to input file> <output format>");
+        pclLogger->error("Example: converter <path to Json DB> <path to input file> <output format>");
         return 1;
     }
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
     // Check command line arguments
     std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    if (!std::filesystem::exists(sJsonDb))
     {
         pclLogger->error("File \"{}\" does not exist", sJsonDb);
         return 1;
     }
 
     std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    if (!std::filesystem::exists(sInFilename))
     {
         pclLogger->error("File \"{}\" does not exist", sInFilename);
         return 1;
@@ -191,6 +188,7 @@ int main(int argc, char* argv[])
                     if (!clFilter.DoFiltering(stMetaData)) { continue; }
 
                     pucFrameBuffer += stMetaData.uiHeaderLength;
+                    uint32_t uiBodyLength = stMetaData.uiLength - stMetaData.uiHeaderLength;
                     // Decode the Log, pass the metadata and populate the intermediate log.
                     eDecoderStatus = clMessageDecoder.Decode(pucFrameBuffer, stMessage, stMetaData);
 
@@ -207,13 +205,13 @@ int main(int argc, char* argv[])
                         }
                         else
                         {
-                            clUnknownBytesOfs.WriteData(reinterpret_cast<char*>(pucFrameBuffer), stMetaData.uiLength);
+                            clUnknownBytesOfs.WriteData(reinterpret_cast<char*>(pucFrameBuffer), uiBodyLength);
                             pclLogger->warn("Encoder returned with status code {}", static_cast<int>(eEncoderStatus));
                         }
                     }
                     else
                     {
-                        clUnknownBytesOfs.WriteData(reinterpret_cast<char*>(pucFrameBuffer), stMetaData.uiLength);
+                        clUnknownBytesOfs.WriteData(reinterpret_cast<char*>(pucFrameBuffer), uiBodyLength);
                         pclLogger->warn("MessageDecoder returned with status code {}", static_cast<int>(eDecoderStatus));
                     }
                 }

--- a/examples/novatel/converter_file_parser/converter_file_parser.cpp
+++ b/examples/novatel/converter_file_parser/converter_file_parser.cpp
@@ -25,20 +25,17 @@
 // ===============================================================================
 
 #include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
 
-#include "src/decoders/novatel/api/file_parser.hpp"
-#include "src/hw_interface/stream_interface/api/inputfilestream.hpp"
-#include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
-#include "src/version.h"
+#include <decoders/novatel/api/file_parser.hpp>
+#include <hw_interface/stream_interface/api/inputfilestream.hpp>
+#include <hw_interface/stream_interface/api/outputfilestream.hpp>
+#include <version.h>
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -58,17 +55,17 @@ int main(int argc, char* argv[])
     if (argc < 3)
     {
         pclLogger->error("ERROR: Need to specify a JSON message definitions DB, an input file and an output format.");
-        pclLogger->error("Example: converter.exe <path to Json DB> <path to input file> <output format>");
+        pclLogger->error("Example: converter <path to Json DB> <path to input file> <output format>");
         return 1;
     }
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
-    if (!FileExists(argv[1]))
+    if (!std::filesystem::exists(argv[1]))
     {
         pclLogger->error("File \"{}\" does not exist", argv[1]);
         return 1;
     }
-    if (!FileExists(argv[2]))
+    if (!std::filesystem::exists(argv[2]))
     {
         pclLogger->error("File \"{}\" does not exist", argv[2]);
         return 1;
@@ -76,14 +73,14 @@ int main(int argc, char* argv[])
 
     // Check command line arguments
     std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    if (!std::filesystem::exists(sJsonDb))
     {
         pclLogger->error("File \"{}\" does not exist", sJsonDb);
         return 1;
     }
 
     std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    if (!std::filesystem::exists(sInFilename))
     {
         pclLogger->error("File \"{}\" does not exist", sInFilename);
         return 1;
@@ -178,6 +175,7 @@ int main(int argc, char* argv[])
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
                     sInFilename.c_str());
+
     Logger::Shutdown();
     return 0;
 }

--- a/examples/novatel/converter_parser/converter_parser.cpp
+++ b/examples/novatel/converter_parser/converter_parser.cpp
@@ -25,20 +25,15 @@
 // ===============================================================================
 
 #include <chrono>
+#include <filesystem>
 
-#include "src/decoders/novatel/api/parser.hpp"
-#include "src/hw_interface/stream_interface/api/inputfilestream.hpp"
-#include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
-#include "src/version.h"
+#include <decoders/novatel/api/parser.hpp>
+#include <hw_interface/stream_interface/api/inputfilestream.hpp>
+#include <hw_interface/stream_interface/api/outputfilestream.hpp>
+#include <version.h>
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -58,21 +53,21 @@ int main(int argc, char* argv[])
     if (argc < 3)
     {
         pclLogger->error("ERROR: Need to specify a JSON message definitions DB, an input file and an output format.");
-        pclLogger->error("Example: converter.exe <path to Json DB> <path to input file> <output format>");
+        pclLogger->error("Example: converter <path to Json DB> <path to input file> <output format>");
         return 1;
     }
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
     // Check command line arguments
     std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    if (!std::filesystem::exists(sJsonDb))
     {
         pclLogger->error("File \"{}\" does not exist", sJsonDb);
         return 1;
     }
 
     std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    if (!std::filesystem::exists(sInFilename))
     {
         pclLogger->error("File \"{}\" does not exist", sInFilename);
         return 1;

--- a/examples/novatel/dynamic_components/dynamic_components.cpp
+++ b/examples/novatel/dynamic_components/dynamic_components.cpp
@@ -24,24 +24,20 @@
 // ! \file dynamic_components.cpp
 // ===============================================================================
 
-#include "src/decoders/dynamic_library/api/common_json_reader.hpp"
-#include "src/decoders/dynamic_library/api/novatel_encoder.hpp"
-#include "src/decoders/dynamic_library/api/novatel_filter.hpp"
-#include "src/decoders/dynamic_library/api/novatel_framer.hpp"
-#include "src/decoders/dynamic_library/api/novatel_header_decoder.hpp"
-#include "src/decoders/dynamic_library/api/novatel_message_decoder.hpp"
-#include "src/hw_interface/stream_interface/api/inputfilestream.hpp"
-#include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
-#include "src/version.h"
+#include <filesystem>
+
+#include <decoders/dynamic_library/api/common_json_reader.hpp>
+#include <decoders/dynamic_library/api/novatel_encoder.hpp>
+#include <decoders/dynamic_library/api/novatel_filter.hpp>
+#include <decoders/dynamic_library/api/novatel_framer.hpp>
+#include <decoders/dynamic_library/api/novatel_header_decoder.hpp>
+#include <decoders/dynamic_library/api/novatel_message_decoder.hpp>
+#include <hw_interface/stream_interface/api/inputfilestream.hpp>
+#include <hw_interface/stream_interface/api/outputfilestream.hpp>
+#include <version.h>
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -61,21 +57,21 @@ int main(int argc, char* argv[])
     if (argc < 3)
     {
         pclLogger->error("ERROR: Need to specify a JSON message definitions DB, an input file and an output format.");
-        pclLogger->error("Example: converter.exe <path to Json DB> <path to input file> <output format>");
+        pclLogger->error("Example: converter <path to Json DB> <path to input file> <output format>");
         return 1;
     }
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
     // Check command line arguments
     std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    if (!std::filesystem::exists(sJsonDb))
     {
         pclLogger->error("File \"{}\" does not exist", sJsonDb);
         return 1;
     }
 
     std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    if (!std::filesystem::exists(sInFilename))
     {
         pclLogger->error("File \"{}\" does not exist", sInFilename);
         return 1;
@@ -177,6 +173,7 @@ int main(int argc, char* argv[])
                     if (!NovatelFilterDoFiltering(pclFilter, &stMetaData)) { continue; }
 
                     pucFrameBuffer += stMetaData.uiHeaderLength;
+                    uint32_t uiBodyLength = stMetaData.uiLength - stMetaData.uiHeaderLength;
                     // Decode the Log, pass the metadata and populate the intermediate log.
                     eDecoderStatus = NovatelMessageDecoderDecode(pclMessageDecoder, pucFrameBuffer, &stMessage, &stMetaData);
 
@@ -193,13 +190,13 @@ int main(int argc, char* argv[])
                         }
                         else
                         {
-                            clUnknownBytesOfs.WriteData(reinterpret_cast<char*>(pucFrameBuffer), stMetaData.uiLength);
+                            clUnknownBytesOfs.WriteData(reinterpret_cast<char*>(pucFrameBuffer), uiBodyLength);
                             pclLogger->warn("Encoder returned with status code {}", static_cast<int32_t>(eEncoderStatus));
                         }
                     }
                     else
                     {
-                        clUnknownBytesOfs.WriteData(reinterpret_cast<char*>(pucFrameBuffer), stMetaData.uiLength);
+                        clUnknownBytesOfs.WriteData(reinterpret_cast<char*>(pucFrameBuffer), uiBodyLength);
                         pclLogger->warn("MessageDecoder returned with status code {}", static_cast<int32_t>(eDecoderStatus));
                     }
                 }

--- a/examples/novatel/dynamic_file_parser/dynamic_file_parser.cpp
+++ b/examples/novatel/dynamic_file_parser/dynamic_file_parser.cpp
@@ -25,22 +25,19 @@
 // ===============================================================================
 
 #include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
 
-#include "src/decoders/dynamic_library/api/common_json_reader.hpp"
-#include "src/decoders/dynamic_library/api/novatel_file_parser.hpp"
-#include "src/decoders/dynamic_library/api/novatel_filter.hpp"
-#include "src/hw_interface/stream_interface/api/inputfilestream.hpp"
-#include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
-#include "src/version.h"
+#include <decoders/dynamic_library/api/common_json_reader.hpp>
+#include <decoders/dynamic_library/api/novatel_file_parser.hpp>
+#include <decoders/dynamic_library/api/novatel_filter.hpp>
+#include <hw_interface/stream_interface/api/inputfilestream.hpp>
+#include <hw_interface/stream_interface/api/outputfilestream.hpp>
+#include <version.h>
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -60,21 +57,21 @@ int main(int argc, char* argv[])
     if (argc < 3)
     {
         pclLogger->error("ERROR: Need to specify a JSON message definitions DB, an input file and an output format.");
-        pclLogger->error("Example: converter.exe <path to Json DB> <path to input file> <output format>");
+        pclLogger->error("Example: converter <path to Json DB> <path to input file> <output format>");
         return 1;
     }
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
     // Check command line arguments
     std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    if (!std::filesystem::exists(sJsonDb))
     {
         pclLogger->error("File \"{}\" does not exist", sJsonDb);
         return 1;
     }
 
     std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    if (!std::filesystem::exists(sInFilename))
     {
         pclLogger->error("File \"{}\" does not exist", sInFilename);
         return 1;
@@ -164,6 +161,7 @@ int main(int argc, char* argv[])
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
                     sInFilename.c_str());
+
     Logger::Shutdown();
     NovatelFileParserDelete(pclFileParser);
     return 0;

--- a/examples/novatel/dynamic_parser/dynamic_parser.cpp
+++ b/examples/novatel/dynamic_parser/dynamic_parser.cpp
@@ -25,22 +25,19 @@
 // ===============================================================================
 
 #include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
 
-#include "src/decoders/dynamic_library/api/common_json_reader.hpp"
-#include "src/decoders/dynamic_library/api/novatel_filter.hpp"
-#include "src/decoders/dynamic_library/api/novatel_parser.hpp"
-#include "src/hw_interface/stream_interface/api/inputfilestream.hpp"
-#include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
-#include "src/version.h"
+#include <decoders/dynamic_library/api/common_json_reader.hpp>
+#include <decoders/dynamic_library/api/novatel_filter.hpp>
+#include <decoders/dynamic_library/api/novatel_parser.hpp>
+#include <hw_interface/stream_interface/api/inputfilestream.hpp>
+#include <hw_interface/stream_interface/api/outputfilestream.hpp>
+#include <version.h>
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -60,21 +57,21 @@ int main(int argc, char* argv[])
     if (argc < 3)
     {
         pclLogger->error("ERROR: Need to specify a JSON message definitions DB, an input file and an output format.");
-        pclLogger->error("Example: converter.exe <path to Json DB> <path to input file> <output format>");
+        pclLogger->error("Example: converter <path to Json DB> <path to input file> <output format>");
         return 1;
     }
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
     // Check command line arguments
     std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    if (!std::filesystem::exists(sJsonDb))
     {
         pclLogger->error("File \"{}\" does not exist", sJsonDb);
         return 1;
     }
 
     std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    if (!std::filesystem::exists(sInFilename))
     {
         pclLogger->error("File \"{}\" does not exist", sInFilename);
         return 1;

--- a/examples/novatel/json_parser/json_parser.cpp
+++ b/examples/novatel/json_parser/json_parser.cpp
@@ -25,20 +25,15 @@
 // ===============================================================================
 
 #include <chrono>
+#include <filesystem>
 
-#include "src/decoders/novatel/api/parser.hpp"
-#include "src/hw_interface/stream_interface/api/inputfilestream.hpp"
-#include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
-#include "src/version.h"
+#include <decoders/novatel/api/parser.hpp>
+#include <hw_interface/stream_interface/api/inputfilestream.hpp>
+#include <hw_interface/stream_interface/api/outputfilestream.hpp>
+#include <version.h>
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -58,7 +53,7 @@ int main(int argc, char* argv[])
     if (argc < 3)
     {
         pclLogger->error("ERROR: Need to specify a JSON message definitions DB, an input file and an output format.");
-        pclLogger->error("Example: converter.exe <path to Json DB> <path to input file> <output format>");
+        pclLogger->error("Example: converter <path to Json DB> <path to input file> <output format>");
         return 1;
     }
     if (argc == 4 || argc == 5) { sEncodeFormat = argv[3]; }
@@ -68,14 +63,14 @@ int main(int argc, char* argv[])
 
     // Check command line arguments
     std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    if (!std::filesystem::exists(sJsonDb))
     {
         pclLogger->error("File \"{}\" does not exist", sJsonDb);
         return 1;
     }
 
     std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    if (!std::filesystem::exists(sInFilename))
     {
         pclLogger->error("File \"{}\" does not exist", sInFilename);
         return 1;

--- a/examples/novatel/range_decompressor/range_decompressor.cpp
+++ b/examples/novatel/range_decompressor/range_decompressor.cpp
@@ -25,25 +25,22 @@
 // ===============================================================================
 
 #include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
 
-#include "src/decoders/common/api/message_decoder.hpp"
-#include "src/decoders/novatel/api/encoder.hpp"
-#include "src/decoders/novatel/api/filter.hpp"
-#include "src/decoders/novatel/api/framer.hpp"
-#include "src/decoders/novatel/api/header_decoder.hpp"
-#include "src/decoders/novatel/api/rangecmp/range_decompressor.hpp"
-#include "src/hw_interface/stream_interface/api/inputfilestream.hpp"
-#include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
-#include "src/version.h"
+#include <decoders/common/api/message_decoder.hpp>
+#include <decoders/novatel/api/encoder.hpp>
+#include <decoders/novatel/api/filter.hpp>
+#include <decoders/novatel/api/framer.hpp>
+#include <decoders/novatel/api/header_decoder.hpp>
+#include <decoders/novatel/api/rangecmp/range_decompressor.hpp>
+#include <hw_interface/stream_interface/api/inputfilestream.hpp>
+#include <hw_interface/stream_interface/api/outputfilestream.hpp>
+#include <version.h>
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -66,17 +63,17 @@ int main(int argc, char* argv[])
     if (argc < 3)
     {
         pclLogger->info("ERROR: Need to specify a JSON message definitions DB, an input file and an output format.\n");
-        pclLogger->info("Example: converter.exe <path to Json DB> <path to input file> <output format>\n");
+        pclLogger->info("Example: converter <path to Json DB> <path to input file> <output format>\n");
         return -1;
     }
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
-    if (!FileExists(argv[1]))
+    if (!std::filesystem::exists(argv[1]))
     {
         pclLogger->error("File \"{}\" does not exist", argv[1]);
         return 1;
     }
-    if (!FileExists(argv[2]))
+    if (!std::filesystem::exists(argv[2]))
     {
         pclLogger->error("File \"{}\" does not exist", argv[2]);
         return 1;

--- a/examples/novatel/rxconfig_handler/rxconfig_handler.cpp
+++ b/examples/novatel/rxconfig_handler/rxconfig_handler.cpp
@@ -25,21 +25,18 @@
 // ===============================================================================
 
 #include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
 
-#include "src/decoders/common/api/common.hpp"
-#include "src/decoders/novatel/api/rxconfig/rxconfig_handler.hpp"
-#include "src/hw_interface/stream_interface/api/inputfilestream.hpp"
-#include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
-#include "src/version.h"
+#include <decoders/common/api/common.hpp>
+#include <decoders/novatel/api/rxconfig/rxconfig_handler.hpp>
+#include <hw_interface/stream_interface/api/inputfilestream.hpp>
+#include <hw_interface/stream_interface/api/outputfilestream.hpp>
+#include <version.h>
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -59,21 +56,21 @@ int main(int argc, char* argv[])
     if (argc < 3)
     {
         pclLogger->error("ERROR: Need to specify a JSON message definitions DB, an input file and an output format.");
-        pclLogger->error("Example: converter.exe <path to Json DB> <path to input file> <output format>");
+        pclLogger->error("Example: converter <path to Json DB> <path to input file> <output format>");
         return 1;
     }
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
     // Check command line arguments
     std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    if (!std::filesystem::exists(sJsonDb))
     {
         pclLogger->error("File \"{}\" does not exist", sJsonDb);
         return 1;
     }
 
     std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    if (!std::filesystem::exists(sInFilename))
     {
         pclLogger->error("File \"{}\" does not exist", sInFilename);
         return 1;

--- a/src/decoders/dynamic_library/src/version.cpp
+++ b/src/decoders/dynamic_library/src/version.cpp
@@ -24,8 +24,8 @@
 // ! \file version.cpp
 // ===============================================================================
 
-#include "version.hpp"
-#include "src/version.h" // this refers to the EDIE version.h
+#include "decoders/dynamic_library/api/version.hpp"
+#include "version.h" // this refers to the EDIE version.h
 
 const char* Version() { return get_version(); }
 

--- a/src/decoders/novatel/src/framer.cpp
+++ b/src/decoders/novatel/src/framer.cpp
@@ -25,7 +25,7 @@
 // ===============================================================================
 
 #include "framer.hpp"
-#include "src/decoders/common/api/crc32.hpp"
+#include "decoders/common/api/crc32.hpp"
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;


### PR DESCRIPTION
A small and minor one.

The `src/` prefix should eventually be replaced with something package-specific, like `novatel_edie/`, `novatel/edie` or just `edie/`. This is just a small step in that direction.

Also fixed invalid number of bytes written in some of the C++ examples.