### PR TITLE
Fix a memory leak in CircularBuffer

### DIFF
--- a/src/decoders/common/api/circular_buffer.hpp
+++ b/src/decoders/common/api/circular_buffer.hpp
@@ -50,9 +50,9 @@ class CircularBuffer
     CircularBuffer() = default;
 
     //----------------------------------------------------------------------------
-    //! \brief Default circular buffer class Destructor.
+    //! \brief Circular buffer class Destructor.
     //----------------------------------------------------------------------------
-    ~CircularBuffer() = default;
+    ~CircularBuffer() { delete[] pucMyBuffer; }
 
     //----------------------------------------------------------------------------
     //! \brief Sets the size of the circular buffer (bytes)

--- a/src/decoders/common/src/circular_buffer.cpp
+++ b/src/decoders/common/src/circular_buffer.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <new>
 
 #include "decoders/common/api/circular_buffer.hpp"
 #include "decoders/common/api/nexcept.hpp"
@@ -37,7 +38,7 @@ void CircularBuffer::SetCapacity(const uint32_t uiCapacity_)
     // Set the size of the buffer (bytes)
     if (uiCapacity_ <= uiMyCapacity) { return; }
 
-    const auto pucBuffer = new unsigned char[uiCapacity_];
+    const auto pucBuffer = new (std::nothrow) unsigned char[uiCapacity_];
 
     // Do nothing if new failed.... just use existing buffer
     if (pucBuffer != nullptr)


### PR DESCRIPTION
- Add a destructor to properly clean up the buffer.
- `new` only returns a nullpointer as expected in the surrounding function if `std::nothrow` is used.