### PR TITLE
decoders: round instead of truncating when converting floats to int

### DIFF
--- a/src/decoders/novatel/src/header_decoder.cpp
+++ b/src/decoders/novatel/src/header_decoder.cpp
@@ -94,7 +94,7 @@ template <ASCII_HEADER eField> bool HeaderDecoder::DecodeAsciiHeaderField(Interm
         stInterHeader_.uiPortAddress = static_cast<uint32_t>(GetEnumValue(vMyPortAddressDefinitions, std::string(*ppcLogBuf_, ullTokenLength)));
         break;
     case ASCII_HEADER::SEQUENCE: stInterHeader_.usSequence = static_cast<uint16_t>(strtoul(*ppcLogBuf_, nullptr, 10)); break;
-    case ASCII_HEADER::IDLE_TIME: stInterHeader_.ucIdleTime = static_cast<uint8_t>(2.0 * strtof(*ppcLogBuf_, nullptr)); break;
+    case ASCII_HEADER::IDLE_TIME: stInterHeader_.ucIdleTime = static_cast<uint8_t>(std::lround(2.0f * strtof(*ppcLogBuf_, nullptr))); break;
     case ASCII_HEADER::TIME_STATUS:
         stInterHeader_.uiTimeStatus = GetEnumValue(vMyGpsTimeStatusDefinitions, std::string(*ppcLogBuf_, ullTokenLength));
         break;

--- a/src/decoders/novatel/src/message_decoder.cpp
+++ b/src/decoders/novatel/src/message_decoder.cpp
@@ -25,6 +25,8 @@
 // ===============================================================================
 
 #include <bitset>
+#include <cmath>
+#include <sstream>
 
 #include "decoders/novatel/api/message_decoder.hpp"
 
@@ -56,7 +58,7 @@ void MessageDecoder::InitOemFieldMaps()
     asciiFieldMap[CalculateBlockCrc32("%T")] = [](std::vector<FieldContainer>& vIntermediateFormat_, const BaseField* pstMessageDataType_,
                                                   char** ppcToken_, [[maybe_unused]] const size_t tokenLength_,
                                                   [[maybe_unused]] JsonReader* pclMsgDb_) {
-        vIntermediateFormat_.emplace_back(static_cast<uint32_t>(strtod(*ppcToken_, nullptr) * SEC_TO_MILLI_SEC), pstMessageDataType_);
+        vIntermediateFormat_.emplace_back(static_cast<uint32_t>(std::llround(strtod(*ppcToken_, nullptr) * SEC_TO_MILLI_SEC)), pstMessageDataType_);
     };
 
     asciiFieldMap[CalculateBlockCrc32("%m")] = [](std::vector<FieldContainer>& vIntermediateFormat_, const BaseField* pstMessageDataType_,
@@ -106,7 +108,7 @@ void MessageDecoder::InitOemFieldMaps()
 
     jsonFieldMap[CalculateBlockCrc32("%T")] = [](std::vector<FieldContainer>& vIntermediateFormat_, const BaseField* pstMessageDataType_,
                                                  json clJsonField_, [[maybe_unused]] JsonReader* pclMsgDb_) {
-        vIntermediateFormat_.emplace_back(static_cast<uint32_t>(clJsonField_.get<double>() * SEC_TO_MILLI_SEC), pstMessageDataType_);
+        vIntermediateFormat_.emplace_back(static_cast<uint32_t>(std::llround(clJsonField_.get<double>() * SEC_TO_MILLI_SEC)), pstMessageDataType_);
     };
 
     jsonFieldMap[CalculateBlockCrc32("%id")] = [](std::vector<FieldContainer>& vIntermediateFormat_, const BaseField* pstMessageDataType_,


### PR DESCRIPTION
This caused millisecond values in the `ASCII_LOG_ROUNDTRIP_GLOALMANAC` test to diverge in the least significant digit after the round trip on some non-x86_64 architectures.