### PR TITLE
message_decoder.cpp: fix a bug in binary field alignment adjustment

### DIFF
--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -297,10 +297,8 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField*>& vMsgDefFields_, 
     {
         // Realign to type byte boundary if needed
         uint8_t usTypeAlignment = std::min(static_cast<uint16_t>(4), field->dataType.length);
-        if (reinterpret_cast<uint64_t>(*ppucLogBuf_) % usTypeAlignment != 0)
-        {
-            *ppucLogBuf_ += usTypeAlignment - (reinterpret_cast<uint64_t>(*ppucLogBuf_) % usTypeAlignment);
-        }
+        uint64_t usAlignmentOffset = static_cast<uint64_t>(*ppucLogBuf_ - pucTempStart) % usTypeAlignment;
+        if (usAlignmentOffset != 0) { *ppucLogBuf_ += usTypeAlignment - usAlignmentOffset; }
 
         switch (field->type)
         {


### PR DESCRIPTION
This one's pretty subtle.

Alignment needs to be applied relative to the message / body start, not the absolute pointer position. This seems to have worked by accident on x86_64, but caused issues on x86.