### PR TITLE
Handle root logger not being initialized

### DIFF
--- a/lib/logger/logger.hpp
+++ b/lib/logger/logger.hpp
@@ -139,6 +139,7 @@ class Logger
      */
     static std::shared_ptr<spdlog::logger> RegisterLogger(std::string sLoggerName_)
     {
+        if (!pclMyRootLogger) { InitLogger(); }
         std::lock_guard<std::mutex> lock(mLoggerMutex);
         pclMyRootLogger->debug("Logger::RegisterLogger(\"{}\")", sLoggerName_);
         std::shared_ptr<spdlog::logger> pclLogger = spdlog::get(sLoggerName_);


### PR DESCRIPTION
Call the default `InitLogger()` if `RegisterLogger()` is called without being initialized first.

Segfaults due to dereferencing a nullptr in the uninitialized root logger object otherwise.