### PR TITLE
Use std::filesystem instead of windows-specific stat function

### DIFF
--- a/examples/novatel/command_encoding/command_encoding.cpp
+++ b/examples/novatel/command_encoding/command_encoding.cpp
@@ -25,18 +25,15 @@
 // ===============================================================================
 
 #include <chrono>
+#include <filesystem>
 
 #include "src/decoders/novatel/api/commander.hpp"
 #include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
 
+namespace fs = std::filesystem;
+
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -56,10 +53,10 @@ int main(int argc, char* argv[])
     }
 
     // Json DB
-    std::string strJsonDb = argv[1];
-    if (!FileExists(strJsonDb))
+    const fs::path pathJsonDb = argv[1];
+    if (!fs::exists(pathJsonDb))
     {
-        logger->error("File \"{}\" does not exist", argv[1]);
+        logger->error("File \"{}\" does not exist", pathJsonDb.string());
         return 1;
     }
 
@@ -75,7 +72,7 @@ int main(int argc, char* argv[])
     JsonReader clJsonDb;
     auto tStart = std::chrono::high_resolution_clock::now();
     logger->info("Loading Database... ");
-    clJsonDb.LoadFile(strJsonDb);
+    clJsonDb.LoadFile(pathJsonDb.string());
     logger->info("Done in {}ms", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
 
     Commander clCommander(&clJsonDb);

--- a/examples/novatel/converter_components/converter_components.cpp
+++ b/examples/novatel/converter_components/converter_components.cpp
@@ -150,7 +150,7 @@ int main(int argc, char* argv[])
     // Setup file streams
     InputFileStream clIfs(pathInFilename.string().c_str());
     OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".").append(sEncodeFormat).append(".UNKNOWN").c_str());
 
     tStart = std::chrono::high_resolution_clock::now();
 

--- a/examples/novatel/converter_components/converter_components.cpp
+++ b/examples/novatel/converter_components/converter_components.cpp
@@ -25,6 +25,7 @@
 // ===============================================================================
 
 #include <chrono>
+#include <filesystem>
 
 #include "src/decoders/common/api/json_reader.hpp"
 #include "src/decoders/common/api/logger.hpp"
@@ -37,14 +38,10 @@
 #include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
 #include "src/version.h"
 
+namespace fs = std::filesystem;
+
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -70,17 +67,16 @@ int main(int argc, char* argv[])
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
     // Check command line arguments
-    std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    const fs::path pathJsonDb = argv[1];
+    if (!fs::exists(pathJsonDb))
     {
-        pclLogger->error("File \"{}\" does not exist", sJsonDb);
+        pclLogger->error("File \"{}\" does not exist", pathJsonDb.string());
         return 1;
     }
-
-    std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    const fs::path pathInFilename = argv[2];
+    if (!fs::exists(pathInFilename))
     {
-        pclLogger->error("File \"{}\" does not exist", sInFilename);
+        pclLogger->error("File \"{}\" does not exist", pathInFilename.string());
         return 1;
     }
 
@@ -95,7 +91,7 @@ int main(int argc, char* argv[])
     JsonReader clJsonDb;
     pclLogger->info("Loading Database...");
     auto tStart = std::chrono::high_resolution_clock::now();
-    clJsonDb.LoadFile(sJsonDb);
+    clJsonDb.LoadFile(pathJsonDb.string());
     pclLogger->info("Done in {}ms",
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
 
@@ -152,9 +148,9 @@ int main(int argc, char* argv[])
     stReadData.uiDataSize = sizeof(acIfsReadBuffer);
 
     // Setup file streams
-    InputFileStream clIfs(sInFilename.c_str());
-    OutputFileStream clConvertedLogsOfs(sInFilename.append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(sInFilename.append(".UNKNOWN").c_str());
+    InputFileStream clIfs(pathInFilename.string().c_str());
+    OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
 
     tStart = std::chrono::high_resolution_clock::now();
 

--- a/examples/novatel/converter_file_parser/converter_file_parser.cpp
+++ b/examples/novatel/converter_file_parser/converter_file_parser.cpp
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
     // Set up file streams
     InputFileStream clIfs(pathInFilename.string().c_str());
     OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".").append(sEncodeFormat).append(".UNKNOWN").c_str());
 
     if (!clFileParser.SetStream(&clIfs))
     {

--- a/examples/novatel/converter_file_parser/converter_file_parser.cpp
+++ b/examples/novatel/converter_file_parser/converter_file_parser.cpp
@@ -25,20 +25,17 @@
 // ===============================================================================
 
 #include <chrono>
+#include <filesystem>
 
 #include "src/decoders/novatel/api/file_parser.hpp"
 #include "src/hw_interface/stream_interface/api/inputfilestream.hpp"
 #include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
 #include "src/version.h"
 
+namespace fs = std::filesystem;
+
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -63,29 +60,17 @@ int main(int argc, char* argv[])
     }
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
-    if (!FileExists(argv[1]))
-    {
-        pclLogger->error("File \"{}\" does not exist", argv[1]);
-        return 1;
-    }
-    if (!FileExists(argv[2]))
-    {
-        pclLogger->error("File \"{}\" does not exist", argv[2]);
-        return 1;
-    }
-
     // Check command line arguments
-    std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    const fs::path pathJsonDb = argv[1];
+    if (!fs::exists(pathJsonDb))
     {
-        pclLogger->error("File \"{}\" does not exist", sJsonDb);
+        pclLogger->error("File \"{}\" does not exist", pathJsonDb.string());
         return 1;
     }
-
-    std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    const fs::path pathInFilename = argv[2];
+    if (!fs::exists(pathInFilename))
     {
-        pclLogger->error("File \"{}\" does not exist", sInFilename);
+        pclLogger->error("File \"{}\" does not exist", pathInFilename.string());
         return 1;
     }
 
@@ -100,7 +85,7 @@ int main(int argc, char* argv[])
     JsonReader clJsonDb;
     pclLogger->info("Loading Database...");
     auto tStart = std::chrono::high_resolution_clock::now();
-    clJsonDb.LoadFile(sJsonDb);
+    clJsonDb.LoadFile(pathJsonDb.string());
     pclLogger->info("Done in {}ms",
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
 
@@ -133,9 +118,9 @@ int main(int argc, char* argv[])
     stReadData.uiDataSize = sizeof(acIfsReadBuffer);
 
     // Set up file streams
-    InputFileStream clIfs(sInFilename.c_str());
-    OutputFileStream clConvertedLogsOfs(sInFilename.append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(sInFilename.append(".UNKNOWN").c_str());
+    InputFileStream clIfs(pathInFilename.string().c_str());
+    OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
 
     if (!clFileParser.SetStream(&clIfs))
     {
@@ -177,7 +162,7 @@ int main(int argc, char* argv[])
 
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
-                    sInFilename.c_str());
+                    pathInFilename.string().c_str());
     Logger::Shutdown();
     return 0;
 }

--- a/examples/novatel/converter_parser/converter_parser.cpp
+++ b/examples/novatel/converter_parser/converter_parser.cpp
@@ -121,7 +121,7 @@ int main(int argc, char* argv[])
     // Set up file streams
     InputFileStream clIfs(pathInFilename.string().c_str());
     OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".").append(sEncodeFormat).append(".UNKNOWN").c_str());
 
     uint32_t uiCompleteMessages = 0;
     uint32_t uiCounter = 0;

--- a/examples/novatel/converter_parser/converter_parser.cpp
+++ b/examples/novatel/converter_parser/converter_parser.cpp
@@ -25,20 +25,17 @@
 // ===============================================================================
 
 #include <chrono>
+#include <filesystem>
 
 #include "src/decoders/novatel/api/parser.hpp"
 #include "src/hw_interface/stream_interface/api/inputfilestream.hpp"
 #include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
 #include "src/version.h"
 
+namespace fs = std::filesystem;
+
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -64,17 +61,16 @@ int main(int argc, char* argv[])
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
     // Check command line arguments
-    std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    const fs::path pathJsonDb = argv[1];
+    if (!fs::exists(pathJsonDb))
     {
-        pclLogger->error("File \"{}\" does not exist", sJsonDb);
+        pclLogger->error("File \"{}\" does not exist", pathJsonDb.string());
         return 1;
     }
-
-    std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    const fs::path pathInFilename = argv[2];
+    if (!fs::exists(pathInFilename))
     {
-        pclLogger->error("File \"{}\" does not exist", sInFilename);
+        pclLogger->error("File \"{}\" does not exist", pathInFilename.string());
         return 1;
     }
 
@@ -89,7 +85,7 @@ int main(int argc, char* argv[])
     JsonReader clJsonDb;
     pclLogger->info("Loading Database...");
     auto tStart = std::chrono::high_resolution_clock::now();
-    clJsonDb.LoadFile(sJsonDb);
+    clJsonDb.LoadFile(pathJsonDb.string());
     pclLogger->info("Done in {}ms",
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
 
@@ -123,9 +119,9 @@ int main(int argc, char* argv[])
     stReadData.uiDataSize = sizeof(acIfsReadBuffer);
 
     // Set up file streams
-    InputFileStream clIfs(sInFilename.c_str());
-    OutputFileStream clConvertedLogsOfs(sInFilename.append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(sInFilename.append(".UNKNOWN").c_str());
+    InputFileStream clIfs(pathInFilename.string().c_str());
+    OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
 
     uint32_t uiCompleteMessages = 0;
     uint32_t uiCounter = 0;
@@ -159,7 +155,7 @@ int main(int argc, char* argv[])
 
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
-                    sInFilename.c_str());
+                    pathInFilename.string().c_str());
     Logger::Shutdown();
     return 0;
 }

--- a/examples/novatel/dynamic_components/dynamic_components.cpp
+++ b/examples/novatel/dynamic_components/dynamic_components.cpp
@@ -137,7 +137,7 @@ int main(int argc, char* argv[])
     // Set up file streams
     InputFileStream clIfs(pathInFilename.string().c_str());
     OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".").append(sEncodeFormat).append(".UNKNOWN").c_str());
 
     tStart = std::chrono::high_resolution_clock::now();
 

--- a/examples/novatel/dynamic_components/dynamic_components.cpp
+++ b/examples/novatel/dynamic_components/dynamic_components.cpp
@@ -24,6 +24,8 @@
 // ! \file dynamic_components.cpp
 // ===============================================================================
 
+#include <filesystem>
+
 #include "src/decoders/dynamic_library/api/common_json_reader.hpp"
 #include "src/decoders/dynamic_library/api/novatel_encoder.hpp"
 #include "src/decoders/dynamic_library/api/novatel_filter.hpp"
@@ -34,14 +36,10 @@
 #include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
 #include "src/version.h"
 
+namespace fs = std::filesystem;
+
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -67,17 +65,16 @@ int main(int argc, char* argv[])
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
     // Check command line arguments
-    std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    const fs::path pathJsonDb = argv[1];
+    if (!fs::exists(pathJsonDb))
     {
-        pclLogger->error("File \"{}\" does not exist", sJsonDb);
+        pclLogger->error("File \"{}\" does not exist", pathJsonDb.string());
         return 1;
     }
-
-    std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    const fs::path pathInFilename = argv[2];
+    if (!fs::exists(pathInFilename))
     {
-        pclLogger->error("File \"{}\" does not exist", sInFilename);
+        pclLogger->error("File \"{}\" does not exist", pathInFilename.string());
         return 1;
     }
 
@@ -91,7 +88,7 @@ int main(int argc, char* argv[])
     pclLogger->info("Loading Database...");
     auto tStart = std::chrono::high_resolution_clock::now();
     JsonReader* pclJsonDb = CommonJsonReaderInit();
-    CommonJsonReaderLoadFile(pclJsonDb, sJsonDb.c_str());
+    CommonJsonReaderLoadFile(pclJsonDb, pathJsonDb.string().c_str());
     pclLogger->info("Done in {}ms",
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
 
@@ -138,9 +135,9 @@ int main(int argc, char* argv[])
     stReadData.uiDataSize = sizeof(acIfsReadBuffer);
 
     // Set up file streams
-    InputFileStream clIfs(sInFilename.c_str());
-    OutputFileStream clConvertedLogsOfs(sInFilename.append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(sInFilename.append(".UNKNOWN").c_str());
+    InputFileStream clIfs(pathInFilename.string().c_str());
+    OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
 
     tStart = std::chrono::high_resolution_clock::now();
 

--- a/examples/novatel/dynamic_file_parser/dynamic_file_parser.cpp
+++ b/examples/novatel/dynamic_file_parser/dynamic_file_parser.cpp
@@ -118,7 +118,7 @@ int main(int argc, char* argv[])
     // Set up file streams
     InputFileStream clIfs(pathInFilename.string().c_str());
     OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".").append(sEncodeFormat).append(".UNKNOWN").c_str());
 
     if (!NovatelFileParserSetStream(pclFileParser, &clIfs))
     {

--- a/examples/novatel/dynamic_file_parser/dynamic_file_parser.cpp
+++ b/examples/novatel/dynamic_file_parser/dynamic_file_parser.cpp
@@ -25,6 +25,7 @@
 // ===============================================================================
 
 #include <chrono>
+#include <filesystem>
 
 #include "src/decoders/dynamic_library/api/common_json_reader.hpp"
 #include "src/decoders/dynamic_library/api/novatel_file_parser.hpp"
@@ -33,14 +34,10 @@
 #include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
 #include "src/version.h"
 
+namespace fs = std::filesystem;
+
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -66,17 +63,16 @@ int main(int argc, char* argv[])
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
     // Check command line arguments
-    std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    const fs::path pathJsonDb = argv[1];
+    if (!fs::exists(pathJsonDb))
     {
-        pclLogger->error("File \"{}\" does not exist", sJsonDb);
+        pclLogger->error("File \"{}\" does not exist", pathJsonDb.string());
         return 1;
     }
-
-    std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    const fs::path pathInFilename = argv[2];
+    if (!fs::exists(pathInFilename))
     {
-        pclLogger->error("File \"{}\" does not exist", sInFilename);
+        pclLogger->error("File \"{}\" does not exist", pathInFilename.string());
         return 1;
     }
 
@@ -90,7 +86,7 @@ int main(int argc, char* argv[])
     pclLogger->info("Loading Database...");
     auto tStart = std::chrono::high_resolution_clock::now();
     JsonReader* pclJsonDb = CommonJsonReaderInit();
-    CommonJsonReaderLoadFile(pclJsonDb, sJsonDb.c_str());
+    CommonJsonReaderLoadFile(pclJsonDb, pathJsonDb.string().c_str());
     pclLogger->info("Done in {}ms",
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
 
@@ -120,9 +116,9 @@ int main(int argc, char* argv[])
     stReadData.uiDataSize = sizeof(acIfsReadBuffer);
 
     // Set up file streams
-    InputFileStream clIfs(sInFilename.c_str());
-    OutputFileStream clConvertedLogsOfs(sInFilename.append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(sInFilename.append(".UNKNOWN").c_str());
+    InputFileStream clIfs(pathInFilename.string().c_str());
+    OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
 
     if (!NovatelFileParserSetStream(pclFileParser, &clIfs))
     {
@@ -163,7 +159,7 @@ int main(int argc, char* argv[])
 
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
-                    sInFilename.c_str());
+                    pathInFilename.string().c_str());
     Logger::Shutdown();
     NovatelFileParserDelete(pclFileParser);
     return 0;

--- a/examples/novatel/dynamic_parser/dynamic_parser.cpp
+++ b/examples/novatel/dynamic_parser/dynamic_parser.cpp
@@ -119,7 +119,7 @@ int main(int argc, char* argv[])
     // Set up file streams
     InputFileStream clIfs(pathInFilename.string().c_str());
     OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".").append(sEncodeFormat).append(".UNKNOWN").c_str());
 
     uint32_t uiCompleteMessages = 0;
     tStart = std::chrono::high_resolution_clock::now();

--- a/examples/novatel/dynamic_parser/dynamic_parser.cpp
+++ b/examples/novatel/dynamic_parser/dynamic_parser.cpp
@@ -25,6 +25,7 @@
 // ===============================================================================
 
 #include <chrono>
+#include <filesystem>
 
 #include "src/decoders/dynamic_library/api/common_json_reader.hpp"
 #include "src/decoders/dynamic_library/api/novatel_filter.hpp"
@@ -33,14 +34,10 @@
 #include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
 #include "src/version.h"
 
+namespace fs = std::filesystem;
+
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -66,17 +63,16 @@ int main(int argc, char* argv[])
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
     // Check command line arguments
-    std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    const fs::path pathJsonDb = argv[1];
+    if (!fs::exists(pathJsonDb))
     {
-        pclLogger->error("File \"{}\" does not exist", sJsonDb);
+        pclLogger->error("File \"{}\" does not exist", pathJsonDb.string());
         return 1;
     }
-
-    std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    const fs::path pathInFilename = argv[2];
+    if (!fs::exists(pathInFilename))
     {
-        pclLogger->error("File \"{}\" does not exist", sInFilename);
+        pclLogger->error("File \"{}\" does not exist", pathInFilename.string());
         return 1;
     }
 
@@ -90,7 +86,7 @@ int main(int argc, char* argv[])
     pclLogger->info("Loading Database...");
     auto tStart = std::chrono::high_resolution_clock::now();
     JsonReader* pclJsonDb = CommonJsonReaderInit();
-    CommonJsonReaderLoadFile(pclJsonDb, sJsonDb.c_str());
+    CommonJsonReaderLoadFile(pclJsonDb, pathJsonDb.string().c_str());
     pclLogger->info("Done in {}ms",
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
 
@@ -121,9 +117,9 @@ int main(int argc, char* argv[])
     stReadData.uiDataSize = sizeof(acIfsReadBuffer);
 
     // Set up file streams
-    InputFileStream clIfs(sInFilename.c_str());
-    OutputFileStream clConvertedLogsOfs(sInFilename.append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(sInFilename.append(".UNKNOWN").c_str());
+    InputFileStream clIfs(pathInFilename.string().c_str());
+    OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
 
     uint32_t uiCompleteMessages = 0;
     tStart = std::chrono::high_resolution_clock::now();
@@ -156,7 +152,7 @@ int main(int argc, char* argv[])
 
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
-                    sInFilename.c_str());
+                    pathInFilename.string().c_str());
     Logger::Shutdown();
     NovatelParserDelete(pclParser);
     return 0;

--- a/examples/novatel/json_parser/json_parser.cpp
+++ b/examples/novatel/json_parser/json_parser.cpp
@@ -25,20 +25,17 @@
 // ===============================================================================
 
 #include <chrono>
+#include <filesystem>
 
 #include "src/decoders/novatel/api/parser.hpp"
 #include "src/hw_interface/stream_interface/api/inputfilestream.hpp"
 #include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
 #include "src/version.h"
 
+namespace fs = std::filesystem;
+
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -67,17 +64,16 @@ int main(int argc, char* argv[])
     if (argc == 5) { sAppendMsg = argv[4]; }
 
     // Check command line arguments
-    std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    const fs::path pathJsonDb = argv[1];
+    if (!fs::exists(pathJsonDb))
     {
-        pclLogger->error("File \"{}\" does not exist", sJsonDb);
+        pclLogger->error("File \"{}\" does not exist", pathJsonDb.string());
         return 1;
     }
-
-    std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    const fs::path pathInFilename = argv[2];
+    if (!fs::exists(pathInFilename))
     {
-        pclLogger->error("File \"{}\" does not exist", sInFilename);
+        pclLogger->error("File \"{}\" does not exist", pathInFilename.string());
         return 1;
     }
 
@@ -92,7 +88,7 @@ int main(int argc, char* argv[])
     JsonReader clJsonDb;
     pclLogger->info("Loading Database...");
     auto tStart = std::chrono::high_resolution_clock::now();
-    clJsonDb.LoadFile(sJsonDb);
+    clJsonDb.LoadFile(pathJsonDb.string());
     pclLogger->info("Done in {}ms",
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
 
@@ -132,9 +128,9 @@ int main(int argc, char* argv[])
     stReadData.uiDataSize = sizeof(acIfsReadBuffer);
 
     // Set up file streams
-    InputFileStream clIfs(sInFilename.c_str());
-    OutputFileStream clConvertedLogsOfs(sInFilename.append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(sInFilename.append(".UNKNOWN").c_str());
+    InputFileStream clIfs(pathInFilename.string().c_str());
+    OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
 
     uint32_t uiCompleteMessages = 0;
     uint32_t uiCounter = 0;
@@ -168,7 +164,7 @@ int main(int argc, char* argv[])
 
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
-                    sInFilename.c_str());
+                    pathInFilename.string().c_str());
     Logger::Shutdown();
     return 0;
 }

--- a/examples/novatel/json_parser/json_parser.cpp
+++ b/examples/novatel/json_parser/json_parser.cpp
@@ -130,7 +130,7 @@ int main(int argc, char* argv[])
     // Set up file streams
     InputFileStream clIfs(pathInFilename.string().c_str());
     OutputFileStream clConvertedLogsOfs(pathInFilename.string().append(".").append(sEncodeFormat).c_str());
-    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".UNKNOWN").c_str());
+    OutputFileStream clUnknownBytesOfs(pathInFilename.string().append(".").append(sEncodeFormat).append(".UNKNOWN").c_str());
 
     uint32_t uiCompleteMessages = 0;
     uint32_t uiCounter = 0;

--- a/examples/novatel/rxconfig_handler/rxconfig_handler.cpp
+++ b/examples/novatel/rxconfig_handler/rxconfig_handler.cpp
@@ -25,6 +25,7 @@
 // ===============================================================================
 
 #include <chrono>
+#include <filesystem>
 
 #include "src/decoders/common/api/common.hpp"
 #include "src/decoders/novatel/api/rxconfig/rxconfig_handler.hpp"
@@ -32,14 +33,10 @@
 #include "src/hw_interface/stream_interface/api/outputfilestream.hpp"
 #include "src/version.h"
 
+namespace fs = std::filesystem;
+
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
-
-inline bool FileExists(const std::string& strName_)
-{
-    struct stat buffer;
-    return stat(strName_.c_str(), &buffer) == 0;
-}
 
 int main(int argc, char* argv[])
 {
@@ -65,17 +62,16 @@ int main(int argc, char* argv[])
     if (argc == 4) { sEncodeFormat = argv[3]; }
 
     // Check command line arguments
-    std::string sJsonDb = argv[1];
-    if (!FileExists(sJsonDb))
+    const fs::path pathJsonDb = argv[1];
+    if (!fs::exists(pathJsonDb))
     {
-        pclLogger->error("File \"{}\" does not exist", sJsonDb);
+        pclLogger->error("File \"{}\" does not exist", pathJsonDb.string());
         return 1;
     }
-
-    std::string sInFilename = argv[2];
-    if (!FileExists(sInFilename))
+    const fs::path pathInFilename = argv[2];
+    if (!fs::exists(pathInFilename))
     {
-        pclLogger->error("File \"{}\" does not exist", sInFilename);
+        pclLogger->error("File \"{}\" does not exist", pathInFilename.string());
         return 1;
     }
 
@@ -90,7 +86,7 @@ int main(int argc, char* argv[])
     JsonReader clJsonDb;
     pclLogger->info("Loading Database...");
     auto tStart = std::chrono::high_resolution_clock::now();
-    clJsonDb.LoadFile(sJsonDb);
+    clJsonDb.LoadFile(pathJsonDb.string());
     pclLogger->info("Done in {}ms",
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
 
@@ -102,9 +98,9 @@ int main(int argc, char* argv[])
     stReadData.uiDataSize = sizeof(acIfsReadBuffer);
 
     // Set up file streams
-    InputFileStream clIfs(sInFilename.c_str());
-    OutputFileStream clConvertedRxConfigOfs((sInFilename + std::string(".").append(sEncodeFormat)).c_str());
-    OutputFileStream clStrippedRxConfigOfs((sInFilename + std::string(".STRIPPED.").append(sEncodeFormat)).c_str());
+    InputFileStream clIfs(pathInFilename.string().c_str());
+    OutputFileStream clConvertedRxConfigOfs((pathInFilename.string() + std::string(".").append(sEncodeFormat)).c_str());
+    OutputFileStream clStrippedRxConfigOfs((pathInFilename.string() + std::string(".STRIPPED.").append(sEncodeFormat)).c_str());
 
     MetaDataStruct stMetaData;
     MetaDataStruct stEmbeddedMetaData;


### PR DESCRIPTION
It was found that the stat functions that windows supports does not have a platform agnostic version that can support 64bit variables on both. It was going to get messy with a bunch of ifdefs and stuff. So Richard and I decided to move towards the std::filesystem route, which looks to be more modern anyways