### PR TITLE
Fix undefined UINT_MAX

### DIFF
--- a/src/decoders/dynamic_library/src/novatel_file_parser.cpp
+++ b/src/decoders/dynamic_library/src/novatel_file_parser.cpp
@@ -24,9 +24,9 @@
 // ! \file novatel_file_parser.cpp
 // ===============================================================================
 
-#include "novatel_file_parser.hpp"
-
 #include <limits>
+
+#include "novatel_file_parser.hpp"
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;

--- a/src/decoders/dynamic_library/src/novatel_file_parser.cpp
+++ b/src/decoders/dynamic_library/src/novatel_file_parser.cpp
@@ -26,6 +26,8 @@
 
 #include "novatel_file_parser.hpp"
 
+#include <limits>
+
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
 
@@ -93,7 +95,10 @@ bool NovatelFileParserSetStream(FileParser* pclFileParser_, InputFileStream* pcl
     return pclFileParser_ && pclIfs_ ? pclFileParser_->SetStream(pclIfs_) : false;
 }
 
-uint32_t NovatelFileParserGetPercentRead(FileParser* pclFileParser_) { return pclFileParser_ ? pclFileParser_->GetPercentRead() : UINT_MAX; }
+uint32_t NovatelFileParserGetPercentRead(FileParser* pclFileParser_)
+{
+    return pclFileParser_ ? pclFileParser_->GetPercentRead() : std::numeric_limits<uint32_t>::max();
+}
 
 STATUS NovatelFileParserRead(FileParser* pclFileParser_, MessageDataStruct* pstMessageData_, MetaDataStruct* pstMetaData_)
 {
@@ -104,5 +109,5 @@ bool NovatelFileParserReset(FileParser* pclFileParser_) { return pclFileParser_ 
 
 uint32_t NovatelFileParserFlush(FileParser* pclFileParser_, unsigned char* pucBuffer_, uint32_t uiBufferSize_)
 {
-    return pclFileParser_ && pucBuffer_ ? pclFileParser_->Flush(pucBuffer_, uiBufferSize_) : UINT_MAX;
+    return pclFileParser_ && pucBuffer_ ? pclFileParser_->Flush(pucBuffer_, uiBufferSize_) : std::numeric_limits<uint32_t>::max();
 }

--- a/src/decoders/dynamic_library/src/novatel_framer.cpp
+++ b/src/decoders/dynamic_library/src/novatel_framer.cpp
@@ -24,9 +24,9 @@
 // ! \file novatel_framer.cpp
 // ===============================================================================
 
-#include "novatel_framer.hpp"
-
 #include <limits>
+
+#include "novatel_framer.hpp"
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;

--- a/src/decoders/dynamic_library/src/novatel_framer.cpp
+++ b/src/decoders/dynamic_library/src/novatel_framer.cpp
@@ -26,6 +26,8 @@
 
 #include "novatel_framer.hpp"
 
+#include <limits>
+
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
 
@@ -67,11 +69,14 @@ void NovatelFramerReportUnknownBytes(Framer* pclFramer_, bool bReportUnknownByte
     if (pclFramer_) { pclFramer_->SetReportUnknownBytes(bReportUnknownBytes_); }
 }
 
-uint32_t NovatelFramerGetAvailableBytes(Framer* pclFramer_) { return pclFramer_ ? pclFramer_->GetBytesAvailableInBuffer() : UINT_MAX; }
+uint32_t NovatelFramerGetAvailableBytes(Framer* pclFramer_)
+{
+    return pclFramer_ ? pclFramer_->GetBytesAvailableInBuffer() : std::numeric_limits<uint32_t>::max();
+}
 
 uint32_t NovatelFramerWrite(Framer* pclFramer_, unsigned char* pucBytes_, uint32_t uiByteCount_)
 {
-    return pclFramer_ ? pclFramer_->Write(pucBytes_, uiByteCount_) : UINT_MAX;
+    return pclFramer_ ? pclFramer_->Write(pucBytes_, uiByteCount_) : std::numeric_limits<uint32_t>::max();
 }
 
 STATUS NovatelFramerRead(Framer* pclFramer_, unsigned char* pucBuffer_, uint32_t uiBufferSize_, MetaDataStruct* pstMetaData_)
@@ -81,5 +86,5 @@ STATUS NovatelFramerRead(Framer* pclFramer_, unsigned char* pucBuffer_, uint32_t
 
 uint32_t NovatelFramerFlush(Framer* pclFramer_, unsigned char* pucBuffer_, uint32_t uiBufferSize_)
 {
-    return pclFramer_ && pucBuffer_ ? pclFramer_->Flush(pucBuffer_, uiBufferSize_) : UINT_MAX;
+    return pclFramer_ && pucBuffer_ ? pclFramer_->Flush(pucBuffer_, uiBufferSize_) : std::numeric_limits<uint32_t>::max();
 }

--- a/src/decoders/dynamic_library/src/novatel_parser.cpp
+++ b/src/decoders/dynamic_library/src/novatel_parser.cpp
@@ -26,6 +26,8 @@
 
 #include "novatel_parser.hpp"
 
+#include <limits>
+
 using namespace novatel::edie;
 using namespace novatel::edie::oem;
 
@@ -84,7 +86,7 @@ unsigned char* NovatelParserGetBuffer(Parser* pclParser_) { return pclParser_ ? 
 
 uint32_t NovatelParserWrite(Parser* pclParser_, unsigned char* pucBytes_, uint32_t uiByteCount_)
 {
-    return pclParser_ && pucBytes_ ? pclParser_->Write(pucBytes_, uiByteCount_) : UINT_MAX;
+    return pclParser_ && pucBytes_ ? pclParser_->Write(pucBytes_, uiByteCount_) : std::numeric_limits<uint32_t>::max();
 }
 
 STATUS NovatelParserRead(Parser* pclParser_, MessageDataStruct* pstMessageData_, MetaDataStruct* pstMetaData_)
@@ -94,5 +96,5 @@ STATUS NovatelParserRead(Parser* pclParser_, MessageDataStruct* pstMessageData_,
 
 uint32_t NovatelParserFlush(Parser* pclParser_, unsigned char* pucBuffer_, uint32_t uiBufferSize_)
 {
-    return pclParser_ && pucBuffer_ ? pclParser_->Flush(pucBuffer_, uiBufferSize_) : UINT_MAX;
+    return pclParser_ && pucBuffer_ ? pclParser_->Flush(pucBuffer_, uiBufferSize_) : std::numeric_limits<uint32_t>::max();
 }

--- a/src/decoders/dynamic_library/src/novatel_parser.cpp
+++ b/src/decoders/dynamic_library/src/novatel_parser.cpp
@@ -24,9 +24,9 @@
 // ! \file novatel_parser.cpp
 // ===============================================================================
 
-#include "novatel_parser.hpp"
-
 #include <limits>
+
+#include "novatel_parser.hpp"
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;


### PR DESCRIPTION
Was getting undefined `UINT_MAX` errors on GCC.
Avoids `UINT_MAX` altogether as is not uniquely defined and depends on the size of `int`.