### PR TITLE
Fix line endings for CMakeLists.txt and conanfile.txt

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Check out as LF or CRLF based on your OS, store in Git index as LF
 * text=auto
+
 # These are unit test files and should use crlf
 *.ASC text eol=crlf
 *.asc text eol=crlf
@@ -7,6 +8,9 @@
 *.GPS text eol=crlf
 *.gps text eol=crlf
 *.BIN -text
+
+CMakeLists.txt text eol=auto
+conanfile.txt text eol=auto
 
 # another way of doing
 #  git config --global core.autocrlf false


### PR DESCRIPTION
Due to an oversight in #37, CMakeLists.txt and conanfile.txt are checked out as CRLF on non-Windows systems. This won't affect any branches or PRs, fortunately, since the files are already stored as LF in the Git index either way.