### PR TITLE
Limit fmt to 11.0.2 for compatibility with spdlog

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -48,7 +48,8 @@ class NovatelEdieConan(ConanFile):
         self.requires("nlohmann_json/[>=3.11 <3.12]", transitive_headers=True)
         self.requires("spdlog/[>=1.13 <2]", transitive_headers=True, transitive_libs=True, force=True)
         self.requires("gegles-spdlog_setup/[>=1.1 <2]", transitive_headers=True)
-        self.requires("fmt/[^11]", force=True)
+        # fmt/11.1.1 is currently not compatible with spdlog https://github.com/gabime/spdlog/issues/3302
+        self.requires("fmt/11.0.2", force=True)
 
     def build_requirements(self):
         self.test_requires("gtest/[>=1.14 <1.15]")


### PR DESCRIPTION
spdlog is [currently not compatible](https://github.com/gabime/spdlog/issues/3302) with the latest fmt/11.1.1 and GCC 11 fails in CI for #76 with
```
error: ‘template<class T, class ... Args> fmt::v11::basic_string_view<Char> spdlog::details::to_string_view’ redeclared as different kind of entity
  369 | inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_string<T, Args...> fmt) {
```