### PR TITLE
Fix example section of readme and delete empty example folder

### DIFF
--- a/examples/novatel/rangecmp/CMakeLists.txt
+++ b/examples/novatel/rangecmp/CMakeLists.txt
@@ -1,4 +1,0 @@
-set(TARGET_NAME "range_decompressor")
-add_executable(${TARGET_NAME} ${TARGET_NAME}.cpp)
-target_link_libraries(${TARGET_NAME} novatel_edie::novatel_edie)
-set_property(TARGET ${TARGET_NAME} PROPERTY FOLDER "examples")


### PR DESCRIPTION
The current version of the readme has two examples, both of which rely on a `InputFileStream` class which does not exist within the current version of `novatel_edie`. This pull request replaces those examples short explanations and links to working examples from the `./examples/` folder.

It also deletes the `./examples/novatel/rangecmp/` folder which is empty save for a CMake file, and appears to have been superseded by the `./examples/novatel/range_decompressor/` folder.