### PR TITLE
Add type hinting support - drop PyMessage subclasses

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -64,8 +64,11 @@ nanobind_add_stub(
 
 add_custom_target(
     dynamic_stubs ALL
-    COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/python/novatel_edie_customizer/novatel_edie_customizer/stubgen.py ${CMAKE_SOURCE_DIR}/database/database.json ${CMAKE_CURRENT_BINARY_DIR}/stubs
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/novatel_edie_customizer/novatel_edie_customizer/stubgen.py ${CMAKE_SOURCE_DIR}/database/database.json ${CMAKE_CURRENT_BINARY_DIR}/stubs
     COMMENT "Generating dynamic stubs"
+    DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/novatel_edie_customizer/novatel_edie_customizer/stubgen.py
+        ${CMAKE_SOURCE_DIR}/database/database.json
 )
 
 if(DEFINED SKBUILD_PROJECT_NAME)

--- a/python/bindings/message_database.cpp
+++ b/python/bindings/message_database.cpp
@@ -279,7 +279,6 @@ void PyMessageDatabase::UpdateMessageTypes()
     // get type constructor
     nb::object type_constructor = nb::module_::import_("builtins").attr("type");
     // specify the python superclasses for the new message and message body types
-    nb::tuple type_tuple = nb::make_tuple(nb::type<oem::PyMessage>());
     nb::tuple body_type_tuple = nb::make_tuple(nb::type<oem::PyMessageBody>());
     // provide no additional attributes via `__dict__`
     nb::dict type_dict = nb::dict();
@@ -287,16 +286,12 @@ void PyMessageDatabase::UpdateMessageTypes()
     // add message and message body types for each message definition
     for (const auto& message_def : MessageDefinitions())
     {
-        nb::object msg_def = type_constructor(message_def->name + "_Message", type_tuple, type_dict);
-        messages_by_name[message_def->name + "_Message"] = msg_def;
         nb::object msg_body_def = type_constructor(message_def->name, body_type_tuple, type_dict);
         messages_by_name[message_def->name] = msg_body_def;
         // add additional MessageBody types for each field array element within the message definition
         AddFieldType(message_def->fields.at(message_def->latestMessageCrc), message_def->name, type_constructor, body_type_tuple, type_dict);
     }
     // provide UNKNOWN types for undecodable messages
-    nb::object default_msg_def = type_constructor("UNKNOWN_Message", type_tuple, type_dict);
-    messages_by_name["UNKNOWN_Message"] = default_msg_def;
     nb::object default_msg_body_def = type_constructor("UNKNOWN", body_type_tuple, type_dict);
     messages_by_name["UNKNOWN"] = default_msg_body_def;
 }

--- a/python/bindings/message_database.cpp
+++ b/python/bindings/message_database.cpp
@@ -188,7 +188,8 @@ void init_common_message_database(nb::module_& m)
         .def_prop_ro("messages", &PyMessageDatabase::GetMessagesByNameDict);
 }
 
-PyMessageDatabase::PyMessageDatabase() { 
+PyMessageDatabase::PyMessageDatabase()
+{
     UpdatePythonEnums();
     UpdateMessageTypes();
 }
@@ -201,12 +202,14 @@ PyMessageDatabase::PyMessageDatabase(std::vector<MessageDefinition::ConstPtr> vM
     UpdateMessageTypes();
 }
 
-PyMessageDatabase::PyMessageDatabase(const MessageDatabase& message_db) noexcept : MessageDatabase(message_db) { 
+PyMessageDatabase::PyMessageDatabase(const MessageDatabase& message_db) noexcept : MessageDatabase(message_db)
+{
     UpdatePythonEnums();
     UpdateMessageTypes();
 }
 
-PyMessageDatabase::PyMessageDatabase(const MessageDatabase&& message_db) noexcept : MessageDatabase(message_db) { 
+PyMessageDatabase::PyMessageDatabase(const MessageDatabase&& message_db) noexcept : MessageDatabase(message_db)
+{
     UpdatePythonEnums();
     UpdateMessageTypes();
 }
@@ -237,7 +240,8 @@ inline void PyMessageDatabase::UpdatePythonEnums()
     {
         nb::dict values;
         const char* enum_name = enum_def->name.c_str();
-        for (const auto& enumerator : enum_def->enumerators) {
+        for (const auto& enumerator : enum_def->enumerators)
+        {
             std::string enumerator_name = enumerator.name;
             cleanString(enumerator_name);
             values[enumerator_name.c_str()] = enumerator.value;
@@ -254,7 +258,8 @@ void PyMessageDatabase::AddFieldType(std::vector<std::shared_ptr<BaseField>> fie
                                      nb::handle type_tuple, nb::handle type_dict)
 {
     // rescursively add field types for each field array element within the provided vector
-    for (const auto& field : fields) {
+    for (const auto& field : fields)
+    {
         if (field->type == FIELD_TYPE::FIELD_ARRAY)
         {
             auto* field_array_field = dynamic_cast<FieldArrayField*>(field.get());
@@ -262,7 +267,7 @@ void PyMessageDatabase::AddFieldType(std::vector<std::shared_ptr<BaseField>> fie
             nb::object field_type = type_constructor(field_name, type_tuple, type_dict);
             messages_by_name[field_name] = field_type;
             AddFieldType(field_array_field->fields, field_name, type_constructor, type_tuple, type_dict);
-        }   
+        }
     }
 }
 
@@ -280,17 +285,18 @@ void PyMessageDatabase::UpdateMessageTypes()
     nb::dict type_dict = nb::dict();
 
     // add message and message body types for each message definition
-    for (const auto& message_def : MessageDefinitions()) {
-        nb::object msg_def = type_constructor(message_def->name, type_tuple, type_dict);
-        messages_by_name[message_def->name] = msg_def;
-        nb::object msg_body_def = type_constructor(message_def->name + "_Body", body_type_tuple, type_dict);
-        messages_by_name[message_def->name + "_Body"] = msg_body_def;
+    for (const auto& message_def : MessageDefinitions())
+    {
+        nb::object msg_def = type_constructor(message_def->name + "_Message", type_tuple, type_dict);
+        messages_by_name[message_def->name + "_Message"] = msg_def;
+        nb::object msg_body_def = type_constructor(message_def->name, body_type_tuple, type_dict);
+        messages_by_name[message_def->name] = msg_body_def;
         // add additional MessageBody types for each field array element within the message definition
-        AddFieldType(message_def->fields.at(message_def->latestMessageCrc), message_def->name + "_Body", type_constructor, body_type_tuple, type_dict);
+        AddFieldType(message_def->fields.at(message_def->latestMessageCrc), message_def->name, type_constructor, body_type_tuple, type_dict);
     }
     // provide UNKNOWN types for undecodable messages
-    nb::object default_msg_def = type_constructor("UNKNOWN", type_tuple, type_dict);
-    messages_by_name["UNKNOWN"] = default_msg_def;
-    nb::object default_msg_body_def = type_constructor("UNKNOWN_Body", body_type_tuple, type_dict);
-    messages_by_name["UNKNOWN_Body"] = default_msg_body_def;
+    nb::object default_msg_def = type_constructor("UNKNOWN_Message", type_tuple, type_dict);
+    messages_by_name["UNKNOWN_Message"] = default_msg_def;
+    nb::object default_msg_body_def = type_constructor("UNKNOWN", body_type_tuple, type_dict);
+    messages_by_name["UNKNOWN"] = default_msg_body_def;
 }

--- a/python/bindings/py_decoded_message.hpp
+++ b/python/bindings/py_decoded_message.hpp
@@ -46,15 +46,14 @@ struct PyMessage
     nb::object header;
     std::string name;
 
-    PyMessage(nb::object message_body_, nb::object header_, std::string name_)
-        : message_body(message_body_), header(header_), name(name_) {}
+    PyMessage(nb::object message_body_, nb::object header_, std::string name_) : message_body(message_body_), header(header_), name(name_) {}
 
     std::string repr() const
     {
-        return "<" + name + " Message>";
+        std::stringstream repr;
+        repr << "<Message " << nb::repr(message_body).c_str() << ">";
+        return repr.str();
     }
 };
-
-
 
 } // namespace novatel::edie::oem

--- a/python/novatel_edie_customizer/novatel_edie_customizer/stubgen.py
+++ b/python/novatel_edie_customizer/novatel_edie_customizer/stubgen.py
@@ -26,7 +26,6 @@ A module concerning the generation of type hint stub files for the novatel_edie 
 import os
 import json
 import re
-import textwrap
 from typing import Union
 
 import typer
@@ -185,19 +184,8 @@ class StubGenerator:
         """
         subfield_hints = []
 
-        # Create the Message type hint
-        name = message_def["name"]
-        message_hint = (textwrap.dedent(f"""\
-            class {name}_Message(Message):
-                @property
-                def header(self) -> Header: ...
-
-                @property
-                def body(self) -> {name}: ...
-
-        """))
-
         # Create the MessageBody type hint
+        name = message_def["name"]
         body_hint = f'class {name}(MessageBody):\n'
         fields = message_def['fields'][message_def['latestMsgDefCrc']]
         if not fields:
@@ -212,7 +200,7 @@ class StubGenerator:
                 subfield_hints.append(self._convert_field_array_def(field, name))
 
         # Combine all hints
-        hints = subfield_hints + [body_hint, message_hint]
+        hints = subfield_hints + [body_hint]
         hint_str = '\n'.join(hints)
 
         return hint_str

--- a/python/test/test_decode_encode.py
+++ b/python/test/test_decode_encode.py
@@ -28,12 +28,14 @@
 # Encoder and Filter.
 ################################################################################
 import enum
+from collections import namedtuple
 
 import novatel_edie as ne
 import pytest
 from novatel_edie import STATUS, ENCODE_FORMAT
+from novatel_edie.messages import *
 from pytest import approx
-from collections import namedtuple
+
 
 # -------------------------------------------------------------------------------------------------------
 # Decode/Encode Unit Tests
@@ -289,38 +291,40 @@ def test_ascii_log_roundtrip_gloalmanac(helper):
 
 def test_ascii_log_roundtrip_gloephem(helper):
     log = b"#GLOEPHEMERISA,COM1,11,67.0,SATTIME,2168,160218.000,02000820,8d29,32768;51,0,1,80,2168,161118000,10782,573,0,0,95,0,-2.3917966796875000e+07,4.8163881835937500e+06,7.4258510742187500e+06,-1.0062713623046875e+03,1.8321990966796875e+02,-3.3695755004882813e+03,1.86264514923095700e-06,-9.31322574615478510e-07,-0.00000000000000000,-6.69313594698905940e-05,5.587935448e-09,0.00000000000000000,84600,3,2,0,13*ad20fc5f\r\n"
-    ret_code, message_data, glo_ephemeris = helper.DecodeEncode(ENCODE_FORMAT.FLATTENED_BINARY, log, return_message=True)
+    ret_code, message_data, message = helper.DecodeEncode(ENCODE_FORMAT.FLATTENED_BINARY, log, return_message=True)
     assert ret_code == Result.SUCCESS
 
-    assert glo_ephemeris.body.sloto == 51
-    assert glo_ephemeris.body.freqo == 0
-    assert glo_ephemeris.body.sat_type == 1
-    assert glo_ephemeris.body.false_iod == 80
-    assert glo_ephemeris.body.ephem_week == 2168
-    assert glo_ephemeris.body.ephem_time == 161118000
-    assert glo_ephemeris.body.time_offset == 10782
-    assert glo_ephemeris.body.nt == 573
-    assert glo_ephemeris.body.GLOEPHEMERIS_reserved == 0
-    assert glo_ephemeris.body.GLOEPHEMERIS_reserved_9 == 0
-    assert glo_ephemeris.body.issue == 95
-    assert glo_ephemeris.body.broadcast_health == 0
-    assert glo_ephemeris.body.pos_x == -2.3917966796875000e+07
-    assert glo_ephemeris.body.pos_y == 4.8163881835937500e+06
-    assert glo_ephemeris.body.pos_z == 7.4258510742187500e+06
-    assert glo_ephemeris.body.vel_x == -1.0062713623046875e+03
-    assert glo_ephemeris.body.vel_y == 1.8321990966796875e+02
-    assert glo_ephemeris.body.vel_z == -3.3695755004882813e+03
-    assert glo_ephemeris.body.ls_acc_x == approx(1.86264514923095700e-06, abs=0.0000000000000001e-06)
-    assert glo_ephemeris.body.ls_acc_y == approx(-9.31322574615478510e-07, abs=0.0000000000000001e-07)
-    assert glo_ephemeris.body.ls_acc_z == approx(-0.00000000000000000, abs=0.0000000000000001)
-    assert glo_ephemeris.body.tau == approx(-6.69313594698905940e-05, abs=0.0000000000000001e-05)
-    assert glo_ephemeris.body.delta_tau == 5.587935448e-09
-    assert glo_ephemeris.body.gamma == approx(0.00000000000000000, abs=0.0000000000000001)
-    assert glo_ephemeris.body.tk == 84600
-    assert glo_ephemeris.body.p == 3
-    assert glo_ephemeris.body.ft == 2
-    assert glo_ephemeris.body.age == 0
-    assert glo_ephemeris.body.flags == 13
+    glo_ephemeris = message.body
+    assert isinstance(glo_ephemeris, GLOEPHEMERIS)
+    assert glo_ephemeris.sloto == 51
+    assert glo_ephemeris.freqo == 0
+    assert glo_ephemeris.sat_type == 1
+    assert glo_ephemeris.false_iod == 80
+    assert glo_ephemeris.ephem_week == 2168
+    assert glo_ephemeris.ephem_time == 161118000
+    assert glo_ephemeris.time_offset == 10782
+    assert glo_ephemeris.nt == 573
+    assert glo_ephemeris.GLOEPHEMERIS_reserved == 0
+    assert glo_ephemeris.GLOEPHEMERIS_reserved_9 == 0
+    assert glo_ephemeris.issue == 95
+    assert glo_ephemeris.broadcast_health == 0
+    assert glo_ephemeris.pos_x == -2.3917966796875000e+07
+    assert glo_ephemeris.pos_y == 4.8163881835937500e+06
+    assert glo_ephemeris.pos_z == 7.4258510742187500e+06
+    assert glo_ephemeris.vel_x == -1.0062713623046875e+03
+    assert glo_ephemeris.vel_y == 1.8321990966796875e+02
+    assert glo_ephemeris.vel_z == -3.3695755004882813e+03
+    assert glo_ephemeris.ls_acc_x == approx(1.86264514923095700e-06, abs=0.0000000000000001e-06)
+    assert glo_ephemeris.ls_acc_y == approx(-9.31322574615478510e-07, abs=0.0000000000000001e-07)
+    assert glo_ephemeris.ls_acc_z == approx(-0.00000000000000000, abs=0.0000000000000001)
+    assert glo_ephemeris.tau == approx(-6.69313594698905940e-05, abs=0.0000000000000001e-05)
+    assert glo_ephemeris.delta_tau == 5.587935448e-09
+    assert glo_ephemeris.gamma == approx(0.00000000000000000, abs=0.0000000000000001)
+    assert glo_ephemeris.tk == 84600
+    assert glo_ephemeris.p == 3
+    assert glo_ephemeris.ft == 2
+    assert glo_ephemeris.age == 0
+    assert glo_ephemeris.flags == 13
 
 
 def test_ascii_log_roundtrip_loglist(helper):
@@ -480,7 +484,7 @@ def test_short_binary_log_roundtrip_rawimu(helper):
 def test_flat_binary_log_decode_bestpos(helper):
     log = b"<BESTPOS COM1 0 72.0 FINESTEERING 2215 148248.000 02000020 cdba 32768\r\n" \
           b"<     SOL_COMPUTED SINGLE 51.15043711386 -114.03067767000 1097.2099 -17.0000 WGS84 0.9038 0.8534 1.7480 \"\" 0.000 0.000 35 30 30 30 00 06 39 33\r\n"
-    ret_code, message_data, bestpos = helper.DecodeEncode(ENCODE_FORMAT.FLATTENED_BINARY, log, return_message=True)
+    ret_code, message_data, message = helper.DecodeEncode(ENCODE_FORMAT.FLATTENED_BINARY, log, return_message=True)
     assert ret_code == Result.SUCCESS
 
     log_header = ne.Oem4BinaryHeader(message_data.header)
@@ -502,32 +506,34 @@ def test_flat_binary_log_decode_bestpos(helper):
     assert log_header.receiver_sw_version == 32768
 
     # SOL_COMPUTED SINGLE 51.15043711386 -114.03067767000 1097.2099 -17.0000 WGS84 0.9038 0.8534 1.7480 \"\" 0.000 0.000 35 30 30 30 00 06 39 33\r\n"
-    assert bestpos.body.solution_status == ne.enums.SolStatus.SOL_COMPUTED
-    assert bestpos.body.position_type == ne.enums.SolType.SINGLE
-    assert bestpos.body.latitude == 51.15043711386
-    assert bestpos.body.longitude == -114.03067767000
-    assert bestpos.body.orthometric_height == 1097.2099
-    assert bestpos.body.undulation == -17.0000
-    assert bestpos.body.datum_id == ne.enums.Datum.WGS84
-    assert bestpos.body.latitude_std_dev == approx(0.9038, abs=1e-5)
-    assert bestpos.body.longitude_std_dev == approx(0.8534, abs=1e-5)
-    assert bestpos.body.height_std_dev == approx(1.7480, abs=1e-5)
-    # assert bestpos.body.base_id == ""
-    assert bestpos.body.diff_age == 0.000
-    assert bestpos.body.solution_age == 0.000
-    assert bestpos.body.num_svs == 35
-    assert bestpos.body.num_soln_svs == 30
-    assert bestpos.body.num_soln_L1_svs == 30
-    assert bestpos.body.num_soln_multi_svs == 30
-    assert bestpos.body.extended_solution_status2 == 0x00
-    assert bestpos.body.ext_sol_stat == 0x06
-    assert bestpos.body.gal_and_bds_mask == 0x39
-    assert bestpos.body.gps_and_glo_mask == 0x33
+    bestpos = message.body
+    assert isinstance(bestpos, BESTPOS)
+    assert bestpos.solution_status == ne.enums.SolStatus.SOL_COMPUTED
+    assert bestpos.position_type == ne.enums.SolType.SINGLE
+    assert bestpos.latitude == 51.15043711386
+    assert bestpos.longitude == -114.03067767000
+    assert bestpos.orthometric_height == 1097.2099
+    assert bestpos.undulation == -17.0000
+    assert bestpos.datum_id == ne.enums.Datum.WGS84
+    assert bestpos.latitude_std_dev == approx(0.9038, abs=1e-5)
+    assert bestpos.longitude_std_dev == approx(0.8534, abs=1e-5)
+    assert bestpos.height_std_dev == approx(1.7480, abs=1e-5)
+    # assert bestpos.base_id == ""
+    assert bestpos.diff_age == 0.000
+    assert bestpos.solution_age == 0.000
+    assert bestpos.num_svs == 35
+    assert bestpos.num_soln_svs == 30
+    assert bestpos.num_soln_L1_svs == 30
+    assert bestpos.num_soln_multi_svs == 30
+    assert bestpos.extended_solution_status2 == 0x00
+    assert bestpos.ext_sol_stat == 0x06
+    assert bestpos.gal_and_bds_mask == 0x39
+    assert bestpos.gps_and_glo_mask == 0x33
 
 
 def test_flat_binary_log_decode_gloephema(helper):
     log = b"#GLOEPHEMERISA,COM1,11,67.0,SATTIME,2168,160218.000,02000820,8d29,32768;51,0,1,80,2168,161118000,10782,573,0,0,95,0,-2.3917966796875000e+07,4.8163881835937500e+06,7.4258510742187500e+06,-1.0062713623046875e+03,1.8321990966796875e+02,-3.3695755004882813e+03,1.86264514923095700e-06,-9.31322574615478510e-07,-0.00000000000000000,-6.69313594698905940e-05,5.587935448e-09,0.00000000000000000,84600,3,2,0,13*ad20fc5f\r\n"
-    ret_code, message_data, gloephemeris = helper.DecodeEncode(ENCODE_FORMAT.FLATTENED_BINARY, log, return_message=True)
+    ret_code, message_data, message = helper.DecodeEncode(ENCODE_FORMAT.FLATTENED_BINARY, log, return_message=True)
     assert ret_code == Result.SUCCESS
 
     log_header = ne.Oem4BinaryHeader(message_data.header)
@@ -548,35 +554,37 @@ def test_flat_binary_log_decode_gloephema(helper):
     assert log_header.msg_def_crc == 0x8d29
     assert log_header.receiver_sw_version == 32768
 
-    assert gloephemeris.body.sloto == 51
-    assert gloephemeris.body.freqo == 0
-    assert gloephemeris.body.sat_type == 1
-    assert gloephemeris.body.false_iod == 80
-    assert gloephemeris.body.ephem_week == 2168
-    assert gloephemeris.body.ephem_time == 161118000
-    assert gloephemeris.body.time_offset == 10782
-    assert gloephemeris.body.nt == 573
-    assert gloephemeris.body.GLOEPHEMERIS_reserved == 0
-    assert gloephemeris.body.GLOEPHEMERIS_reserved_9 == 0
-    assert gloephemeris.body.issue == 95
-    assert gloephemeris.body.broadcast_health == 0
-    assert gloephemeris.body.pos_x == -2.3917966796875000e+07
-    assert gloephemeris.body.pos_y == 4.8163881835937500e+06
-    assert gloephemeris.body.pos_z == 7.4258510742187500e+06
-    assert gloephemeris.body.vel_x == -1.0062713623046875e+03
-    assert gloephemeris.body.vel_y == 1.8321990966796875e+02
-    assert gloephemeris.body.vel_z == -3.3695755004882813e+03
-    assert gloephemeris.body.ls_acc_x == approx(1.86264514923095700e-06, abs=0.0000000000000001e-06)
-    assert gloephemeris.body.ls_acc_y == approx(-9.31322574615478510e-07, abs=0.0000000000000001e-07)
-    assert gloephemeris.body.ls_acc_z == approx(-0.00000000000000000, abs=0.0000000000000001)
-    assert gloephemeris.body.tau == approx(-6.69313594698905940e-05, abs=0.0000000000000001e-05)
-    assert gloephemeris.body.delta_tau == 5.587935448e-09
-    assert gloephemeris.body.gamma == approx(0.00000000000000000, abs=0.0000000000000001)
-    assert gloephemeris.body.tk == 84600
-    assert gloephemeris.body.p == 3
-    assert gloephemeris.body.ft == 2
-    assert gloephemeris.body.age == 0
-    assert gloephemeris.body.flags == 13
+    gloephemeris = message.body
+    assert isinstance(gloephemeris, GLOEPHEMERIS)
+    assert gloephemeris.sloto == 51
+    assert gloephemeris.freqo == 0
+    assert gloephemeris.sat_type == 1
+    assert gloephemeris.false_iod == 80
+    assert gloephemeris.ephem_week == 2168
+    assert gloephemeris.ephem_time == 161118000
+    assert gloephemeris.time_offset == 10782
+    assert gloephemeris.nt == 573
+    assert gloephemeris.GLOEPHEMERIS_reserved == 0
+    assert gloephemeris.GLOEPHEMERIS_reserved_9 == 0
+    assert gloephemeris.issue == 95
+    assert gloephemeris.broadcast_health == 0
+    assert gloephemeris.pos_x == -2.3917966796875000e+07
+    assert gloephemeris.pos_y == 4.8163881835937500e+06
+    assert gloephemeris.pos_z == 7.4258510742187500e+06
+    assert gloephemeris.vel_x == -1.0062713623046875e+03
+    assert gloephemeris.vel_y == 1.8321990966796875e+02
+    assert gloephemeris.vel_z == -3.3695755004882813e+03
+    assert gloephemeris.ls_acc_x == approx(1.86264514923095700e-06, abs=0.0000000000000001e-06)
+    assert gloephemeris.ls_acc_y == approx(-9.31322574615478510e-07, abs=0.0000000000000001e-07)
+    assert gloephemeris.ls_acc_z == approx(-0.00000000000000000, abs=0.0000000000000001)
+    assert gloephemeris.tau == approx(-6.69313594698905940e-05, abs=0.0000000000000001e-05)
+    assert gloephemeris.delta_tau == 5.587935448e-09
+    assert gloephemeris.gamma == approx(0.00000000000000000, abs=0.0000000000000001)
+    assert gloephemeris.tk == 84600
+    assert gloephemeris.p == 3
+    assert gloephemeris.ft == 2
+    assert gloephemeris.age == 0
+    assert gloephemeris.flags == 13
 
 
 def test_flat_binary_log_decode_portstatsb(helper):


### PR DESCRIPTION
@riley-kinahan Some suggested changes to #96. Found it easier to show the changes than to add a review comment.

I think the custom PyMessage sub-class for each message type in the database is an overkill and adding a `_Body` to the message body classes adds too much noise, especially if it's included in the field names as well. This PR drops the PyMessage sub-classes and the `_Body` suffix.

I also tweaked the repr for PyMessage.

After these changes:
```python
>>> message
<Message GLOEPHEMERIS(sloto=51, freqo=0, sat_type=1, false_iod=80, ephem_week=2168, ephem_time=161118000, time_offset=10782, nt=573, GLOEPHEMERIS_reserved=0, GLOEPHEMERIS_reserved_9=0, issue=95, broadcast_health=0, pos_x=-23917966.796875, pos_y=4816388.18359375, pos_z=7425851.07421875, vel_x=-1006.2713623046875, vel_y=183.21990966796875, vel_z=-3369.5755004882812, ls_acc_x=1.862645149230957e-06, ls_acc_y=-9.313225746154785e-07, ls_acc_z=-0.0, tau=-6.69313594698906e-05, delta_tau=5.587935448e-09, gamma=0.0, tk=84600, p=3, ft=2, age=0, flags=13)>
>>> type(message)
novatel_edie.bindings.Message
>>> type(message.body)
importlib._bootstrap.GLOEPHEMERIS
>>> from novatel_edie.messages import *
... isinstance(message.body, GLOEPHEMERIS)
True
```