### PR TITLE
Revert "Curiously Recurring Template Pattern for Framers"

### DIFF
--- a/include/novatel_edie/decoders/common/framer.hpp
+++ b/include/novatel_edie/decoders/common/framer.hpp
@@ -37,7 +37,7 @@
 //! \brief Base class for all framers. Contains necessary buffers and member
 //! variables, defining generic framer operations.
 //============================================================================
-template <typename Derived> class FramerBase
+class FramerBase
 {
   protected:
     std::shared_ptr<spdlog::logger> pclMyLogger;
@@ -52,7 +52,7 @@ template <typename Derived> class FramerBase
     bool bMyPayloadOnly{false};
     bool bMyFrameJson{false};
 
-    void ResetState() { return static_cast<Derived*>(this)->ResetStateImpl(); }
+    virtual void ResetState() = 0;
 
     [[nodiscard]] bool IsCrlf(const uint32_t uiPosition_) const
     {

--- a/include/novatel_edie/decoders/oem/framer.hpp
+++ b/include/novatel_edie/decoders/oem/framer.hpp
@@ -36,7 +36,7 @@ namespace novatel::edie::oem {
 //! \class Framer
 //! \brief Search bytes for patterns that could be OEM message.
 //============================================================================
-class Framer : public FramerBase<Framer>
+class Framer : public FramerBase
 {
   private:
     NovAtelFrameState eMyFrameState{NovAtelFrameState::WAITING_FOR_SYNC};
@@ -44,7 +44,7 @@ class Framer : public FramerBase<Framer>
     uint32_t uiMyJsonObjectOpenBraces{0};
     uint32_t uiMyAbbrevAsciiHeaderPosition{0};
 
-    void ResetStateImpl();
+    void ResetState() override;
 
     //----------------------------------------------------------------------------
     //! \brief Check if the characters following an '*' fit the CRC format.
@@ -82,8 +82,6 @@ class Framer : public FramerBase<Framer>
     //! to the size specified by uiFrameBufferSize_.
     //----------------------------------------------------------------------------
     [[nodiscard]] STATUS GetFrame(unsigned char* pucFrameBuffer_, uint32_t uiFrameBufferSize_, MetaDataStruct& stMetaData_);
-
-    friend class FramerBase<Framer>;
 };
 
 } // namespace novatel::edie::oem

--- a/src/decoders/oem/src/framer.cpp
+++ b/src/decoders/oem/src/framer.cpp
@@ -79,7 +79,7 @@ bool Framer::IsAbbrevAsciiResponse() const
 }
 
 // -------------------------------------------------------------------------------------------------------
-void Framer::ResetStateImpl() { eMyFrameState = NovAtelFrameState::WAITING_FOR_SYNC; }
+void Framer::ResetState() { eMyFrameState = NovAtelFrameState::WAITING_FOR_SYNC; }
 
 // -------------------------------------------------------------------------------------------------------
 STATUS
@@ -121,7 +121,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
             ucDataByte > 127)
         {
             stMetaData_.eFormat = HEADER_FORMAT::UNKNOWN;
-            ResetStateImpl();
+            ResetState();
             uiMyByteCount--;
         }
 
@@ -191,7 +191,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                 break;
             default:
                 stMetaData_.eFormat = HEADER_FORMAT::UNKNOWN;
-                ResetStateImpl();
+                ResetState();
                 uiMyByteCount--;
             }
             break;
@@ -211,7 +211,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                 break;
             default:
                 stMetaData_.eFormat = HEADER_FORMAT::UNKNOWN;
-                ResetStateImpl();
+                ResetState();
                 uiMyByteCount--;
                 break;
             }
@@ -225,7 +225,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
             else
             {
                 stMetaData_.eFormat = HEADER_FORMAT::UNKNOWN;
-                ResetStateImpl();
+                ResetState();
                 uiMyByteCount--;
             }
             break;
@@ -238,7 +238,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                 if (uiFrameBufferSize_ < OEM4_BINARY_HEADER_LENGTH)
                 {
                     uiMyByteCount = 0;
-                    ResetStateImpl();
+                    ResetState();
                     return STATUS::BUFFER_FULL;
                 }
 
@@ -252,7 +252,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                     uiMyByteCount = OEM4_BINARY_SYNC_LENGTH;
                     uiMyExpectedPayloadLength = 0;
                     uiMyExpectedMessageLength = 0;
-                    ResetStateImpl();
+                    ResetState();
                     break;
                 }
 
@@ -263,7 +263,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                     uiMyByteCount = 0;
                     uiMyExpectedPayloadLength = 0;
                     uiMyExpectedMessageLength = 0;
-                    ResetStateImpl();
+                    ResetState();
                     return STATUS::BUFFER_FULL;
                 }
 
@@ -279,7 +279,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                 if (uiFrameBufferSize_ < OEM4_SHORT_BINARY_HEADER_LENGTH)
                 {
                     uiMyByteCount = 0;
-                    ResetStateImpl();
+                    ResetState();
                     return STATUS::BUFFER_FULL;
                 }
 
@@ -293,7 +293,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                     uiMyByteCount = OEM4_SHORT_BINARY_SYNC_LENGTH;
                     uiMyExpectedPayloadLength = 0;
                     uiMyExpectedMessageLength = 0;
-                    ResetStateImpl();
+                    ResetState();
                     break;
                 }
 
@@ -304,7 +304,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                     uiMyByteCount = 0;
                     uiMyExpectedPayloadLength = 0;
                     uiMyExpectedMessageLength = 0;
-                    ResetStateImpl();
+                    ResetState();
                     return STATUS::BUFFER_FULL;
                 }
 
@@ -338,7 +338,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                 else
                 {
                     uiMyByteCount = stMetaData_.eFormat == HEADER_FORMAT::BINARY ? OEM4_BINARY_SYNC_LENGTH : OEM4_SHORT_BINARY_SYNC_LENGTH;
-                    ResetStateImpl();
+                    ResetState();
                 }
 
                 uiMyExpectedPayloadLength = 0;
@@ -377,7 +377,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
             {
                 uiMyByteCount = OEM4_ASCII_SYNC_LENGTH;
                 uiMyExpectedPayloadLength = 0;
-                ResetStateImpl();
+                ResetState();
             }
             else { CalculateCharacterCrc32(uiMyCalculatedCrc32, ucDataByte); }
             break;
@@ -395,7 +395,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
 
                     if (uiFrameBufferSize_ < stMetaData_.uiLength)
                     {
-                        ResetStateImpl();
+                        ResetState();
                         return STATUS::BUFFER_FULL;
                     }
 
@@ -424,7 +424,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                     uiMyByteCount = OEM4_ASCII_SYNC_LENGTH;
                     uiMyExpectedPayloadLength = 0;
                     uiMyAbbrevAsciiHeaderPosition = 0;
-                    ResetStateImpl();
+                    ResetState();
                 }
             }
             else if (uiMyByteCount >= MAX_ASCII_MESSAGE_LENGTH)
@@ -432,7 +432,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                 uiMyByteCount = OEM4_ASCII_SYNC_LENGTH;
                 uiMyAbbrevAsciiHeaderPosition = 0;
                 uiMyExpectedPayloadLength = 0;
-                ResetStateImpl();
+                ResetState();
             }
             break;
 
@@ -466,7 +466,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                         uiMyByteCount = OEM4_ASCII_SYNC_LENGTH;
                         uiMyAbbrevAsciiHeaderPosition = 0;
                         uiMyExpectedPayloadLength = 0;
-                        ResetStateImpl();
+                        ResetState();
                     }
                 }
             }
@@ -482,7 +482,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                     uiMyByteCount = 0;
                     uiMyAbbrevAsciiHeaderPosition = 0;
                     uiMyExpectedPayloadLength = 0;
-                    ResetStateImpl();
+                    ResetState();
                     return STATUS::BUFFER_FULL;
                 }
 
@@ -499,7 +499,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                 uiMyByteCount = OEM4_ASCII_SYNC_LENGTH;
                 uiMyAbbrevAsciiHeaderPosition = 0;
                 uiMyExpectedPayloadLength = 0;
-                ResetStateImpl();
+                ResetState();
             }
             break;
 
@@ -521,7 +521,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
 
                     if (uiFrameBufferSize_ < stMetaData_.uiLength)
                     {
-                        ResetStateImpl();
+                        ResetState();
                         return STATUS::BUFFER_FULL;
                     }
 
@@ -532,14 +532,14 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                 else
                 {
                     uiMyByteCount = OEM4_ASCII_SYNC_LENGTH;
-                    ResetStateImpl();
+                    ResetState();
                 }
             }
             else if (uiMyByteCount >= MAX_ASCII_MESSAGE_LENGTH)
             {
                 uiMyByteCount = OEM4_ASCII_SYNC_LENGTH;
                 uiMyExpectedPayloadLength = 0;
-                ResetStateImpl();
+                ResetState();
             }
             break;
         }
@@ -549,7 +549,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
             {
                 uiMyByteCount = NMEA_SYNC_LENGTH;
                 uiMyExpectedPayloadLength = 0;
-                ResetStateImpl();
+                ResetState();
             }
             else { uiMyCalculatedCrc32 ^= ucDataByte; }
             break;
@@ -573,7 +573,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                     if (uiFrameBufferSize_ < stMetaData_.uiLength)
                     {
                         uiMyByteCount = 0;
-                        ResetStateImpl();
+                        ResetState();
                         return STATUS::BUFFER_FULL;
                     }
 
@@ -585,14 +585,14 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
                 else
                 {
                     uiMyByteCount = NMEA_SYNC_LENGTH;
-                    ResetStateImpl();
+                    ResetState();
                 }
             }
             else if (uiMyByteCount >= MAX_NMEA_MESSAGE_LENGTH)
             {
                 uiMyByteCount = NMEA_SYNC_LENGTH;
                 uiMyExpectedPayloadLength = 0;
-                ResetStateImpl();
+                ResetState();
             }
             break;
         }
@@ -601,7 +601,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
             {
                 uiMyByteCount = 0;
                 uiMyExpectedPayloadLength = 0;
-                ResetStateImpl();
+                ResetState();
                 return STATUS::BUFFER_FULL;
             }
 
@@ -625,7 +625,7 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, const uint32_t uiFrameBufferSiz
         }
     }
 
-    ResetStateImpl();
+    ResetState();
 
     return STATUS::SUCCESS;
 }


### PR DESCRIPTION
#84 requires dynamic dispatch, so framers cant use CRTP
This reverts changes in commit framer CRTP 7e00a47f6c7bfcfea0e768c181bb7e3b1aa6bb32.