### PR TITLE
Logging Refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ include(cmake/ThirdParty.cmake)
 # Build Project
 project(novatel_edie VERSION ${RELEASE_VERSION} LANGUAGES CXX)
 
-
 option(BUILD_TESTS "Build tests" ON)
 option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_BENCHMARKS "Build benchmarks" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ include(cmake/ThirdParty.cmake)
 # Build Project
 project(novatel_edie VERSION ${RELEASE_VERSION} LANGUAGES CXX)
 
+add_definitions(-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+
 option(BUILD_TESTS "Build tests" ON)
 option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_BENCHMARKS "Build benchmarks" OFF)

--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -210,7 +210,7 @@ BENCHMARK(DecompressRangeCmp5);
 
 int main(int argc, char** argv)
 {
-    Logger::InitLogger();
+    LoggerManager::InitLogger();
 
     std::filesystem::path pathSourceFile = __FILE__;
     std::filesystem::path pathRepoDir = pathSourceFile.parent_path().parent_path();

--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -210,7 +210,7 @@ BENCHMARK(DecompressRangeCmp5);
 
 int main(int argc, char** argv)
 {
-    LoggerManager::InitLogger();
+    getLoggerManager() -> InitManager();
 
     std::filesystem::path pathSourceFile = __FILE__;
     std::filesystem::path pathRepoDir = pathSourceFile.parent_path().parent_path();

--- a/examples/novatel/command_encoding/command_encoding.cpp
+++ b/examples/novatel/command_encoding/command_encoding.cpp
@@ -43,11 +43,11 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    CPPLoggerManager* pclLoggerManager = GetLoggerManager();
-    std::shared_ptr<spdlog::logger> logger = pclLoggerManager->RegisterLogger("command_encoder");
+    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
+    std::shared_ptr<spdlog::logger> logger = pclMyLoggerManager->RegisterLogger("command_encoder");
     logger->set_level(spdlog::level::debug);
-    pclLoggerManager->AddConsoleLogging(logger);
-    pclLoggerManager->AddRotatingFileLogger(logger);
+    pclMyLoggerManager->AddConsoleLogging(logger);
+    pclMyLoggerManager->AddRotatingFileLogger(logger);
 
     if (argc < 3)
     {

--- a/examples/novatel/command_encoding/command_encoding.cpp
+++ b/examples/novatel/command_encoding/command_encoding.cpp
@@ -44,6 +44,7 @@ int main(int argc, char* argv[])
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
     CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
+    pclMyLoggerManager->InitLogger();
     std::shared_ptr<spdlog::logger> logger = pclMyLoggerManager->RegisterLogger("command_encoder");
     logger->set_level(spdlog::level::debug);
     pclMyLoggerManager->AddConsoleLogging(logger);

--- a/examples/novatel/command_encoding/command_encoding.cpp
+++ b/examples/novatel/command_encoding/command_encoding.cpp
@@ -43,11 +43,11 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    Logger::InitLogger();
-    std::shared_ptr<spdlog::logger> logger = Logger::RegisterLogger("command_encoder");
+    CPPLoggerManager* pclLoggerManager = GetLoggerManager();
+    std::shared_ptr<spdlog::logger> logger = pclLoggerManager->RegisterLogger("command_encoder");
     logger->set_level(spdlog::level::debug);
-    Logger::AddConsoleLogging(logger);
-    Logger::AddRotatingFileLogger(logger);
+    pclLoggerManager->AddConsoleLogging(logger);
+    pclLoggerManager->AddRotatingFileLogger(logger);
 
     if (argc < 3)
     {

--- a/examples/novatel/command_encoding/command_encoding.cpp
+++ b/examples/novatel/command_encoding/command_encoding.cpp
@@ -76,7 +76,8 @@ int main(int argc, char* argv[])
     auto tStart = std::chrono::high_resolution_clock::now();
     pclLogger->info("Loading Database... ");
     MessageDatabase::Ptr clJsonDb = LoadJsonDbFile(pathJsonDb.string());
-    pclLogger->info("Done in {}ms", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
+    pclLogger->info("Done in {}ms",
+                    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
 
     Commander clCommander(clJsonDb);
 

--- a/examples/novatel/command_encoding/command_encoding.cpp
+++ b/examples/novatel/command_encoding/command_encoding.cpp
@@ -41,19 +41,18 @@ using namespace novatel::edie::oem;
 
 int main(int argc, char* argv[])
 {
-    // This example uses the default logger config, but you can also pass a config file to InitLogger()
-    // Example config file: logger\example_logger_config.toml
-    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
-    pclMyLoggerManager->InitLogger();
-    std::shared_ptr<spdlog::logger> logger = pclMyLoggerManager->RegisterLogger("command_encoder");
-    logger->set_level(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(logger);
-    pclMyLoggerManager->AddRotatingFileLogger(logger);
+    // This example uses the default pclLogger config, but you can also pass a config file to InitLogger()
+    // Example config file: pclLogger\example_logger_config.toml
+    LOGGER_MANAGER->InitLogger();
+    auto pclLogger = CREATE_LOGGER();
+    pclLogger->set_level(spdlog::level::debug);
+    LOGGER_MANAGER->AddConsoleLogging(pclLogger);
+    LOGGER_MANAGER->AddRotatingFileLogger(pclLogger);
 
     if (argc < 3)
     {
-        logger->error("Format: command_encoding <path to Json DB> <output format> <abbreviated ascii command>\n");
-        logger->error("Example: command_encoding database/database.json ASCII \"RTKTIMEOUT 30\"\n");
+        pclLogger->error("Format: command_encoding <path to Json DB> <output format> <abbreviated ascii command>\n");
+        pclLogger->error("Example: command_encoding database/database.json ASCII \"RTKTIMEOUT 30\"\n");
         return 1;
     }
 
@@ -61,7 +60,7 @@ int main(int argc, char* argv[])
     const fs::path pathJsonDb = argv[1];
     if (!fs::exists(pathJsonDb))
     {
-        logger->error("File \"{}\" does not exist", pathJsonDb.string());
+        pclLogger->error("File \"{}\" does not exist", pathJsonDb.string());
         return 1;
     }
 
@@ -70,14 +69,14 @@ int main(int argc, char* argv[])
     ENCODE_FORMAT eEncodeFormat = StringToEncodeFormat(strEncodeFormat);
     if (eEncodeFormat == ENCODE_FORMAT::UNSPECIFIED)
     {
-        logger->error("Unsupported output format. Choose from:\n\tASCII\n\tBINARY");
+        pclLogger->error("Unsupported output format. Choose from:\n\tASCII\n\tBINARY");
         return 1;
     }
 
     auto tStart = std::chrono::high_resolution_clock::now();
-    logger->info("Loading Database... ");
+    pclLogger->info("Loading Database... ");
     MessageDatabase::Ptr clJsonDb = LoadJsonDbFile(pathJsonDb.string());
-    logger->info("Done in {}ms", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
+    pclLogger->info("Done in {}ms", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count());
 
     Commander clCommander(clJsonDb);
 
@@ -85,17 +84,18 @@ int main(int argc, char* argv[])
     char* pcEncodedMessageBuffer = acEncodeBuffer;
     uint32_t uiEncodeBufferLength = MAX_ASCII_MESSAGE_LENGTH;
 
-    logger->info("Converting \"{}\" to {}", argv[3], strEncodeFormat);
+    pclLogger->info("Converting \"{}\" to {}", argv[3], strEncodeFormat);
     STATUS eCommanderStatus =
         clCommander.Encode(argv[3], static_cast<uint32_t>(strlen(argv[3])), pcEncodedMessageBuffer, uiEncodeBufferLength, eEncodeFormat);
     if (eCommanderStatus != STATUS::SUCCESS)
     {
-        logger->info("Failed to formulate a command ({})", eCommanderStatus);
+        pclLogger->info("Failed to formulate a command ({})", eCommanderStatus);
         return -1;
     }
 
     std::string sOutFilename = std::string("COMMAND.").append(strEncodeFormat);
     std::ofstream ofs(sOutFilename.c_str(), std::ios::binary);
     ofs.write(pcEncodedMessageBuffer, uiEncodeBufferLength);
+    LOGGER_MANAGER->Shutdown();
     return 0;
 }

--- a/examples/novatel/converter_components/converter_components.cpp
+++ b/examples/novatel/converter_components/converter_components.cpp
@@ -48,11 +48,11 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    Logger::InitLogger();
-    std::shared_ptr<spdlog::logger> pclLogger = Logger::RegisterLogger("converter");
+    CPPLoggerManager* pclMyLoggerManger = GetLoggerManager();
+    std::shared_ptr<spdlog::logger> pclLogger = pclLoggerManager->RegisterLogger("converter");
     pclLogger->set_level(spdlog::level::debug);
-    Logger::AddConsoleLogging(pclLogger);
-    Logger::AddRotatingFileLogger(pclLogger);
+    pclMyLoggerManger->AddConsoleLogging(pclLogger);
+    pclMyLoggerManger->AddRotatingFileLogger(pclLogger);
 
     // Get command line arguments
     pclLogger->info("Decoder library information:\n{}", caPrettyPrint);
@@ -98,31 +98,31 @@ int main(int argc, char* argv[])
     // Set up the EDIE components
     Framer clFramer;
     clFramer.SetLoggerLevel(spdlog::level::debug);
-    Logger::AddConsoleLogging(clFramer.GetLogger());
-    Logger::AddRotatingFileLogger(clFramer.GetLogger());
+    pclMyLoggerManger->AddConsoleLogging(clFramer.GetLogger());
+    pclMyLoggerManger->AddRotatingFileLogger(clFramer.GetLogger());
     clFramer.SetReportUnknownBytes(true);
     clFramer.SetPayloadOnly(false);
     clFramer.SetFrameJson(false);
 
     HeaderDecoder clHeaderDecoder(clJsonDb);
     clHeaderDecoder.SetLoggerLevel(spdlog::level::debug);
-    Logger::AddConsoleLogging(clHeaderDecoder.GetLogger());
-    Logger::AddRotatingFileLogger(clHeaderDecoder.GetLogger());
+    pclMyLoggerManger->AddConsoleLogging(clHeaderDecoder.GetLogger());
+    pclMyLoggerManger->AddRotatingFileLogger(clHeaderDecoder.GetLogger());
 
     MessageDecoder clMessageDecoder(clJsonDb);
     clMessageDecoder.SetLoggerLevel(spdlog::level::debug);
-    Logger::AddConsoleLogging(clMessageDecoder.GetLogger());
-    Logger::AddRotatingFileLogger(clMessageDecoder.GetLogger());
+    pclMyLoggerManger->AddConsoleLogging(clMessageDecoder.GetLogger());
+    pclMyLoggerManger->AddRotatingFileLogger(clMessageDecoder.GetLogger());
 
     Encoder clEncoder(clJsonDb);
     clEncoder.SetLoggerLevel(spdlog::level::debug);
-    Logger::AddConsoleLogging(clEncoder.GetLogger());
-    Logger::AddRotatingFileLogger(clEncoder.GetLogger());
+    pclMyLoggerManger->AddConsoleLogging(clEncoder.GetLogger());
+    pclMyLoggerManger->AddRotatingFileLogger(clEncoder.GetLogger());
 
     Filter clFilter;
     clFilter.SetLoggerLevel(spdlog::level::debug);
-    Logger::AddConsoleLogging(clFilter.GetLogger());
-    Logger::AddRotatingFileLogger(clFilter.GetLogger());
+    pclMyLoggerManger->AddConsoleLogging(clFilter.GetLogger());
+    pclMyLoggerManger->AddRotatingFileLogger(clFilter.GetLogger());
 
     // Set up buffers
     std::array<char, MAX_ASCII_MESSAGE_LENGTH> cData;
@@ -221,6 +221,6 @@ int main(int argc, char* argv[])
     // Clean up
     uint32_t uiBytes = clFramer.Flush(acFrameBuffer, sizeof(acFrameBuffer));
     unknownOfs.write(reinterpret_cast<char*>(acFrameBuffer), uiBytes);
-    Logger::Shutdown();
+    pclMyLoggerManger->Shutdown();
     return 0;
 }

--- a/examples/novatel/converter_components/converter_components.cpp
+++ b/examples/novatel/converter_components/converter_components.cpp
@@ -48,11 +48,12 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    CPPLoggerManager* pclMyLoggerManger = GetLoggerManager();
+    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
+    pclMyLoggerManager->InitLogger();
     std::shared_ptr<spdlog::logger> pclLogger = pclLoggerManager->RegisterLogger("converter");
     pclLogger->set_level(spdlog::level::debug);
-    pclMyLoggerManger->AddConsoleLogging(pclLogger);
-    pclMyLoggerManger->AddRotatingFileLogger(pclLogger);
+    pclMyLoggerManager->AddConsoleLogging(pclLogger);
+    pclMyLoggerManager->AddRotatingFileLogger(pclLogger);
 
     // Get command line arguments
     pclLogger->info("Decoder library information:\n{}", caPrettyPrint);
@@ -98,31 +99,31 @@ int main(int argc, char* argv[])
     // Set up the EDIE components
     Framer clFramer;
     clFramer.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManger->AddConsoleLogging(clFramer.GetLogger());
-    pclMyLoggerManger->AddRotatingFileLogger(clFramer.GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clFramer.GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clFramer.GetLogger());
     clFramer.SetReportUnknownBytes(true);
     clFramer.SetPayloadOnly(false);
     clFramer.SetFrameJson(false);
 
     HeaderDecoder clHeaderDecoder(clJsonDb);
     clHeaderDecoder.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManger->AddConsoleLogging(clHeaderDecoder.GetLogger());
-    pclMyLoggerManger->AddRotatingFileLogger(clHeaderDecoder.GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clHeaderDecoder.GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clHeaderDecoder.GetLogger());
 
     MessageDecoder clMessageDecoder(clJsonDb);
     clMessageDecoder.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManger->AddConsoleLogging(clMessageDecoder.GetLogger());
-    pclMyLoggerManger->AddRotatingFileLogger(clMessageDecoder.GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clMessageDecoder.GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clMessageDecoder.GetLogger());
 
     Encoder clEncoder(clJsonDb);
     clEncoder.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManger->AddConsoleLogging(clEncoder.GetLogger());
-    pclMyLoggerManger->AddRotatingFileLogger(clEncoder.GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clEncoder.GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clEncoder.GetLogger());
 
     Filter clFilter;
     clFilter.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManger->AddConsoleLogging(clFilter.GetLogger());
-    pclMyLoggerManger->AddRotatingFileLogger(clFilter.GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clFilter.GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clFilter.GetLogger());
 
     // Set up buffers
     std::array<char, MAX_ASCII_MESSAGE_LENGTH> cData;
@@ -221,6 +222,6 @@ int main(int argc, char* argv[])
     // Clean up
     uint32_t uiBytes = clFramer.Flush(acFrameBuffer, sizeof(acFrameBuffer));
     unknownOfs.write(reinterpret_cast<char*>(acFrameBuffer), uiBytes);
-    pclMyLoggerManger->Shutdown();
+    pclMyLoggerManager->Shutdown();
     return 0;
 }

--- a/examples/novatel/converter_components/converter_components.cpp
+++ b/examples/novatel/converter_components/converter_components.cpp
@@ -48,12 +48,12 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
-    pclMyLoggerManager->InitLogger();
-    std::shared_ptr<spdlog::logger> pclLogger = pclLoggerManager->RegisterLogger("converter");
+    LOGGER_MANAGER->InitLogger();
+
+    auto pclLogger = CREATE_LOGGER();
     pclLogger->set_level(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(pclLogger);
-    pclMyLoggerManager->AddRotatingFileLogger(pclLogger);
+    LOGGER_MANAGER->AddConsoleLogging(pclLogger);
+    LOGGER_MANAGER->AddRotatingFileLogger(pclLogger);
 
     // Get command line arguments
     pclLogger->info("Decoder library information:\n{}", caPrettyPrint);
@@ -99,31 +99,31 @@ int main(int argc, char* argv[])
     // Set up the EDIE components
     Framer clFramer;
     clFramer.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(clFramer.GetLogger());
-    pclMyLoggerManager->AddRotatingFileLogger(clFramer.GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clFramer.GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clFramer.GetLogger());
     clFramer.SetReportUnknownBytes(true);
     clFramer.SetPayloadOnly(false);
     clFramer.SetFrameJson(false);
 
     HeaderDecoder clHeaderDecoder(clJsonDb);
     clHeaderDecoder.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(clHeaderDecoder.GetLogger());
-    pclMyLoggerManager->AddRotatingFileLogger(clHeaderDecoder.GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clHeaderDecoder.GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clHeaderDecoder.GetLogger());
 
     MessageDecoder clMessageDecoder(clJsonDb);
     clMessageDecoder.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(clMessageDecoder.GetLogger());
-    pclMyLoggerManager->AddRotatingFileLogger(clMessageDecoder.GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clMessageDecoder.GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clMessageDecoder.GetLogger());
 
     Encoder clEncoder(clJsonDb);
     clEncoder.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(clEncoder.GetLogger());
-    pclMyLoggerManager->AddRotatingFileLogger(clEncoder.GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clEncoder.GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clEncoder.GetLogger());
 
     Filter clFilter;
     clFilter.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(clFilter.GetLogger());
-    pclMyLoggerManager->AddRotatingFileLogger(clFilter.GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clFilter.GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clFilter.GetLogger());
 
     // Set up buffers
     std::array<char, MAX_ASCII_MESSAGE_LENGTH> cData;
@@ -222,6 +222,6 @@ int main(int argc, char* argv[])
     // Clean up
     uint32_t uiBytes = clFramer.Flush(acFrameBuffer, sizeof(acFrameBuffer));
     unknownOfs.write(reinterpret_cast<char*>(acFrameBuffer), uiBytes);
-    pclMyLoggerManager->Shutdown();
+    LOGGER_MANAGER->Shutdown();
     return 0;
 }

--- a/examples/novatel/converter_file_parser/converter_file_parser.cpp
+++ b/examples/novatel/converter_file_parser/converter_file_parser.cpp
@@ -44,11 +44,12 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    Logger::InitLogger();
-    std::shared_ptr<spdlog::logger> pclLogger = Logger::RegisterLogger("converter");
+    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
+    pclMyLoggerManager->InitLogger();
+    std::shared_ptr<spdlog::logger> pclLogger = pclLoggerManager->RegisterLogger("converter");
     pclLogger->set_level(spdlog::level::debug);
-    Logger::AddConsoleLogging(pclLogger);
-    Logger::AddRotatingFileLogger(pclLogger);
+    pclMyLoggerManager->AddConsoleLogging(pclLogger);
+    pclMyLoggerManager->AddRotatingFileLogger(pclLogger);
 
     // Get command line arguments
     pclLogger->info("Decoder library information:\n{}", caPrettyPrint);
@@ -96,13 +97,13 @@ int main(int argc, char* argv[])
 
     FileParser clFileParser(clJsonDb);
     clFileParser.SetLoggerLevel(spdlog::level::debug);
-    Logger::AddConsoleLogging(clFileParser.GetLogger());
-    Logger::AddRotatingFileLogger(clFileParser.GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clFileParser.GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clFileParser.GetLogger());
 
     auto clFilter = std::make_shared<Filter>();
     clFilter->SetLoggerLevel(spdlog::level::debug);
-    Logger::AddConsoleLogging(clFilter->GetLogger());
-    Logger::AddRotatingFileLogger(clFilter->GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clFilter->GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clFilter->GetLogger());
 
     // Initialize structures and error codes
     auto eStatus = STATUS::UNKNOWN;
@@ -159,6 +160,6 @@ int main(int argc, char* argv[])
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
                     pathInFilename.string().c_str());
-    Logger::Shutdown();
+    pclMyLoggerManager->Shutdown();
     return 0;
 }

--- a/examples/novatel/converter_file_parser/converter_file_parser.cpp
+++ b/examples/novatel/converter_file_parser/converter_file_parser.cpp
@@ -44,12 +44,11 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
-    pclMyLoggerManager->InitLogger();
-    std::shared_ptr<spdlog::logger> pclLogger = pclLoggerManager->RegisterLogger("converter");
+    LOGGER_MANAGER->InitLogger();
+    auto pclLogger = CREATE_LOGGER();
     pclLogger->set_level(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(pclLogger);
-    pclMyLoggerManager->AddRotatingFileLogger(pclLogger);
+    LOGGER_MANAGER->AddConsoleLogging(pclLogger);
+    LOGGER_MANAGER->AddRotatingFileLogger(pclLogger);
 
     // Get command line arguments
     pclLogger->info("Decoder library information:\n{}", caPrettyPrint);
@@ -97,13 +96,13 @@ int main(int argc, char* argv[])
 
     FileParser clFileParser(clJsonDb);
     clFileParser.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(clFileParser.GetLogger());
-    pclMyLoggerManager->AddRotatingFileLogger(clFileParser.GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clFileParser.GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clFileParser.GetLogger());
 
     auto clFilter = std::make_shared<Filter>();
     clFilter->SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(clFilter->GetLogger());
-    pclMyLoggerManager->AddRotatingFileLogger(clFilter->GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clFilter->GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clFilter->GetLogger());
 
     // Initialize structures and error codes
     auto eStatus = STATUS::UNKNOWN;
@@ -160,6 +159,6 @@ int main(int argc, char* argv[])
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
                     pathInFilename.string().c_str());
-    pclMyLoggerManager->Shutdown();
+    LOGGER_MANAGER->Shutdown();
     return 0;
 }

--- a/examples/novatel/converter_parser/converter_parser.cpp
+++ b/examples/novatel/converter_parser/converter_parser.cpp
@@ -43,7 +43,6 @@ int main(int argc, char* argv[])
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
     CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
-
     pclMyLoggerManager->InitLogger();
     std::shared_ptr<spdlog::logger> pclLogger = pclMyLoggerManager->RegisterLogger("converter_parser");
     pclLogger->set_level(spdlog::level::debug);

--- a/examples/novatel/converter_parser/converter_parser.cpp
+++ b/examples/novatel/converter_parser/converter_parser.cpp
@@ -42,12 +42,11 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
-    pclMyLoggerManager->InitLogger();
-    std::shared_ptr<spdlog::logger> pclLogger = pclMyLoggerManager->RegisterLogger("converter_parser");
+    LOGGER_MANAGER->InitLogger();
+    auto pclLogger = CREATE_LOGGER();
     pclLogger->set_level(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(pclLogger);
-    pclMyLoggerManager->AddRotatingFileLogger(pclLogger);
+    LOGGER_MANAGER->AddConsoleLogging(pclLogger);
+    LOGGER_MANAGER->AddRotatingFileLogger(pclLogger);
 
     // Get command line arguments
     pclLogger->info("Decoder library information:\n{}", caPrettyPrint);
@@ -96,13 +95,13 @@ int main(int argc, char* argv[])
     Parser clParser(clJsonDb);
     clParser.SetEncodeFormat(eEncodeFormat);
     clParser.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(clParser.GetLogger());
-    pclMyLoggerManager->AddRotatingFileLogger(clParser.GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clParser.GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clParser.GetLogger());
 
     auto clFilter = std::make_shared<Filter>();
     clFilter->SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(clFilter->GetLogger());
-    pclMyLoggerManager->AddRotatingFileLogger(clFilter->GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clFilter->GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clFilter->GetLogger());
 
     // Initialize structures
     MetaDataStruct stMetaData;
@@ -154,6 +153,6 @@ int main(int argc, char* argv[])
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
                     pathInFilename.string().c_str());
-    pclMyLoggerManager->Shutdown();
+    LOGGER_MANAGER->Shutdown();
     return 0;
 }

--- a/examples/novatel/converter_parser/converter_parser.cpp
+++ b/examples/novatel/converter_parser/converter_parser.cpp
@@ -42,11 +42,13 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    Logger::InitLogger();
-    std::shared_ptr<spdlog::logger> pclLogger = Logger::RegisterLogger("converter_parser");
+    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
+
+    pclMyLoggerManager->InitLogger();
+    std::shared_ptr<spdlog::logger> pclLogger = pclMyLoggerManager->RegisterLogger("converter_parser");
     pclLogger->set_level(spdlog::level::debug);
-    Logger::AddConsoleLogging(pclLogger);
-    Logger::AddRotatingFileLogger(pclLogger);
+    pclMyLoggerManager->AddConsoleLogging(pclLogger);
+    pclMyLoggerManager->AddRotatingFileLogger(pclLogger);
 
     // Get command line arguments
     pclLogger->info("Decoder library information:\n{}", caPrettyPrint);
@@ -95,13 +97,13 @@ int main(int argc, char* argv[])
     Parser clParser(clJsonDb);
     clParser.SetEncodeFormat(eEncodeFormat);
     clParser.SetLoggerLevel(spdlog::level::debug);
-    Logger::AddConsoleLogging(clParser.GetLogger());
-    Logger::AddRotatingFileLogger(clParser.GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clParser.GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clParser.GetLogger());
 
     auto clFilter = std::make_shared<Filter>();
     clFilter->SetLoggerLevel(spdlog::level::debug);
-    Logger::AddConsoleLogging(clFilter->GetLogger());
-    Logger::AddRotatingFileLogger(clFilter->GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clFilter->GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clFilter->GetLogger());
 
     // Initialize structures
     MetaDataStruct stMetaData;
@@ -153,6 +155,6 @@ int main(int argc, char* argv[])
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
                     pathInFilename.string().c_str());
-    Logger::Shutdown();
+    pclMyLoggerManager->Shutdown();
     return 0;
 }

--- a/examples/novatel/json_parser/json_parser.cpp
+++ b/examples/novatel/json_parser/json_parser.cpp
@@ -42,11 +42,13 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    Logger::InitLogger();
-    std::shared_ptr<spdlog::logger> pclLogger = Logger::RegisterLogger("json_parser");
+
+    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
+    pclMyLoggerManager->InitLogger();
+    std::shared_ptr<spdlog::logger> pclLogger = pclMyLoggerManager->RegisterLogger("json_parser");
     pclLogger->set_level(spdlog::level::debug);
-    Logger::AddConsoleLogging(pclLogger);
-    Logger::AddRotatingFileLogger(pclLogger);
+    pclMyLoggerManager->AddConsoleLogging(pclLogger);
+    pclMyLoggerManager->AddRotatingFileLogger(pclLogger);
 
     // Get command line arguments
     pclLogger->info("Decoder library information:\n{}", caPrettyPrint);
@@ -104,13 +106,13 @@ int main(int argc, char* argv[])
     Parser clParser(clJsonDb);
     clParser.SetEncodeFormat(eEncodeFormat);
     clParser.SetLoggerLevel(spdlog::level::debug);
-    Logger::AddConsoleLogging(clParser.GetLogger());
-    Logger::AddRotatingFileLogger(clParser.GetLogger());
+    GetLoggerManager()->AddConsoleLogging(clParser.GetLogger());
+    GetLoggerManager()->AddRotatingFileLogger(clParser.GetLogger());
 
     auto clFilter = std::make_shared<Filter>();
     clFilter->SetLoggerLevel(spdlog::level::debug);
-    Logger::AddConsoleLogging(clFilter->GetLogger());
-    Logger::AddRotatingFileLogger(clFilter->GetLogger());
+    GetLoggerManager()->AddConsoleLogging(clFilter->GetLogger());
+    GetLoggerManager()->AddRotatingFileLogger(clFilter->GetLogger());
 
     // Initialize structures
     MetaDataStruct stMetaData;
@@ -162,6 +164,6 @@ int main(int argc, char* argv[])
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
                     pathInFilename.string().c_str());
-    Logger::Shutdown();
+    pclMyLoggerManager->Shutdown();
     return 0;
 }

--- a/examples/novatel/json_parser/json_parser.cpp
+++ b/examples/novatel/json_parser/json_parser.cpp
@@ -42,13 +42,11 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-
-    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
-    pclMyLoggerManager->InitLogger();
-    std::shared_ptr<spdlog::logger> pclLogger = pclMyLoggerManager->RegisterLogger("json_parser");
+    LOGGER_MANAGER->InitLogger();
+    auto pclLogger = CREATE_LOGGER();
     pclLogger->set_level(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(pclLogger);
-    pclMyLoggerManager->AddRotatingFileLogger(pclLogger);
+    LOGGER_MANAGER->AddConsoleLogging(pclLogger);
+    LOGGER_MANAGER->AddRotatingFileLogger(pclLogger);
 
     // Get command line arguments
     pclLogger->info("Decoder library information:\n{}", caPrettyPrint);
@@ -106,13 +104,13 @@ int main(int argc, char* argv[])
     Parser clParser(clJsonDb);
     clParser.SetEncodeFormat(eEncodeFormat);
     clParser.SetLoggerLevel(spdlog::level::debug);
-    GetLoggerManager()->AddConsoleLogging(clParser.GetLogger());
-    GetLoggerManager()->AddRotatingFileLogger(clParser.GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clParser.GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clParser.GetLogger());
 
     auto clFilter = std::make_shared<Filter>();
     clFilter->SetLoggerLevel(spdlog::level::debug);
-    GetLoggerManager()->AddConsoleLogging(clFilter->GetLogger());
-    GetLoggerManager()->AddRotatingFileLogger(clFilter->GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clFilter->GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clFilter->GetLogger());
 
     // Initialize structures
     MetaDataStruct stMetaData;
@@ -164,6 +162,6 @@ int main(int argc, char* argv[])
     pclLogger->info("Converted {} logs in {}ms from {}", uiCompleteMessages,
                     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - tStart).count(),
                     pathInFilename.string().c_str());
-    pclMyLoggerManager->Shutdown();
+    LOGGER_MANAGER->Shutdown();
     return 0;
 }

--- a/examples/novatel/range_decompressor/range_decompressor.cpp
+++ b/examples/novatel/range_decompressor/range_decompressor.cpp
@@ -47,11 +47,12 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    Logger::InitLogger();
-    std::shared_ptr<spdlog::logger> pclLogger = Logger::RegisterLogger("range_decompressor");
+    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
+    pclMyLoggerManager->InitLogger();
+    std::shared_ptr<spdlog::logger> pclLogger = pclMyLoggerManager->RegisterLogger("range_decompressor");
     pclLogger->set_level(spdlog::level::debug);
-    Logger::AddConsoleLogging(pclLogger);
-    Logger::AddRotatingFileLogger(pclLogger);
+    pclMyLoggerManager->AddConsoleLogging(pclLogger);
+    pclMyLoggerManager->AddRotatingFileLogger(pclLogger);
 
     if (argc == 2 && strcmp(argv[1], "-V") == 0)
     {
@@ -106,12 +107,12 @@ int main(int argc, char* argv[])
     clHeaderDecoder.SetLoggerLevel(spdlog::level::debug);
     clMessageDecoder.SetLoggerLevel(spdlog::level::debug);
     clEncoder.SetLoggerLevel(spdlog::level::debug);
-    Logger::AddConsoleLogging(clFramer.GetLogger());
-    Logger::AddConsoleLogging(clHeaderDecoder.GetLogger());
-    Logger::AddConsoleLogging(clMessageDecoder.GetLogger());
-    Logger::AddRotatingFileLogger(clFramer.GetLogger());
-    Logger::AddRotatingFileLogger(clHeaderDecoder.GetLogger());
-    Logger::AddRotatingFileLogger(clMessageDecoder.GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clFramer.GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clHeaderDecoder.GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clMessageDecoder.GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clFramer.GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clHeaderDecoder.GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clMessageDecoder.GetLogger());
 
     clFramer.SetFrameJson(false);
     clFramer.SetPayloadOnly(false);
@@ -192,6 +193,6 @@ int main(int argc, char* argv[])
     std::chrono::duration<double> elapsedSeconds = std::chrono::system_clock::now() - start;
     pclLogger->info("Decoded {} messages in {}s. ({}msg/s)", uiCompletedMessages, elapsedSeconds.count(),
                     uiCompletedMessages / elapsedSeconds.count());
-    Logger::Shutdown();
+    pclMyLoggerManager->Shutdown();
     return 0;
 }

--- a/examples/novatel/range_decompressor/range_decompressor.cpp
+++ b/examples/novatel/range_decompressor/range_decompressor.cpp
@@ -47,12 +47,11 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
-    pclMyLoggerManager->InitLogger();
-    std::shared_ptr<spdlog::logger> pclLogger = pclMyLoggerManager->RegisterLogger("range_decompressor");
+    LOGGER_MANAGER->InitLogger();
+    auto pclLogger = CREATE_LOGGER();
     pclLogger->set_level(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(pclLogger);
-    pclMyLoggerManager->AddRotatingFileLogger(pclLogger);
+    LOGGER_MANAGER->AddConsoleLogging(pclLogger);
+    LOGGER_MANAGER->AddRotatingFileLogger(pclLogger);
 
     if (argc == 2 && strcmp(argv[1], "-V") == 0)
     {
@@ -107,12 +106,12 @@ int main(int argc, char* argv[])
     clHeaderDecoder.SetLoggerLevel(spdlog::level::debug);
     clMessageDecoder.SetLoggerLevel(spdlog::level::debug);
     clEncoder.SetLoggerLevel(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(clFramer.GetLogger());
-    pclMyLoggerManager->AddConsoleLogging(clHeaderDecoder.GetLogger());
-    pclMyLoggerManager->AddConsoleLogging(clMessageDecoder.GetLogger());
-    pclMyLoggerManager->AddRotatingFileLogger(clFramer.GetLogger());
-    pclMyLoggerManager->AddRotatingFileLogger(clHeaderDecoder.GetLogger());
-    pclMyLoggerManager->AddRotatingFileLogger(clMessageDecoder.GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clFramer.GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clHeaderDecoder.GetLogger());
+    LOGGER_MANAGER->AddConsoleLogging(clMessageDecoder.GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clFramer.GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clHeaderDecoder.GetLogger());
+    LOGGER_MANAGER->AddRotatingFileLogger(clMessageDecoder.GetLogger());
 
     clFramer.SetFrameJson(false);
     clFramer.SetPayloadOnly(false);
@@ -193,6 +192,6 @@ int main(int argc, char* argv[])
     std::chrono::duration<double> elapsedSeconds = std::chrono::system_clock::now() - start;
     pclLogger->info("Decoded {} messages in {}s. ({}msg/s)", uiCompletedMessages, elapsedSeconds.count(),
                     uiCompletedMessages / elapsedSeconds.count());
-    pclMyLoggerManager->Shutdown();
+    LOGGER_MANAGER->Shutdown();
     return 0;
 }

--- a/examples/novatel/rxconfig_handler/rxconfig_handler.cpp
+++ b/examples/novatel/rxconfig_handler/rxconfig_handler.cpp
@@ -43,11 +43,12 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    Logger::InitLogger();
-    std::shared_ptr<spdlog::logger> pclLogger = Logger::RegisterLogger("rxconfig_converter");
+    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
+    pclMyLoggerManager->InitLogger();
+    std::shared_ptr<spdlog::logger> pclLogger = pclMyLoggerManager->RegisterLogger("rxconfig_converter");
     pclLogger->set_level(spdlog::level::debug);
-    Logger::AddConsoleLogging(pclLogger);
-    Logger::AddRotatingFileLogger(pclLogger);
+    pclMyLoggerManager->AddConsoleLogging(pclLogger);
+    pclMyLoggerManager->AddRotatingFileLogger(pclLogger);
 
     // Get command line arguments
     pclLogger->info("Decoder library information:\n{}", caPrettyPrint);
@@ -150,6 +151,6 @@ int main(int argc, char* argv[])
         }
     }
 
-    Logger::Shutdown();
+    pclMyLoggerManager->Shutdown();
     return 0;
 }

--- a/examples/novatel/rxconfig_handler/rxconfig_handler.cpp
+++ b/examples/novatel/rxconfig_handler/rxconfig_handler.cpp
@@ -43,12 +43,11 @@ int main(int argc, char* argv[])
 {
     // This example uses the default logger config, but you can also pass a config file to InitLogger()
     // Example config file: logger\example_logger_config.toml
-    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
-    pclMyLoggerManager->InitLogger();
-    std::shared_ptr<spdlog::logger> pclLogger = pclMyLoggerManager->RegisterLogger("rxconfig_converter");
+    LOGGER_MANAGER->InitLogger();
+    auto pclLogger = CREATE_LOGGER();
     pclLogger->set_level(spdlog::level::debug);
-    pclMyLoggerManager->AddConsoleLogging(pclLogger);
-    pclMyLoggerManager->AddRotatingFileLogger(pclLogger);
+    LOGGER_MANAGER->AddConsoleLogging(pclLogger);
+    LOGGER_MANAGER->AddRotatingFileLogger(pclLogger);
 
     // Get command line arguments
     pclLogger->info("Decoder library information:\n{}", caPrettyPrint);
@@ -151,6 +150,6 @@ int main(int argc, char* argv[])
         }
     }
 
-    pclMyLoggerManager->Shutdown();
+    LOGGER_MANAGER->Shutdown();
     return 0;
 }

--- a/include/novatel_edie/common/logger.hpp
+++ b/include/novatel_edie/common/logger.hpp
@@ -48,16 +48,24 @@ class LoggerManager
 {
   public:
     //----------------------------------------------------------------------------
-    // ! \brief Preform any cleanup and destroy the manager object.
+    //! \brief Preform any cleanup and destroy the manager object.
     //----------------------------------------------------------------------------
     virtual void Shutdown() = 0;
 
+    //----------------------------------------------------------------------------
+    //! \brief Virutal destructor for required for virtual functions.
+    //! 
+    //! In general leaving cleanup to destructor is unsafe as LoggerManager's 
+    //! lifetime is undefined in relation to other static objects it relies upon.
+    //! Instead `Shutdown()` method of concrete subclass should be called prior
+    //! to termination.
+    //----------------------------------------------------------------------------
     virtual ~LoggerManager() = 0;
 
     //----------------------------------------------------------------------------
-    // ! \brief Register a logger with the root logger's sinks.
-    // ! \param[in] sLoggerName_ A name for the logger
-    // ! \return A shared pointer to the logger.
+    //! \brief Register a logger with the root logger's sinks.
+    //! \param[in] sLoggerName_ A name for the logger
+    //! \return A shared pointer to the logger.
     //----------------------------------------------------------------------------
     virtual std::shared_ptr<spdlog::logger> RegisterLogger(const std::string& sLoggerName_) = 0;
 };
@@ -75,7 +83,7 @@ class CPPLoggerManager : public LoggerManager
     std::map<std::string, std::shared_ptr<spdlog::sinks::rotating_file_sink_mt>> rotatingFiles;
 
     //----------------------------------------------------------------------------
-    // ! \brief Preform a basic initialization of the root logger.
+    //! \brief Preform a basic initialization of the root logger.
     //----------------------------------------------------------------------------
     void InitRootLogger()
     {
@@ -89,12 +97,17 @@ class CPPLoggerManager : public LoggerManager
     }
 
   public:
+    //----------------------------------------------------------------------------
+    //! \brief Destructs the CPPLoggerManager.
+    //!
+    //! Shutdown should be called first.
+    //----------------------------------------------------------------------------
     ~CPPLoggerManager() = default;
 
     //----------------------------------------------------------------------------
-    // ! \brief Flush all rotating file sinks and shutdown spdlog.
-    //
-    // Must be called by users before program termination.
+    //! \brief Flushes all rotating file sinks and shutdown spdlog.
+    //!
+    //! Must be called by users before program termination.
     //----------------------------------------------------------------------------
     void Shutdown() override
     {
@@ -110,9 +123,10 @@ class CPPLoggerManager : public LoggerManager
     }
 
     //----------------------------------------------------------------------------
-    // ! \brief Register a logger with the root logger's sinks.
-    // ! \param[in] sLoggerName_ A name for the logger.
-    // ! \return A shared pointer to the logger.
+    //! \brief Registers a logger with the root logger's sinks.
+    //! 
+    //! \param[in] sLoggerName_ A name for the logger.
+    //! \return A shared pointer to the logger.
     //----------------------------------------------------------------------------
     std::shared_ptr<spdlog::logger> RegisterLogger(const std::string& sLoggerName_) override
     {
@@ -140,14 +154,16 @@ class CPPLoggerManager : public LoggerManager
     }
 
     //----------------------------------------------------------------------------
-    // ! \brief Change the global spdlog logging level.
-    // ! \param[in] eLevel_ The logging level to set.
+    //! \brief Changes the global spdlog logging level.
+    //! 
+    //! \param[in] eLevel_ The logging level to set.
     //----------------------------------------------------------------------------
     void SetLoggingLevel(spdlog::level::level_enum eLevel_) { spdlog::set_level(eLevel_); }
 
     //----------------------------------------------------------------------------
-    // ! \brief Initialize the logger with an optional configuration file.
-    // ! \param[in] configPath_ The path to the configuration file.
+    //! \brief Initializes the logger with an optional configuration file.
+    //! 
+    //! \param[in] configPath_ The path to the configuration file.
     //----------------------------------------------------------------------------
     void InitLogger(const std::filesystem::path& configPath_ = "")
     {
@@ -174,9 +190,10 @@ class CPPLoggerManager : public LoggerManager
     }
 
     //----------------------------------------------------------------------------
-    // ! \brief Add console output to a logger.
-    // ! \param[in] lgr  The logger to add a console sink to.
-    // ! \param[in] eLevel_  The logging level to enable.
+    //! \brief Adds console output to a logger.
+    //! 
+    //! \param[in] lgr  The logger to add a console sink to.
+    //! \param[in] eLevel_  The logging level to enable.
     //----------------------------------------------------------------------------
     void AddConsoleLogging(const std::shared_ptr<spdlog::logger>& lgr, spdlog::level::level_enum eLevel_ = spdlog::level::info)
     {
@@ -188,13 +205,14 @@ class CPPLoggerManager : public LoggerManager
     }
 
     //----------------------------------------------------------------------------
-    // ! \brief Add file output to a logger.
-    // ! \param[in] lgr  The logger to add a rotating file sink to.
-    // ! \param[in] eLevel_  Logging level to enable.
-    // ! \param[in] sFileName_  Logger output file name.
-    // ! \param[in] uiFileSize_  Max file size.
-    // ! \param[in] uiMaxFiles_  Max number of rotating files.
-    // ! \param[in] bRotateOnOpen_  Rotate files on open.
+    //! \brief Adds file output to a logger.
+    //! 
+    //! \param[in] lgr  The logger to add a rotating file sink to.
+    //! \param[in] eLevel_  Logging level to enable.
+    //! \param[in] sFileName_  Logger output file name.
+    //! \param[in] uiFileSize_  Max file size.
+    //! \param[in] uiMaxFiles_  Max number of rotating files.
+    //! \param[in] bRotateOnOpen_  Rotate files on open.
     //----------------------------------------------------------------------------
     void AddRotatingFileLogger(const std::shared_ptr<spdlog::logger>& lgr, spdlog::level::level_enum level = spdlog::level::info,
                                const std::string& sFileName = "default.log", size_t maxFileSize = 5 * 1024 * 1024, size_t maxFiles = 3,
@@ -214,8 +232,9 @@ class CPPLoggerManager : public LoggerManager
 extern std::unique_ptr<LoggerManager> pclLoggerManager;
 
 //----------------------------------------------------------------------------
-// ! \brief Get a LoggerManager to alter logging configuration.
-// ! \return A pointer to the current LoggingManager.
+//! \brief Gets a LoggerManager to alter logging configuration.
+//! 
+//! \return A pointer to the current LoggingManager.
 //----------------------------------------------------------------------------
 extern CPPLoggerManager* GetLoggerManager();
 

--- a/include/novatel_edie/common/logger.hpp
+++ b/include/novatel_edie/common/logger.hpp
@@ -54,7 +54,6 @@ class LoggerManager
 
     virtual ~LoggerManager() = 0;
 
-
     //----------------------------------------------------------------------------
     // ! \brief Register a logger with the root logger's sinks.
     // ! \param[in] sLoggerName_ A name for the logger

--- a/include/novatel_edie/common/logger.hpp
+++ b/include/novatel_edie/common/logger.hpp
@@ -54,8 +54,8 @@ class LoggerManager
 
     //----------------------------------------------------------------------------
     //! \brief Virutal destructor for required for virtual functions.
-    //! 
-    //! In general leaving cleanup to destructor is unsafe as LoggerManager's 
+    //!
+    //! In general leaving cleanup to destructor is unsafe as LoggerManager's
     //! lifetime is undefined in relation to other static objects it relies upon.
     //! Instead `Shutdown()` method of concrete subclass should be called prior
     //! to termination.
@@ -124,7 +124,7 @@ class CPPLoggerManager : public LoggerManager
 
     //----------------------------------------------------------------------------
     //! \brief Registers a logger with the root logger's sinks.
-    //! 
+    //!
     //! \param[in] sLoggerName_ A name for the logger.
     //! \return A shared pointer to the logger.
     //----------------------------------------------------------------------------
@@ -155,14 +155,14 @@ class CPPLoggerManager : public LoggerManager
 
     //----------------------------------------------------------------------------
     //! \brief Changes the global spdlog logging level.
-    //! 
+    //!
     //! \param[in] eLevel_ The logging level to set.
     //----------------------------------------------------------------------------
     void SetLoggingLevel(spdlog::level::level_enum eLevel_) { spdlog::set_level(eLevel_); }
 
     //----------------------------------------------------------------------------
     //! \brief Initializes the logger with an optional configuration file.
-    //! 
+    //!
     //! \param[in] configPath_ The path to the configuration file.
     //----------------------------------------------------------------------------
     void InitLogger(const std::filesystem::path& configPath_ = "")
@@ -191,7 +191,7 @@ class CPPLoggerManager : public LoggerManager
 
     //----------------------------------------------------------------------------
     //! \brief Adds console output to a logger.
-    //! 
+    //!
     //! \param[in] lgr  The logger to add a console sink to.
     //! \param[in] eLevel_  The logging level to enable.
     //----------------------------------------------------------------------------
@@ -206,7 +206,7 @@ class CPPLoggerManager : public LoggerManager
 
     //----------------------------------------------------------------------------
     //! \brief Adds file output to a logger.
-    //! 
+    //!
     //! \param[in] lgr  The logger to add a rotating file sink to.
     //! \param[in] eLevel_  Logging level to enable.
     //! \param[in] sFileName_  Logger output file name.
@@ -233,9 +233,31 @@ extern std::unique_ptr<LoggerManager> pclLoggerManager;
 
 //----------------------------------------------------------------------------
 //! \brief Gets a LoggerManager to alter logging configuration.
-//! 
+//!
 //! \return A pointer to the current LoggingManager.
 //----------------------------------------------------------------------------
 extern CPPLoggerManager* GetLoggerManager();
+
+//----------------------------------------------------------------------------
+//! \brief A wrapper class for CPPLoggerManager to allow backwards compatibility in the API
+//----------------------------------------------------------------------------
+class Logger
+{
+  public:
+    static void InitLogger(const std::filesystem::path& configPath = "") { GetLoggerManager()->InitLogger(configPath); }
+    static void Shutdown() { GetLoggerManager()->Shutdown(); }
+    static void SetLoggingLevel(spdlog::level::level_enum eLevel_) { GetLoggerManager()->SetLoggingLevel(eLevel_); }
+    static std::shared_ptr<spdlog::logger> RegisterLogger(const std::string& sLoggerName_) { GetLoggerManager()->RegisterLogger(sLoggerName_); }
+    static void AddConsoleLogging(const std::shared_ptr<spdlog::logger>& lgr, spdlog::level::level_enum eLevel_ = spdlog::level::info)
+    {
+        GetLoggerManager()->AddConsoleLogging(lgr, eLevel_);
+    }
+    static void AddRotatingFileLogger(const std::shared_ptr<spdlog::logger>& lgr, spdlog::level::level_enum level = spdlog::level::info,
+                                      const std::string& sFileName = "default.log", size_t maxFileSize = 5 * 1024 * 1024, size_t maxFiles = 3,
+                                      bool rotateOnOpen = true)
+    {
+        GetLoggerManager()->AddRotatingFileLogger(lgr, level, sFileName, maxFiles, maxFileSize, rotateOnOpen);
+    }
+};
 
 #endif // LOGGER_H

--- a/include/novatel_edie/common/logger.hpp
+++ b/include/novatel_edie/common/logger.hpp
@@ -91,7 +91,7 @@ class CPPLoggerManager : public LoggerManager
     // ! \brief Preform default cleanup.
     // !
     // ! Users are responsible for calling shutdown themselves before program
-    // ! termination. Manipulating spdlog registry in destructor of a 
+    // ! termination. Manipulating spdlog registry in destructor of a
     // ! global object results in undefined behavior.
     // ! https://github.com/gabime/spdlog/issues/2113
     //----------------------------------------------------------------------------
@@ -99,7 +99,7 @@ class CPPLoggerManager : public LoggerManager
 
     //----------------------------------------------------------------------------
     // ! \brief Flush all rotating file sinks and shutdown spdlog.
-    // 
+    //
     // Must be called by users before program termination.
     //----------------------------------------------------------------------------
     void Shutdown()

--- a/include/novatel_edie/common/logger.hpp
+++ b/include/novatel_edie/common/logger.hpp
@@ -88,21 +88,11 @@ class CPPLoggerManager : public LoggerManager
 
   public:
     //----------------------------------------------------------------------------
-    // ! \brief Preform default cleanup.
-    // !
-    // ! Users are responsible for calling shutdown themselves before program
-    // ! termination. Manipulating spdlog registry in destructor of a
-    // ! global object results in undefined behavior.
-    // ! https://github.com/gabime/spdlog/issues/2113
-    //----------------------------------------------------------------------------
-    ~CPPLoggerManager() = default;
-
-    //----------------------------------------------------------------------------
     // ! \brief Flush all rotating file sinks and shutdown spdlog.
     //
     // Must be called by users before program termination.
     //----------------------------------------------------------------------------
-    void Shutdown()
+    void Shutdown() override
     {
         std::lock_guard<std::mutex> lock(loggerMutex);
         if (rootLogger) { rootLogger->flush(); }

--- a/include/novatel_edie/common/logger.hpp
+++ b/include/novatel_edie/common/logger.hpp
@@ -52,6 +52,9 @@ class LoggerManager
     //----------------------------------------------------------------------------
     virtual void Shutdown() = 0;
 
+    virtual ~LoggerManager() = 0;
+
+
     //----------------------------------------------------------------------------
     // ! \brief Register a logger with the root logger's sinks.
     // ! \param[in] sLoggerName_ A name for the logger
@@ -87,6 +90,8 @@ class CPPLoggerManager : public LoggerManager
     }
 
   public:
+    ~CPPLoggerManager() = default;
+
     //----------------------------------------------------------------------------
     // ! \brief Flush all rotating file sinks and shutdown spdlog.
     //

--- a/include/novatel_edie/common/logger.hpp
+++ b/include/novatel_edie/common/logger.hpp
@@ -247,7 +247,7 @@ class Logger
     static void InitLogger(const std::filesystem::path& configPath = "") { GetLoggerManager()->InitLogger(configPath); }
     static void Shutdown() { GetLoggerManager()->Shutdown(); }
     static void SetLoggingLevel(spdlog::level::level_enum eLevel_) { GetLoggerManager()->SetLoggingLevel(eLevel_); }
-    static std::shared_ptr<spdlog::logger> RegisterLogger(const std::string& sLoggerName_) { GetLoggerManager()->RegisterLogger(sLoggerName_); }
+    static std::shared_ptr<spdlog::logger> RegisterLogger(const std::string& sLoggerName_) { return GetLoggerManager()->RegisterLogger(sLoggerName_); }
     static void AddConsoleLogging(const std::shared_ptr<spdlog::logger>& lgr, spdlog::level::level_enum eLevel_ = spdlog::level::info)
     {
         GetLoggerManager()->AddConsoleLogging(lgr, eLevel_);

--- a/include/novatel_edie/common/logger.hpp
+++ b/include/novatel_edie/common/logger.hpp
@@ -50,7 +50,7 @@ class LoggerManager
     //----------------------------------------------------------------------------
     // ! \brief Preform any cleanup and destroy the manager object.
     //----------------------------------------------------------------------------
-    virtual ~LoggerManager() = 0;
+    virtual void Shutdown() = 0;
 
     //----------------------------------------------------------------------------
     // ! \brief Register a logger with the root logger's sinks.

--- a/include/novatel_edie/common/logger.hpp
+++ b/include/novatel_edie/common/logger.hpp
@@ -247,7 +247,10 @@ class Logger
     static void InitLogger(const std::filesystem::path& configPath = "") { GetLoggerManager()->InitLogger(configPath); }
     static void Shutdown() { GetLoggerManager()->Shutdown(); }
     static void SetLoggingLevel(spdlog::level::level_enum eLevel_) { GetLoggerManager()->SetLoggingLevel(eLevel_); }
-    static std::shared_ptr<spdlog::logger> RegisterLogger(const std::string& sLoggerName_) { return GetLoggerManager()->RegisterLogger(sLoggerName_); }
+    static std::shared_ptr<spdlog::logger> RegisterLogger(const std::string& sLoggerName_)
+    {
+        return GetLoggerManager()->RegisterLogger(sLoggerName_);
+    }
     static void AddConsoleLogging(const std::shared_ptr<spdlog::logger>& lgr, spdlog::level::level_enum eLevel_ = spdlog::level::info)
     {
         GetLoggerManager()->AddConsoleLogging(lgr, eLevel_);

--- a/include/novatel_edie/common/logger.hpp
+++ b/include/novatel_edie/common/logger.hpp
@@ -238,6 +238,10 @@ extern std::unique_ptr<LoggerManager> pclLoggerManager;
 //----------------------------------------------------------------------------
 extern CPPLoggerManager* GetLoggerManager();
 
+// Macro for easy user creation of loggers
+#define LOGGER_MANAGER GetLoggerManager()
+#define CREATE_LOGGER() GetLoggerManager()->RegisterLogger(std::filesystem::path(__FILE__).stem().string())
+
 //----------------------------------------------------------------------------
 //! \brief A wrapper class for CPPLoggerManager to allow backwards compatibility in the API
 //----------------------------------------------------------------------------

--- a/include/novatel_edie/decoders/common/encoder.hpp
+++ b/include/novatel_edie/decoders/common/encoder.hpp
@@ -122,7 +122,7 @@ template <typename T> std::function<bool(const FieldContainer&, char**, uint32_t
 template <typename Derived> class EncoderBase
 {
   protected:
-    std::shared_ptr<spdlog::logger> pclMyLogger{Logger::RegisterLogger("encoder")};
+    std::shared_ptr<spdlog::logger> pclMyLogger{pclLoggerManager->RegisterLogger("encoder")};
     MessageDatabase::ConstPtr pclMyMsgDbStrongRef{nullptr};
     const MessageDatabase* pclMyMsgDb{nullptr};
 

--- a/include/novatel_edie/decoders/common/framer.hpp
+++ b/include/novatel_edie/decoders/common/framer.hpp
@@ -78,7 +78,7 @@ class FramerBase
     //
     //! \param[in] strLoggerName_ String to name the internal logger.
     //----------------------------------------------------------------------------
-    FramerBase(const std::string& strLoggerName_) : pclMyLogger(Logger::RegisterLogger(strLoggerName_))
+    FramerBase(const std::string& strLoggerName_) : pclMyLogger(pclLoggerManager->RegisterLogger(strLoggerName_))
     {
         clMyCircularDataBuffer.Clear();
         pclMyLogger->debug("Framer initialized");

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -73,7 +73,7 @@ class MessageDecoderBase
   private:
     static constexpr std::string_view svErrorPrefix = "ERROR:";
 
-    std::shared_ptr<spdlog::logger> pclMyLogger{Logger::RegisterLogger("message_decoder")};
+    std::shared_ptr<spdlog::logger> pclMyLogger{pclLoggerManager->RegisterLogger("message_decoder")};
 
     MessageDatabase::Ptr pclMyMsgDb{nullptr};
 

--- a/include/novatel_edie/decoders/oem/commander.hpp
+++ b/include/novatel_edie/decoders/oem/commander.hpp
@@ -43,7 +43,7 @@ namespace novatel::edie::oem {
 class Commander
 {
   private:
-    std::shared_ptr<spdlog::logger> pclMyLogger{Logger::RegisterLogger("novatel_commander")};
+    std::shared_ptr<spdlog::logger> pclMyLogger{pclLoggerManager->RegisterLogger("novatel_commander")};
     MessageDecoder clMyMessageDecoder;
     Encoder clMyEncoder;
     MessageDatabase::Ptr pclMyMsgDb{nullptr};

--- a/include/novatel_edie/decoders/oem/file_parser.hpp
+++ b/include/novatel_edie/decoders/oem/file_parser.hpp
@@ -31,8 +31,8 @@
 #include <iosfwd>
 #include <memory>
 
-#include "novatel_edie/decoders/common/common.hpp"
 #include "novatel_edie/common/logger.hpp"
+#include "novatel_edie/decoders/common/common.hpp"
 #include "novatel_edie/decoders/oem/parser.hpp"
 
 namespace novatel::edie::oem {

--- a/include/novatel_edie/decoders/oem/file_parser.hpp
+++ b/include/novatel_edie/decoders/oem/file_parser.hpp
@@ -115,10 +115,10 @@ class FileParser
     //! \param[in] eLevel_ The logging level to enable.
     //! \param[in] sFileName_ The logging level to enable.
     //----------------------------------------------------------------------------
-    //void EnableFramerDecoderLogging(spdlog::level::level_enum eLevel_ = spdlog::level::debug, const std::string& sFileName_ = "edie.log")
-    //{
-    //    clMyParser.EnableFramerDecoderLogging(eLevel_, sFileName_);
-    //}
+    void EnableFramerDecoderLogging(spdlog::level::level_enum eLevel_ = spdlog::level::debug, const std::string& sFileName_ = "edie.log")
+    {
+        clMyParser.EnableFramerDecoderLogging(eLevel_, sFileName_);
+    }
 
     //----------------------------------------------------------------------------
     //! \brief Set the level of detail produced by the internal logger.

--- a/include/novatel_edie/decoders/oem/file_parser.hpp
+++ b/include/novatel_edie/decoders/oem/file_parser.hpp
@@ -32,6 +32,7 @@
 #include <memory>
 
 #include "novatel_edie/decoders/common/common.hpp"
+#include "novatel_edie/common/logger.hpp"
 #include "novatel_edie/decoders/oem/parser.hpp"
 
 namespace novatel::edie::oem {
@@ -43,7 +44,7 @@ namespace novatel::edie::oem {
 class FileParser
 {
   private:
-    std::shared_ptr<spdlog::logger> pclMyLogger{Logger::RegisterLogger("novatel_file_parser")};
+    std::shared_ptr<spdlog::logger> pclMyLogger{pclLoggerManager->RegisterLogger("novatel_file_parser")};
     Parser clMyParser;
     std::shared_ptr<std::istream> pclMyInputStream{nullptr};
 
@@ -114,10 +115,10 @@ class FileParser
     //! \param[in] eLevel_ The logging level to enable.
     //! \param[in] sFileName_ The logging level to enable.
     //----------------------------------------------------------------------------
-    void EnableFramerDecoderLogging(spdlog::level::level_enum eLevel_ = spdlog::level::debug, const std::string& sFileName_ = "edie.log")
-    {
-        clMyParser.EnableFramerDecoderLogging(eLevel_, sFileName_);
-    }
+    //void EnableFramerDecoderLogging(spdlog::level::level_enum eLevel_ = spdlog::level::debug, const std::string& sFileName_ = "edie.log")
+    //{
+    //    clMyParser.EnableFramerDecoderLogging(eLevel_, sFileName_);
+    //}
 
     //----------------------------------------------------------------------------
     //! \brief Set the level of detail produced by the internal logger.

--- a/include/novatel_edie/decoders/oem/filter.hpp
+++ b/include/novatel_edie/decoders/oem/filter.hpp
@@ -47,7 +47,7 @@ namespace novatel::edie::oem {
 class Filter
 {
   private:
-    std::shared_ptr<spdlog::logger> pclMyLogger{Logger::RegisterLogger("novatel_filter")};
+    std::shared_ptr<spdlog::logger> pclMyLogger{pclLoggerManager->RegisterLogger("novatel_filter")};
 
     std::vector<bool (Filter::*)(const MetaDataStruct&) const> vMyFilterFunctions;
 

--- a/include/novatel_edie/decoders/oem/header_decoder.hpp
+++ b/include/novatel_edie/decoders/oem/header_decoder.hpp
@@ -43,7 +43,7 @@ namespace novatel::edie::oem {
 class HeaderDecoder
 {
   private:
-    std::shared_ptr<spdlog::logger> pclMyLogger{Logger::RegisterLogger("novatel_header_decoder")};
+    std::shared_ptr<spdlog::logger> pclMyLogger{pclLoggerManager->RegisterLogger("novatel_header_decoder")};
     MessageDatabase::Ptr pclMyMsgDb{nullptr};
     EnumDefinition::ConstPtr vMyCommandDefinitions{nullptr};
     EnumDefinition::ConstPtr vMyPortAddressDefinitions{nullptr};

--- a/include/novatel_edie/decoders/oem/parser.hpp
+++ b/include/novatel_edie/decoders/oem/parser.hpp
@@ -50,7 +50,7 @@ namespace novatel::edie::oem {
 class Parser
 {
   private:
-    std::shared_ptr<spdlog::logger> pclMyLogger{Logger::RegisterLogger("novatel_parser")};
+    std::shared_ptr<spdlog::logger> pclMyLogger{pclLoggerManager->RegisterLogger("novatel_parser")};
 
     MessageDatabase::Ptr pclMyMessageDb;
     Filter::Ptr pclMyUserFilter;
@@ -131,7 +131,7 @@ class Parser
     //! \param[in] eLevel_ The logging level to enable.
     //! \param[in] sFileName_ The logging level to enable.
     //----------------------------------------------------------------------------
-    void EnableFramerDecoderLogging(spdlog::level::level_enum eLevel_ = spdlog::level::debug, const std::string& sFileName_ = "edie.log");
+    //void EnableFramerDecoderLogging(spdlog::level::level_enum eLevel_ = spdlog::level::debug, const std::string& sFileName_ = "edie.log");
 
     //----------------------------------------------------------------------------
     //! \brief Set the level of detail produced by the internal logger.

--- a/include/novatel_edie/decoders/oem/parser.hpp
+++ b/include/novatel_edie/decoders/oem/parser.hpp
@@ -131,7 +131,7 @@ class Parser
     //! \param[in] eLevel_ The logging level to enable.
     //! \param[in] sFileName_ The logging level to enable.
     //----------------------------------------------------------------------------
-    //void EnableFramerDecoderLogging(spdlog::level::level_enum eLevel_ = spdlog::level::debug, const std::string& sFileName_ = "edie.log");
+    void EnableFramerDecoderLogging(spdlog::level::level_enum eLevel_ = spdlog::level::debug, const std::string& sFileName_ = "edie.log");
 
     //----------------------------------------------------------------------------
     //! \brief Set the level of detail produced by the internal logger.

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -43,7 +43,6 @@ nanobind_add_module(python_bindings
     ${CMAKE_CURRENT_SOURCE_DIR}/bindings/py_message_objects.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bindings/internal/decoder_tester.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bindings/internal/logger_tester.cpp
-
 )
 
 set_target_properties(python_bindings PROPERTIES OUTPUT_NAME bindings)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -35,13 +35,15 @@ nanobind_add_module(python_bindings
     ${CMAKE_CURRENT_SOURCE_DIR}/bindings/message_db_singleton.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bindings/logger.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bindings/message_database.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/bindings/decoder_tester.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bindings/oem_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bindings/init_modules.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bindings/parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bindings/range_decompressor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bindings/rxconfig_handler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bindings/py_message_objects.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/bindings/internal/decoder_tester.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/bindings/internal/logger_tester.cpp
+
 )
 
 set_target_properties(python_bindings PROPERTIES OUTPUT_NAME bindings)

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -6,7 +6,7 @@
 namespace nb = nanobind;
 
 void init_common_common(nb::module_&);
-void init_common_logger(nb::module_&);
+void init_common_logger(nb::module_&, nb::module_&);
 void init_message_db_singleton(nb::module_&);
 void init_common_message_database(nb::module_&);
 void init_novatel_commander(nb::module_&);
@@ -28,8 +28,13 @@ void init_logger_tester(nb::module_&);
 
 NB_MODULE(bindings, m)
 {
+    nb::module_ messages_mod = m.def_submodule("messages", "NovAtel OEM message definitions.");
+    nb::module_ enums_mod = m.def_submodule("enums", "Enumerations used by NovAtel OEM message fields.");
+    nb::module_ internal_mod = m.def_submodule("_internal", "NOT PART OF THE PUBLIC API.");
+
+    std::cout << "Starting" << std::endl;
     init_common_common(m);
-    init_common_logger(m);
+    init_common_logger(m, internal_mod);
     init_message_db_singleton(m);
     init_novatel_commander(m);
     init_novatel_common(m);
@@ -44,11 +49,9 @@ NB_MODULE(bindings, m)
     init_novatel_parser(m);
     init_novatel_rxconfig_handler(m);
     init_novatel_range_decompressor(m);
-    nb::module_ messages_mod = m.def_submodule("messages", "NovAtel OEM message definitions.");
     init_novatel_oem_messages(messages_mod);
-    nb::module_ enums_mod = m.def_submodule("enums", "Enumerations used by NovAtel OEM message fields.");
     init_novatel_oem_enums(enums_mod);
-    nb::module_ internal_mod = m.def_submodule("_internal", "NOT PART OF THE PUBLIC API.");
     init_decoder_tester(internal_mod);
     init_logger_tester(internal_mod);
+    std::cout << "Ending" << std::endl;
 }

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -2,7 +2,6 @@
 #include <memory>
 
 #include "novatel_edie/common/logger.hpp"
-#include "py_logger.hpp"
 
 namespace nb = nanobind;
 

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -24,6 +24,7 @@ void init_novatel_parser(nb::module_&);
 void init_novatel_range_decompressor(nb::module_&);
 void init_novatel_rxconfig_handler(nb::module_&);
 void init_decoder_tester(nb::module_&);
+void init_logger_tester(nb::module_&);
 
 NB_MODULE(bindings, m)
 {
@@ -49,4 +50,5 @@ NB_MODULE(bindings, m)
     init_novatel_oem_enums(enums_mod);
     nb::module_ internal_mod = m.def_submodule("_internal", "NOT PART OF THE PUBLIC API.");
     init_decoder_tester(internal_mod);
+    init_logger_tester(internal_mod);
 }

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -32,7 +32,6 @@ NB_MODULE(bindings, m)
     nb::module_ enums_mod = m.def_submodule("enums", "Enumerations used by NovAtel OEM message fields.");
     nb::module_ internal_mod = m.def_submodule("_internal", "NOT PART OF THE PUBLIC API.");
 
-    std::cout << "Starting" << std::endl;
     init_common_common(m);
     init_common_logger(m, internal_mod);
     init_message_db_singleton(m);
@@ -53,5 +52,4 @@ NB_MODULE(bindings, m)
     init_novatel_oem_enums(enums_mod);
     init_decoder_tester(internal_mod);
     init_logger_tester(internal_mod);
-    std::cout << "Ending" << std::endl;
 }

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -1,4 +1,8 @@
 #include <nanobind/nanobind.h>
+#include <memory>
+
+#include "novatel_edie/common/logger.hpp"
+#include "py_logger.hpp"
 
 namespace nb = nanobind;
 
@@ -44,6 +48,6 @@ NB_MODULE(bindings, m)
     init_novatel_oem_messages(messages_mod);
     nb::module_ enums_mod = m.def_submodule("enums", "Enumerations used by NovAtel OEM message fields.");
     init_novatel_oem_enums(enums_mod);
-    nb::module_ interal_mod = m.def_submodule("_internal", "NOT PART OF THE PUBLIC API.");
-    init_decoder_tester(interal_mod);
+    nb::module_ internal_mod = m.def_submodule("_internal", "NOT PART OF THE PUBLIC API.");
+    init_decoder_tester(internal_mod);
 }

--- a/python/bindings/commander.cpp
+++ b/python/bindings/commander.cpp
@@ -14,7 +14,7 @@ void init_novatel_commander(nb::module_& m)
         .def("__init__", [](oem::Commander* t) { new (t) oem::Commander(MessageDbSingleton::get()); }) // NOLINT(*.NewDeleteLeaks)
         .def(nb::init<PyMessageDatabase::Ptr&>(), "message_db"_a)
         .def("load_db", &oem::Commander::LoadJsonDb, "message_db"_a)
-        .def_prop_ro("logger", &oem::Commander::GetLogger)
+        //.def_prop_ro("logger", &oem::Commander::GetLogger)
         .def(
             "encode",
             [](oem::Commander& commander, const nb::bytes& command, const ENCODE_FORMAT format) {

--- a/python/bindings/commander.cpp
+++ b/python/bindings/commander.cpp
@@ -14,7 +14,6 @@ void init_novatel_commander(nb::module_& m)
         .def("__init__", [](oem::Commander* t) { new (t) oem::Commander(MessageDbSingleton::get()); }) // NOLINT(*.NewDeleteLeaks)
         .def(nb::init<PyMessageDatabase::Ptr&>(), "message_db"_a)
         .def("load_db", &oem::Commander::LoadJsonDb, "message_db"_a)
-        //.def_prop_ro("logger", &oem::Commander::GetLogger)
         .def(
             "encode",
             [](oem::Commander& commander, const nb::bytes& command, const ENCODE_FORMAT format) {

--- a/python/bindings/decoder.cpp
+++ b/python/bindings/decoder.cpp
@@ -32,8 +32,6 @@ void init_novatel_decoder(nb::module_& m)
     nb::class_<oem::PyDecoder>(m, "Decoder")
         .def(nb::init<>())
         .def(nb::init<PyMessageDatabase::Ptr>(), "message_db"_a)
-        //.def_prop_ro("header_logger", [](oem::PyDecoder& self) { return self.header_decoder.GetLogger(); })
-        //.def_prop_ro("message_logger", [](oem::PyDecoder& self) { return self.message_decoder.GetLogger(); })
         .def(
             "decode_header",
             [](const oem::PyDecoder& decoder, const nb::bytes raw_header, oem::MetaDataStruct* metadata) {

--- a/python/bindings/decoder.cpp
+++ b/python/bindings/decoder.cpp
@@ -32,8 +32,8 @@ void init_novatel_decoder(nb::module_& m)
     nb::class_<oem::PyDecoder>(m, "Decoder")
         .def(nb::init<>())
         .def(nb::init<PyMessageDatabase::Ptr>(), "message_db"_a)
-        .def_prop_ro("header_logger", [](oem::PyDecoder& self) { return self.header_decoder.GetLogger(); })
-        .def_prop_ro("message_logger", [](oem::PyDecoder& self) { return self.message_decoder.GetLogger(); })
+        //.def_prop_ro("header_logger", [](oem::PyDecoder& self) { return self.header_decoder.GetLogger(); })
+        //.def_prop_ro("message_logger", [](oem::PyDecoder& self) { return self.message_decoder.GetLogger(); })
         .def(
             "decode_header",
             [](const oem::PyDecoder& decoder, const nb::bytes raw_header, oem::MetaDataStruct* metadata) {

--- a/python/bindings/file_parser.cpp
+++ b/python/bindings/file_parser.cpp
@@ -78,9 +78,6 @@ void init_novatel_file_parser(nb::module_& m)
     nb::class_<oem::PyFileParser>(m, "FileParser")
         .def(nb::init<const std::filesystem::path&>(), "file_path"_a)
         .def(nb::init<const std::filesystem::path&, const PyMessageDatabase::Ptr&>(), "file_path"_a, "message_db"_a)
-        //.def_prop_ro("logger", &oem::PyFileParser::GetLogger)
-        //.def("enable_framer_decoder_logging", &oem::PyFileParser::EnableFramerDecoderLogging, "level"_a = spdlog::level::debug,
-        //     "filename"_a = "edie.log")
         .def_prop_rw("ignore_abbreviated_ascii_responses", &oem::PyFileParser::GetIgnoreAbbreviatedAsciiResponses,
                      &oem::PyFileParser::SetIgnoreAbbreviatedAsciiResponses)
         .def_prop_rw("decompress_range_cmp", &oem::PyFileParser::GetDecompressRangeCmp, &oem::PyFileParser::SetDecompressRangeCmp)

--- a/python/bindings/file_parser.cpp
+++ b/python/bindings/file_parser.cpp
@@ -78,9 +78,9 @@ void init_novatel_file_parser(nb::module_& m)
     nb::class_<oem::PyFileParser>(m, "FileParser")
         .def(nb::init<const std::filesystem::path&>(), "file_path"_a)
         .def(nb::init<const std::filesystem::path&, const PyMessageDatabase::Ptr&>(), "file_path"_a, "message_db"_a)
-        .def_prop_ro("logger", &oem::PyFileParser::GetLogger)
-        .def("enable_framer_decoder_logging", &oem::PyFileParser::EnableFramerDecoderLogging, "level"_a = spdlog::level::debug,
-             "filename"_a = "edie.log")
+        //.def_prop_ro("logger", &oem::PyFileParser::GetLogger)
+        //.def("enable_framer_decoder_logging", &oem::PyFileParser::EnableFramerDecoderLogging, "level"_a = spdlog::level::debug,
+        //     "filename"_a = "edie.log")
         .def_prop_rw("ignore_abbreviated_ascii_responses", &oem::PyFileParser::GetIgnoreAbbreviatedAsciiResponses,
                      &oem::PyFileParser::SetIgnoreAbbreviatedAsciiResponses)
         .def_prop_rw("decompress_range_cmp", &oem::PyFileParser::GetDecompressRangeCmp, &oem::PyFileParser::SetDecompressRangeCmp)

--- a/python/bindings/filter.cpp
+++ b/python/bindings/filter.cpp
@@ -10,7 +10,6 @@ void init_novatel_filter(nb::module_& m)
 {
     nb::class_<oem::Filter>(m, "Filter")
         .def(nb::init())
-        //.def_prop_ro("logger", &oem::Filter::GetLogger)
         .def("set_lower_time_bound", &oem::Filter::SetIncludeLowerTimeBound, "week"_a, "seconds"_a)
         .def("set_upper_time_bound", &oem::Filter::SetIncludeUpperTimeBound, "week"_a, "seconds"_a)
         .def("invert_time_filter", &oem::Filter::InvertTimeFilter, "invert"_a)

--- a/python/bindings/filter.cpp
+++ b/python/bindings/filter.cpp
@@ -10,7 +10,7 @@ void init_novatel_filter(nb::module_& m)
 {
     nb::class_<oem::Filter>(m, "Filter")
         .def(nb::init())
-        .def_prop_ro("logger", &oem::Filter::GetLogger)
+        //.def_prop_ro("logger", &oem::Filter::GetLogger)
         .def("set_lower_time_bound", &oem::Filter::SetIncludeLowerTimeBound, "week"_a, "seconds"_a)
         .def("set_upper_time_bound", &oem::Filter::SetIncludeUpperTimeBound, "week"_a, "seconds"_a)
         .def("invert_time_filter", &oem::Filter::InvertTimeFilter, "invert"_a)

--- a/python/bindings/framer.cpp
+++ b/python/bindings/framer.cpp
@@ -47,7 +47,7 @@ void init_novatel_framer(nb::module_& m)
 {
     nb::class_<oem::PyFramer>(m, "Framer")
         .def(nb::init())
-        .def_prop_ro("logger", [](const oem::PyFramer& self) { return self.GetLogger(); })
+        //.def_prop_ro("logger", [](const oem::PyFramer& self) { return self.GetLogger(); })
         .def(
             "set_frame_json", [](oem::PyFramer& self, bool frame_json) { self.SetFrameJson(frame_json); }, "frame_json"_a)
         .def(

--- a/python/bindings/framer.cpp
+++ b/python/bindings/framer.cpp
@@ -56,7 +56,7 @@ void init_novatel_framer(nb::module_& m)
             "report_unknown_bytes"_a)
         .def_prop_ro("bytes_available_in_buffer", [](const oem::PyFramer& framer) { return framer.GetBytesAvailableInBuffer(); })
         .def("get_frame", &oem::PyFramer::PyGetFrame, "buffer_size"_a = MESSAGE_SIZE_MAX)
-        .def("__iter__", [](nb::handle_t<oem::Framer> self) { return self; })
+        .def("__iter__", [](nb::handle_t<oem::PyFramer> self) { return self; })
         .def("__next__", &oem::PyFramer::PyIterGetFrame)
         .def("write",
              [](oem::PyFramer& framer, const nb::bytes& data) { return framer.Write(reinterpret_cast<const uint8_t*>(data.c_str()), data.size()); })

--- a/python/bindings/framer.cpp
+++ b/python/bindings/framer.cpp
@@ -47,7 +47,6 @@ void init_novatel_framer(nb::module_& m)
 {
     nb::class_<oem::PyFramer>(m, "Framer")
         .def(nb::init())
-        //.def_prop_ro("logger", [](const oem::PyFramer& self) { return self.GetLogger(); })
         .def(
             "set_frame_json", [](oem::PyFramer& self, bool frame_json) { self.SetFrameJson(frame_json); }, "frame_json"_a)
         .def(

--- a/python/bindings/internal/decoder_tester.cpp
+++ b/python/bindings/internal/decoder_tester.cpp
@@ -1,14 +1,14 @@
 #include "novatel_edie/decoders/oem/message_decoder.hpp"
+#include "novatel_edie/decoders/oem/common.hpp"
 
 #include <nanobind/stl/bind_vector.h>
 #include <nanobind/stl/list.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/variant.h>
 
-#include "bindings_core.hpp"
-#include "message_db_singleton.hpp"
-#include "novatel_edie/decoders/oem/common.hpp"
-#include "py_message_objects.hpp"
+#include "../bindings_core.hpp"
+#include "../message_db_singleton.hpp"
+#include "../py_message_objects.hpp"
 
 namespace nb = nanobind;
 using namespace nb::literals;

--- a/python/bindings/internal/logger_tester.cpp
+++ b/python/bindings/internal/logger_tester.cpp
@@ -3,7 +3,6 @@
 
 namespace nb = nanobind;
 using namespace nb::literals;
-using namespace python_log;
 
 class PyLoggerTester
 {

--- a/python/bindings/internal/logger_tester.cpp
+++ b/python/bindings/internal/logger_tester.cpp
@@ -1,0 +1,32 @@
+#include "novatel_edie/common/logger.hpp"
+#include "../py_logger.hpp"
+
+namespace nb = nanobind;
+using namespace nb::literals;
+using namespace python_log;
+
+class PyLoggerTester
+{
+  private:
+    std::shared_ptr<spdlog::logger> pclMyLogger{pclLoggerManager->RegisterLogger("logger_tester")};
+
+  public:
+    void SwitchLogger(std::string name) { pclMyLogger = pclLoggerManager->RegisterLogger(name); }
+    void LogDebug(std::string message) { SPDLOG_LOGGER_DEBUG(pclMyLogger, message); }
+    void LogInfo(std::string message) { SPDLOG_LOGGER_INFO(pclMyLogger, message); }
+    void LogWarn(std::string message) { SPDLOG_LOGGER_WARN(pclMyLogger, message); }
+    void LogError(std::string message) { SPDLOG_LOGGER_ERROR(pclMyLogger, message); }
+    void LogCritical(std::string message) { SPDLOG_LOGGER_CRITICAL(pclMyLogger, message); }
+};
+
+void init_logger_tester(nb::module_& m)
+{
+    nb::class_<PyLoggerTester>(m, "LoggerTester")
+        .def(nb::init<>())
+        .def("SetLoggerName", &PyLoggerTester::SwitchLogger)
+        .def("LogDebug", &PyLoggerTester::LogDebug)
+        .def("LogInfo", &PyLoggerTester::LogInfo)
+        .def("LogWarn", &PyLoggerTester::LogWarn)
+        .def("LogError", &PyLoggerTester::LogError)
+        .def("LogCritical", &PyLoggerTester::LogCritical);
+}

--- a/python/bindings/logger.cpp
+++ b/python/bindings/logger.cpp
@@ -1,6 +1,7 @@
 #include "novatel_edie/common/logger.hpp"
 
 #include "bindings_core.hpp"
+#include "py_logger.hpp"
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -8,61 +9,7 @@ namespace spd = spdlog;
 
 void init_common_logger(nb::module_& m)
 {
-    nb::enum_<spdlog::level::level_enum>(m, "LogLevel")
-        .value("TRACE", spd::level::trace)
-        .value("DEBUG", spd::level::debug)
-        .value("INFO", spd::level::info)
-        .value("WARN", spd::level::warn)
-        .value("ERR", spd::level::err)
-        .value("CRITICAL", spd::level::critical)
-        .value("OFF", spd::level::off)
-        .def("__str__", [](nb::handle self) { return nb::str("LogLevel.") + getattr(self, "__name__"); });
-
-    nb::enum_<spdlog::pattern_time_type>(m, "LogPatternTimeType")
-        .value("LOCAL", spdlog::pattern_time_type::local)
-        .value("UTC", spdlog::pattern_time_type::utc);
-
-    nb::class_<spdlog::logger>(m, "_SpdlogLogger")
-        .def(nb::init<std::string>())
-        .def(
-            "log", [](spd::logger& logger, spd::level::level_enum level, std::string_view msg) { logger.log(level, msg); }, "level"_a, "msg"_a)
-        .def(
-            "trace", [](spd::logger& logger, std::string_view msg) { logger.trace(msg); }, "msg"_a)
-        .def(
-            "debug", [](spd::logger& logger, std::string_view msg) { logger.debug(msg); }, "msg"_a)
-        .def(
-            "info", [](spd::logger& logger, std::string_view msg) { logger.info(msg); }, "msg"_a)
-        .def(
-            "warn", [](spd::logger& logger, std::string_view msg) { logger.warn(msg); }, "msg"_a)
-        .def(
-            "error", [](spd::logger& logger, std::string_view msg) { logger.error(msg); }, "msg"_a)
-        .def(
-            "critical", [](spd::logger& logger, std::string_view msg) { logger.critical(msg); }, "msg"_a)
-        .def("should_log", &spd::logger::should_log, "level"_a)
-        .def("should_backtrace", &spd::logger::should_backtrace)
-        .def("set_level", &spd::logger::set_level, "level"_a)
-        .def_prop_ro("level", &spd::logger::level)
-        .def_prop_ro("name", &spd::logger::name)
-        // .def("set_formatter", &spd::logger::set_formatter, "formatter"_a)
-        .def("set_pattern", &spd::logger::set_pattern, "pattern"_a, "time_type"_a = spd::pattern_time_type::local)
-        .def("enable_backtrace", &spd::logger::enable_backtrace, "n_messages"_a)
-        .def("disable_backtrace", &spd::logger::disable_backtrace)
-        .def("dump_backtrace", &spd::logger::dump_backtrace)
-        .def("flush", &spd::logger::flush)
-        .def("flush_on", &spd::logger::flush_on, "level"_a)
-        .def_prop_ro("flush_level", &spd::logger::flush_level)
-        .def("set_error_handler", &spd::logger::set_error_handler, "handler"_a)
-        .def("clone", &spd::logger::clone, "logger_name"_a)
-        .def("__repr__", [](const spd::logger& logger) { return nb::str("<_SpdlogLogger: {}, {}>").format(logger.name(), logger.level()); });
-
-    nb::class_<Logger>(m, "Logging")
-        .def(nb::init())
-        // .def(nb::init<std::string>(), "logger_config_path_"_a)
-        .def_static("get", spdlog::get, "logger_name"_a, "Returns spdlog::get(logger_name).")
-        .def_static("shutdown", &Logger::Shutdown, "Stop any running threads started by spdlog and clean registry loggers")
-        .def_static("set_logging_level", &Logger::SetLoggingLevel, "level"_a, "Change the global spdlog logging level")
-        .def_static("register_logger", &Logger::RegisterLogger, "name"_a, "Register a logger with the root logger's sinks.")
-        .def_static("add_console_logging", &Logger::AddConsoleLogging, "logger"_a, "level"_a = spd::level::debug, "Add console output to the logger")
-        .def_static("add_rotating_file_logger", &Logger::AddRotatingFileLogger, "logger"_a, "level"_a = spd::level::debug, "file_name"_a = "edie.log",
-                    "file_size"_a = 5 * 1024 * 1024, "max_files"_a = 2, "rotate_on_open"_a = true, "Add rotating file output to the logger");
+    // Shutdown existing CPPLoggerManager and replace with a PyLoggerManager
+    GetLoggerManager()->Shutdown();
+    pclLoggerManager.reset(new python_log::PyLoggerManager()); 
 }

--- a/python/bindings/logger.cpp
+++ b/python/bindings/logger.cpp
@@ -20,8 +20,7 @@ void init_common_logger(nb::module_& m, nb::module_& internal_m)
         "enable_internal_logging", [manager]() { manager->EnableInternalLogging(); },
         "Enable logging which originates from novatel_edie's native C++ code.");
 
-    internal_m.def("set_level", [manager](nb::handle logger, int level) {
-        manager->SetLoggerLevel(logger, level);
+    internal_m.def("set_level", [manager](nb::handle self, nb::args args_, nb::kwargs kwargs_) { manager->SetLoggerLevel(self, args_, kwargs_);
     });
 
     internal_m.def("exit_cleanup", [manager]() { manager->Shutdown(); });

--- a/python/bindings/logger.cpp
+++ b/python/bindings/logger.cpp
@@ -12,4 +12,8 @@ void init_common_logger(nb::module_& m)
     // Shutdown existing CPPLoggerManager and replace with a PyLoggerManager
     GetLoggerManager()->Shutdown();
     pclLoggerManager.reset(new python_log::PyLoggerManager()); 
+    auto manager = static_cast<python_log::PyLoggerManager*>(pclLoggerManager.get());
+
+    m.def("disable_internal_logging", [manager]() { manager->DisableInternalLogging(); });
+    m.def("enable_internal_logging", [manager]() { manager->EnableInternalLogging(); });
 }

--- a/python/bindings/logger.cpp
+++ b/python/bindings/logger.cpp
@@ -7,7 +7,7 @@ namespace nb = nanobind;
 using namespace nb::literals;
 namespace spd = spdlog;
 
-void init_common_logger(nb::module_& m)
+void init_common_logger(nb::module_& m, nb::module_& internal_m)
 {
     // replace with a PyLoggerManager
     pclLoggerManager.reset(new PyLoggerManager());
@@ -19,4 +19,15 @@ void init_common_logger(nb::module_& m)
     m.def(
         "enable_internal_logging", [manager]() { manager->EnableInternalLogging(); },
         "Enable logging which originates from novatel_edie's native C++ code.");
+
+    internal_m.def("set_level", [manager](nb::handle logger, int level) {
+        manager->SetLoggerLevel(logger, level);
+    });
+
+    internal_m.def("exit_cleanup", [manager]() { manager->Shutdown(); });
+
+    manager->SetInternalMod(internal_m);
+
+    nb::module_ atexit = nb::module_::import_("atexit");
+    atexit.attr("register")(internal_m.attr("exit_cleanup"));
 }

--- a/python/bindings/logger.cpp
+++ b/python/bindings/logger.cpp
@@ -16,8 +16,8 @@ void init_common_logger(nb::module_& m)
 
     m.def(
         "disable_internal_logging", [manager]() { manager->DisableInternalLogging(); },
-        "Disable logging which originates in novatel_edie's native C++ code.");
+        "Disable logging which originates from novatel_edie's native C++ code.");
     m.def(
         "enable_internal_logging", [manager]() { manager->EnableInternalLogging(); },
-        "Enable logging which originates in novatel_edie's native C++ code.");
+        "Enable logging which originates from novatel_edie's native C++ code.");
 }

--- a/python/bindings/logger.cpp
+++ b/python/bindings/logger.cpp
@@ -9,10 +9,9 @@ namespace spd = spdlog;
 
 void init_common_logger(nb::module_& m)
 {
-    // Shutdown existing CPPLoggerManager and replace with a PyLoggerManager
-    GetLoggerManager()->Shutdown();
-    pclLoggerManager.reset(new python_log::PyLoggerManager());
-    auto manager = static_cast<python_log::PyLoggerManager*>(pclLoggerManager.get());
+    // replace with a PyLoggerManager
+    pclLoggerManager.reset(new PyLoggerManager());
+    auto manager = static_cast<PyLoggerManager*>(pclLoggerManager.get());
 
     m.def(
         "disable_internal_logging", [manager]() { manager->DisableInternalLogging(); },

--- a/python/bindings/logger.cpp
+++ b/python/bindings/logger.cpp
@@ -9,10 +9,11 @@ namespace spd = spdlog;
 
 void init_common_logger(nb::module_& m, nb::module_& internal_m)
 {
-    // replace with a PyLoggerManager
+    // Set the global LoggerManager to be a PyLoggerManager
     pclLoggerManager.reset(new PyLoggerManager());
     auto manager = static_cast<PyLoggerManager*>(pclLoggerManager.get());
 
+    // Add public functions for configuring internal logging
     m.def(
         "disable_internal_logging", [manager]() { manager->DisableInternalLogging(); },
         "Disable logging which originates from novatel_edie's native C++ code.");
@@ -20,13 +21,14 @@ void init_common_logger(nb::module_& m, nb::module_& internal_m)
         "enable_internal_logging", [manager]() { manager->EnableInternalLogging(); },
         "Enable logging which originates from novatel_edie's native C++ code.");
 
-    internal_m.def("set_level", [manager](nb::handle self, nb::args args_, nb::kwargs kwargs_) { manager->SetLoggerLevel(self, args_, kwargs_);
-    });
-
+    // Create python entry-point to custom setLevel and cleanup functions
+    internal_m.def("set_level", [manager](nb::handle self, nb::args args_, nb::kwargs kwargs_) { manager->SetLoggerLevel(self, args_, kwargs_); });
     internal_m.def("exit_cleanup", [manager]() { manager->Shutdown(); });
 
+    // Provide these the setLevel entry-point to the LoggerManager
     manager->SetInternalMod(internal_m);
 
+    // Run the custom cleanup code before any normal termination of the Python interpreter
     nb::module_ atexit = nb::module_::import_("atexit");
     atexit.attr("register")(internal_m.attr("exit_cleanup"));
 }

--- a/python/bindings/logger.cpp
+++ b/python/bindings/logger.cpp
@@ -11,9 +11,13 @@ void init_common_logger(nb::module_& m)
 {
     // Shutdown existing CPPLoggerManager and replace with a PyLoggerManager
     GetLoggerManager()->Shutdown();
-    pclLoggerManager.reset(new python_log::PyLoggerManager()); 
+    pclLoggerManager.reset(new python_log::PyLoggerManager());
     auto manager = static_cast<python_log::PyLoggerManager*>(pclLoggerManager.get());
 
-    m.def("disable_internal_logging", [manager]() { manager->DisableInternalLogging(); });
-    m.def("enable_internal_logging", [manager]() { manager->EnableInternalLogging(); });
+    m.def(
+        "disable_internal_logging", [manager]() { manager->DisableInternalLogging(); },
+        "Disable logging which originates in novatel_edie's native C++ code.");
+    m.def(
+        "enable_internal_logging", [manager]() { manager->EnableInternalLogging(); },
+        "Enable logging which originates in novatel_edie's native C++ code.");
 }

--- a/python/bindings/parser.cpp
+++ b/python/bindings/parser.cpp
@@ -93,8 +93,6 @@ void init_novatel_parser(nb::module_& m)
     nb::class_<oem::PyParser>(m, "Parser")
         .def("__init__", [](oem::PyParser* t) { new (t) oem::PyParser(MessageDbSingleton::get()); }) // NOLINT(*.NewDeleteLeaks)
         .def(nb::init<const PyMessageDatabase::Ptr&>(), "message_db"_a)
-        //.def_prop_ro("logger", &oem::PyParser::GetLogger)
-        //.def("enable_framer_decoder_logging", &oem::PyParser::EnableFramerDecoderLogging, "level"_a = spdlog::level::debug, "filename"_a = "edie.log")
         .def_prop_rw("ignore_abbreviated_ascii_responses", &oem::PyParser::GetIgnoreAbbreviatedAsciiResponses,
                      &oem::PyParser::SetIgnoreAbbreviatedAsciiResponses)
         .def_prop_rw("decompress_range_cmp", &oem::PyParser::GetDecompressRangeCmp, &oem::PyParser::SetDecompressRangeCmp)

--- a/python/bindings/parser.cpp
+++ b/python/bindings/parser.cpp
@@ -3,9 +3,10 @@
 #include "bindings_core.hpp"
 #include "exceptions.hpp"
 #include "message_db_singleton.hpp"
-#include "parser.hpp"
 #include "py_message_data.hpp"
 #include "py_message_objects.hpp"
+#include "parser.hpp"
+#include "py_logger.hpp"
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -92,8 +93,8 @@ void init_novatel_parser(nb::module_& m)
     nb::class_<oem::PyParser>(m, "Parser")
         .def("__init__", [](oem::PyParser* t) { new (t) oem::PyParser(MessageDbSingleton::get()); }) // NOLINT(*.NewDeleteLeaks)
         .def(nb::init<const PyMessageDatabase::Ptr&>(), "message_db"_a)
-        .def_prop_ro("logger", &oem::PyParser::GetLogger)
-        .def("enable_framer_decoder_logging", &oem::PyParser::EnableFramerDecoderLogging, "level"_a = spdlog::level::debug, "filename"_a = "edie.log")
+        //.def_prop_ro("logger", &oem::PyParser::GetLogger)
+        //.def("enable_framer_decoder_logging", &oem::PyParser::EnableFramerDecoderLogging, "level"_a = spdlog::level::debug, "filename"_a = "edie.log")
         .def_prop_rw("ignore_abbreviated_ascii_responses", &oem::PyParser::GetIgnoreAbbreviatedAsciiResponses,
                      &oem::PyParser::SetIgnoreAbbreviatedAsciiResponses)
         .def_prop_rw("decompress_range_cmp", &oem::PyParser::GetDecompressRangeCmp, &oem::PyParser::SetDecompressRangeCmp)

--- a/python/bindings/py_logger.hpp
+++ b/python/bindings/py_logger.hpp
@@ -14,8 +14,6 @@
 
 namespace nb = nanobind;
 
-namespace python_log {
-
 //============================================================================
 //! \class python_sink
 //! \brief A spdlog sink that marshalls logs into a python logger.
@@ -158,5 +156,3 @@ class PyLoggerManager : public LoggerManager
         for (const auto& [name, logger] : loggers) { logger->set_level(logger_level); }
     }
 };
-
-} // namespace python_log

--- a/python/bindings/py_logger.hpp
+++ b/python/bindings/py_logger.hpp
@@ -207,6 +207,12 @@ class PyLoggerManager : public LoggerManager
         return spd_logger;
     }
 
+    //----------------------------------------------------------------------------
+    //! \brief Refreshes the spdlog
+    //!
+    //! \param[in] logger_name_  The name of the logger on the Python side.
+    //! \return A shared pointer to the newly registered or pre-existing spd logger.
+    //----------------------------------------------------------------------------
     void RefreshSpdLoggerLevel(nb::handle logger)
     {
         std::string logger_name = nb::cast<std::string>(logger.attr("name"));
@@ -231,7 +237,7 @@ class PyLoggerManager : public LoggerManager
     //! Flushes managed spd loggers, deallocates them, and deallocates
     //! stored Python setLevel callbacks.
     //----------------------------------------------------------------------------
-    void Shutdown()
+    void Shutdown() override
     {
         for (const auto& [name, logger] : loggers) { logger->flush(); }
         loggers.clear();

--- a/python/bindings/py_logger.hpp
+++ b/python/bindings/py_logger.hpp
@@ -231,6 +231,8 @@ class PyLoggerManager : public LoggerManager
     }
 
   public:
+    ~PyLoggerManager() = default;
+
     //----------------------------------------------------------------------------
     //! \brief Cleans up managed loggers and stored Python objects.
     //!

--- a/python/bindings/py_logger.hpp
+++ b/python/bindings/py_logger.hpp
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include <mutex>
+
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/details/synchronous_factory.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/spdlog.h>
+
+#include "bindings_core.hpp"
+#include "novatel_edie/common/logger.hpp"
+
+namespace nb = nanobind;
+
+namespace python_log {
+
+//============================================================================
+//! \class python_sink
+//! \brief A spdlog sink that marshalls logs into a python logger.
+//============================================================================
+class python_sink : public spdlog::sinks::base_sink<spdlog::details::null_mutex>
+{
+  private:
+    nb::handle py_logger;
+
+    //----------------------------------------------------------------------------
+    // ! \brief Checks if a python logger is enabled for a specified log level.
+    // ! \param[in] py_logger The python logger to check for.
+    // ! \param[in] level The python log level to check for.
+    // ! \return Whether the logger is enabled for the level.
+    //----------------------------------------------------------------------------
+    inline bool is_enabled(int level) { return nb::cast<bool>(py_logger.attr("isEnabledFor")(level)); }
+
+    //----------------------------------------------------------------------------
+    // ! \brief Convert from an spdlog level enum to an appropriate integer value.
+    // ! \param[in] level The spdlog level enum value.
+    // ! \return The integer representing that same log level in python.
+    //----------------------------------------------------------------------------
+    inline int get_python_log_level(spdlog::level::level_enum level)
+    {
+        switch (level)
+        {
+        case spdlog::level::trace: return 5;     // SUB-DEBUG
+        case spdlog::level::debug: return 10;    // DEBUG
+        case spdlog::level::info: return 20;     // INFO
+        case spdlog::level::warn: return 30;     // WARNING
+        case spdlog::level::err: return 40;      // ERROR
+        case spdlog::level::critical: return 50; // CRITICAL
+        default: throw std::runtime_error("Logging was performed at an unknown level");
+        }
+    }
+
+  public:
+    //----------------------------------------------------------------------------
+    // ! \brief Create a python_sink to a specfic Python logger.
+    // ! \param[in] py_logger_ A handle to the Python logger object.
+    //----------------------------------------------------------------------------
+    explicit python_sink(nb::handle py_logger_) : py_logger(py_logger_) {}
+
+    //----------------------------------------------------------------------------
+    // ! \brief Send a log message to the attached python logger if enabled.
+    // ! \param[in] msg The message to send to the python logger.
+    //----------------------------------------------------------------------------
+    void sink_it_(const spdlog::details::log_msg& msg) override
+    {
+        int level = get_python_log_level(msg.level);
+        if (is_enabled(level))
+        {
+            nb::object source_filename = msg.source.filename ? nb::str(msg.source.filename) : nb::none();
+            nb::object source_funcname = msg.source.funcname ? nb::str(msg.source.funcname) : nb::none();
+            nb::str msg_payload = nb::str(msg.payload.data(), msg.payload.size());
+            // Formatting arguments and exectution info are None
+            nb::object record = py_logger.attr("makeRecord")(py_logger.attr("name"), level, source_filename, msg.source.line, msg_payload, nb::none(),
+                                                             nb::none(), source_funcname);
+            py_logger.attr("handle")(record);
+        }
+    }
+
+    //----------------------------------------------------------------------------
+    // ! \brief Preserve default flush behavior.
+    //----------------------------------------------------------------------------
+    void flush_() override {}
+};
+
+//============================================================================
+//! \class PyLoggerManager
+//! \brief A LoggerManager capable of registering connections to Python loggers.
+//!
+//! Will automatically be set as the global `pclLoggerManager` during
+//! Python API initialization.
+//============================================================================
+class PyLoggerManager : public LoggerManager
+{
+  private:
+    std::map<std::string, std::shared_ptr<spdlog::logger>> loggers;
+
+    //----------------------------------------------------------------------------
+    // ! \brief Convert from the provided C++ logger name to an appropriate Python one.
+    // ! \return The name for the logger on the Python side.
+    //----------------------------------------------------------------------------
+    std::string CLoggerNameToPyLoggerName(std::string logger_name_)
+    {
+        std::string py_name = "novatel_edie";
+        if (logger_name_ == "header_decoder" || logger_name_ == "message_decoder") { py_name += ".decoder"; }
+        return py_name + "." + logger_name_;
+    }
+
+  public:
+    //----------------------------------------------------------------------------
+    // ! \brief Flush all python logger sinks and clear out logger references.
+    // !
+    // ! spdlog::shutdown is not called due to certain static variables 
+    // ! required to do so being possibly deallocated at destruction time.
+    // ! This is only acceptable because the PyLoggerManager does not make use 
+    // ! of asynchronous logging and does use the spdlog logger registry.
+    //----------------------------------------------------------------------------
+    ~PyLoggerManager() override
+    {
+        for (const auto& [fileName, sink] : loggers) { sink->flush(); }
+        loggers.clear();
+    }
+
+    //----------------------------------------------------------------------------
+    // ! \brief Register a new logger with a python logger sink.
+    // ! \return A shared pointer to the newly registered logger.
+    //----------------------------------------------------------------------------
+    std::shared_ptr<spdlog::logger> RegisterLogger(const std::string& logger_name_)
+    {
+        // Get logger if it exists
+        std::string py_name = CLoggerNameToPyLoggerName(logger_name_);
+        auto it = loggers.find(py_name);
+        if (it != loggers.end()) { return it->second; }
+        // Create logger
+        nb::object py_logger = nb::module_::import_("logging").attr("getLogger")(py_name);
+        std::shared_ptr<python_sink> sink = std::make_shared<python_sink>(py_logger);
+        std::shared_ptr<spdlog::logger> spd_logger = std::make_shared<spdlog::logger>(py_name, sink);
+        // Ensure all messages are sent to python_sink
+        spd_logger->set_level(spdlog::level::trace);
+        // Save and return logger - No need to use spdlog registry as accessibility is only through python
+        loggers[py_name] = spd_logger;
+        return spd_logger;
+    }
+};
+
+} // namespace python_log

--- a/python/bindings/py_logger.hpp
+++ b/python/bindings/py_logger.hpp
@@ -182,7 +182,6 @@ class PyLoggerManager : public LoggerManager
     std::shared_ptr<spdlog::logger> RegisterPythonLogger(const std::string& logger_name_)
     {
         // Get the logger if it exists
-        std::cout << "Registering " << logger_name_ << std::endl;
         auto it = loggers.find(logger_name_);
         if (it != loggers.end()) { return it->second; }
 

--- a/python/bindings/py_logger.hpp
+++ b/python/bindings/py_logger.hpp
@@ -21,6 +21,7 @@ namespace nb = nanobind;
 class python_sink : public spdlog::sinks::base_sink<spdlog::details::null_mutex>
 {
   private:
+    // A reference to the python logger which messages will be pushed to
     nb::handle py_logger;
 
     //----------------------------------------------------------------------------
@@ -32,7 +33,7 @@ class python_sink : public spdlog::sinks::base_sink<spdlog::details::null_mutex>
     inline bool is_enabled(int level) { return nb::cast<bool>(py_logger.attr("isEnabledFor")(level)); }
 
     //----------------------------------------------------------------------------
-    //! \brief Convert from an spdlog level enum to an appropriate integer value.
+    //! \brief Converts from an spdlog level enum to an appropriate integer value.
     //! \param[in] level The spdlog level enum value.
     //! \return The integer representing that same log level in python.
     //----------------------------------------------------------------------------
@@ -40,7 +41,7 @@ class python_sink : public spdlog::sinks::base_sink<spdlog::details::null_mutex>
     {
         switch (level)
         {
-        case spdlog::level::trace: return 5;     // SUB-DEBUG
+        case spdlog::level::trace: return 1;     // SUB-DEBUG
         case spdlog::level::debug: return 10;    // DEBUG
         case spdlog::level::info: return 20;     // INFO
         case spdlog::level::warn: return 30;     // WARNING
@@ -52,13 +53,13 @@ class python_sink : public spdlog::sinks::base_sink<spdlog::details::null_mutex>
 
   public:
     //----------------------------------------------------------------------------
-    //! \brief Create a python_sink to a specfic Python logger.
+    //! \brief Creates a python_sink to a specfic Python logger.
     //! \param[in] py_logger_ A handle to the Python logger object.
     //----------------------------------------------------------------------------
     explicit python_sink(nb::handle py_logger_) : py_logger(py_logger_) {}
 
     //----------------------------------------------------------------------------
-    //! \brief Send a log message to the attached python logger if enabled.
+    //! \brief Sends a log message to the attached python logger if enabled.
     //! \param[in] msg The message to send to the python logger.
     //----------------------------------------------------------------------------
     void sink_it_(const spdlog::details::log_msg& msg) override
@@ -69,7 +70,7 @@ class python_sink : public spdlog::sinks::base_sink<spdlog::details::null_mutex>
             nb::object source_filename = msg.source.filename ? nb::str(msg.source.filename) : nb::none();
             nb::object source_funcname = msg.source.funcname ? nb::str(msg.source.funcname) : nb::none();
             nb::str msg_payload = nb::str(msg.payload.data(), msg.payload.size());
-            // Formatting arguments and exectution info are None
+            // Formatting arguments and execution info are None
             nb::object record = py_logger.attr("makeRecord")(py_logger.attr("name"), level, source_filename, msg.source.line, msg_payload, nb::none(),
                                                              nb::none(), source_funcname);
             py_logger.attr("handle")(record);
@@ -77,7 +78,7 @@ class python_sink : public spdlog::sinks::base_sink<spdlog::details::null_mutex>
     }
 
     //----------------------------------------------------------------------------
-    //! \brief Preserve default flush behavior.
+    //! \brief Preserves default flush behavior.
     //----------------------------------------------------------------------------
     void flush_() override {}
 };
@@ -85,20 +86,30 @@ class python_sink : public spdlog::sinks::base_sink<spdlog::details::null_mutex>
 //============================================================================
 //! \class PyLoggerManager
 //! \brief A LoggerManager capable of registering connections to Python loggers.
-//! 
+//!
+//! Manages all spd loggers associated with python ones and is responsible for
+//! updating their log level as appropriate.
+//!
 //! Will automatically be set as the global `pclLoggerManager` during
 //! Python API initialization.
-//! 
+//!
 //! Only designed for single-threaded access.
 //============================================================================
 class PyLoggerManager : public LoggerManager
 {
   private:
-    spdlog::level::level_enum logger_level = spdlog::level::trace;
+    // whether any messages should be logged
+    bool disabled = false;
+    // the set of spd loggers under management
     std::map<std::string, std::shared_ptr<spdlog::logger>> loggers;
+    // functions used for setting log level on Python side
+    std::map<std::string, nb::callable> set_level_funcs;
+    // a reference to the set of novatel_edie internal python functions - stored as handle to avoid cleanup
+    nb::handle internal_mod = nb::none();
 
     //----------------------------------------------------------------------------
-    //! \brief Convert from the provided C++ logger name to an appropriate Python one.
+    //! \brief Converts from the provided C++ logger name to an appropriate Python one.
+    //!
     //! \return The name for the logger on the Python side.
     //----------------------------------------------------------------------------
     std::string CLoggerNameToPyLoggerName(std::string logger_name_)
@@ -108,51 +119,184 @@ class PyLoggerManager : public LoggerManager
         return py_name + "." + logger_name_;
     }
 
-  public:
     //----------------------------------------------------------------------------
-    //! \brief Flush all python logger sinks and clear out logger references.
+    //! \brief Converts from a Python log level to and spdlog one.
     //!
-    //! spdlog::shutdown is not called due to certain static variables
-    //! required to do so being possibly deallocated at destruction time.
-    //! This is only acceptable because the PyLoggerManager does not make use
-    //! of asynchronous logging and does use the spdlog logger registry.
+    //! \return The appropriate spdlog level.
     //----------------------------------------------------------------------------
-    ~PyLoggerManager() override
+    inline spdlog::level::level_enum get_spd_log_level(int level)
     {
-        for (const auto& [name, logger] : loggers) { logger->flush(); }
-        loggers.clear();
+        if (level < 10) { return spdlog::level::trace; }
+        else if (level < 20) { return spdlog::level::debug; }
+        else if (level < 30) { return spdlog::level::info; }
+        else if (level < 40) { return spdlog::level::warn; }
+        else if (level < 50) { return spdlog::level::err; }
+        else if (level == 50) { return spdlog::level::critical; }
+        else { return spdlog::level::off; }
     }
 
     //----------------------------------------------------------------------------
-    //! \brief Register a new logger with a python logger sink.
-    //! \return A shared pointer to the newly registered logger.
+    //! \brief Gets the effective level of a logger as an spdlog level.
+    //!
+    //! \param[in] logger_ The logger whose level to get.
+    //! \return The appropriate spdlog level.
+    //----------------------------------------------------------------------------
+    spdlog::level::level_enum GetEffectiveLogLevel(nb::handle logger_)
+    {
+        return get_spd_log_level(nb::cast<int>(logger_.attr("getEffectiveLevel")()));
+    }
+
+    //----------------------------------------------------------------------------
+    //! \brief Injects a hook into the setLevel function of the provided logger.
+    //! 
+    //! Allows the PyLoggerManager to update an spdlogger's level on changes to the 
+    //! corresponding Python logger's level.
+    //!
+    //! \param[in] logger_ The logger whose level to get.
+    //! \return The appropriate spdlog level.
+    //----------------------------------------------------------------------------
+    void InjectHook(nb::handle logger)
+    {
+        std::string logger_name = nb::cast<std::string>(logger.attr("name"));
+        // If hook is already injected return
+        if (set_level_funcs.find(logger_name) != set_level_funcs.end()) { return; }
+        // Otherwise save old method and inject hook into object
+        nb::callable original_func = logger.attr("setLevel");
+        set_level_funcs[logger_name] = original_func;
+        nb::handle set_level_func = internal_mod.attr("set_level");
+        nb::module_ types = nb::module_::import_("types");
+        nb::object instance_set_level_func = types.attr("MethodType")(set_level_func, logger);
+        logger.attr("setLevel") = instance_set_level_func;
+    }
+
+    //----------------------------------------------------------------------------
+    //! \brief Registers a new logger associated with a Python one.
+    //! 
+    //! \param[in] logger_name_  The name of the logger on the Python side.
+    //! \return A shared pointer to the newly registered or pre-existing spd logger.
+    //----------------------------------------------------------------------------
+    std::shared_ptr<spdlog::logger> RegisterPythonLogger(const std::string& logger_name_)
+    {
+        // Get the logger if it exists
+        std::cout << "Registering " << logger_name_ << std::endl;
+        auto it = loggers.find(logger_name_);
+        if (it != loggers.end()) { return it->second; }
+
+        // Register its parent logger first
+        if (logger_name_ != "root")
+        {
+            std::string parent_name;
+            size_t last_delimiter = logger_name_.find_last_of('.');
+            if (last_delimiter != std::string::npos) { parent_name = logger_name_.substr(0, last_delimiter); }
+            else { parent_name = "root"; }
+            RegisterPythonLogger(parent_name);
+        }
+
+        // Create logger
+        nb::handle py_logger = nb::module_::import_("logging").attr("getLogger")(logger_name_);
+        std::shared_ptr<python_sink> sink = std::make_shared<python_sink>(py_logger);
+        std::shared_ptr<spdlog::logger> spd_logger = std::make_shared<spdlog::logger>(logger_name_, sink);
+
+        // Set appropriate log level and add callback into the logger object to update on change
+        if (disabled) { spd_logger->set_level(spdlog::level::off); }
+        else { spd_logger->set_level(GetEffectiveLogLevel(py_logger)); }
+        InjectHook(py_logger);
+
+        // Save and return logger
+        loggers[logger_name_] = spd_logger;
+        return spd_logger;
+    }
+
+    void SetSpdLoggerLevel(nb::handle logger, int level)
+    {
+        std::string logger_name = nb::cast<std::string>(logger.attr("name"));
+
+        auto it = loggers.find(logger_name);
+        // Ignore logger if it is not under management
+        if (it == loggers.end()) { return; }
+
+        nb::set children = nb::cast<nb::set>(logger.attr("getChildren")());
+        for (auto child : children)
+        {
+            if (nb::cast<int>(child.attr("level")) == 0) { SetSpdLoggerLevel(child, level); }
+        }
+
+        std::cout << "Setting " << logger_name << " to " << level << std::endl;
+        std::shared_ptr<spdlog::logger> spd_logger = it->second;
+        spd_logger->set_level(get_spd_log_level(level));
+    }
+  public:
+    //----------------------------------------------------------------------------
+    //! \brief Cleans up managed loggers and stored Python objects.
+    //!
+    //! Flush
+    //----------------------------------------------------------------------------
+    void Shutdown()
+    {
+        for (const auto& [name, logger] : loggers) { logger->flush(); }
+        loggers.clear();
+        set_level_funcs.clear();
+    }
+
+    void SetLoggerLevel(nb::handle logger, int level)
+    {
+
+        if (!disabled) { SetSpdLoggerLevel(logger, level); }
+
+        // Proceed with orginal function call
+        std::string logger_name = nb::cast<std::string>(logger.attr("name"));
+        auto it = set_level_funcs.find(logger_name);
+        if (it == set_level_funcs.end()) { throw std::runtime_error("The logger is under management but has no associated setLevel function"); }
+        nb::callable original_func = it->second;
+        original_func(level);
+    }
+
+    //----------------------------------------------------------------------------
+    //! \brief Sets the reference for accessing internal novatel_edie Python functions.
+    //! 
+    //! Includes `set_level` function used for triggering custom log level manipulation.
+    //!
+    //! \param[in] internal_mod_ The module of internal functionality.
+    //----------------------------------------------------------------------------
+    void SetInternalMod(nb::module_ internal_mod_) { internal_mod = internal_mod_; }
+
+    //----------------------------------------------------------------------------
+    //! \brief Registers a new logger associated with a python one.
+    //!
+    //! \param[in] logger_name_  The name of the logger on the C++ side.
+    //! \return A shared pointer to the newly registered or pre-existing logger.
     //----------------------------------------------------------------------------
     std::shared_ptr<spdlog::logger> RegisterLogger(const std::string& logger_name_)
     {
         // Get logger if it exists
         std::string py_name = CLoggerNameToPyLoggerName(logger_name_);
-        auto it = loggers.find(py_name);
-        if (it != loggers.end()) { return it->second; }
-        // Create logger
-        nb::object py_logger = nb::module_::import_("logging").attr("getLogger")(py_name);
-        std::shared_ptr<python_sink> sink = std::make_shared<python_sink>(py_logger);
-        std::shared_ptr<spdlog::logger> spd_logger = std::make_shared<spdlog::logger>(py_name, sink);
-        // Ensure all messages are sent to python_sink
-        spd_logger->set_level(logger_level);
-        // Save and return logger - No need to use spdlog registry as accessibility is only through python
-        loggers[py_name] = spd_logger;
-        return spd_logger;
+        return RegisterPythonLogger(py_name);
     }
 
+    //----------------------------------------------------------------------------
+    //! \brief Disables all logging within C++ code.
+    //!
+    //! Each spdlog logger under management is set to off.
+    //----------------------------------------------------------------------------
     void DisableInternalLogging()
     {
-        logger_level = spdlog::level::off;
-        for (const auto& [name, logger] : loggers) { logger->set_level(logger_level); }
+        disabled = true;
+        for (const auto& [name, logger] : loggers) { logger->set_level(spdlog::level::off); }
     }
 
+    //----------------------------------------------------------------------------
+    //! \brief Enables logging within C++ code.
+    //!
+    //! Each spdlog logger under management is set the match with python log level.
+    //----------------------------------------------------------------------------
     void EnableInternalLogging()
     {
-        logger_level = spdlog::level::trace;
-        for (const auto& [name, logger] : loggers) { logger->set_level(logger_level); }
+        disabled = false;
+        nb::handle logging = nb::module_::import_("logging");
+        for (const auto& [name, logger] : loggers)
+        {
+            nb::handle py_logger = logging.attr("getLogger")(name);
+            logger->set_level(GetEffectiveLogLevel(py_logger));
+        }
     }
 };

--- a/python/bindings/range_decompressor.cpp
+++ b/python/bindings/range_decompressor.cpp
@@ -15,7 +15,7 @@ void init_novatel_range_decompressor(nb::module_& m)
     nb::class_<oem::RangeDecompressor>(m, "RangeDecompressor")
         .def("__init__", [](oem::RangeDecompressor* t) { new (t) oem::RangeDecompressor(MessageDbSingleton::get()); }) // NOLINT(*.NewDeleteLeaks)
         .def(nb::init<PyMessageDatabase::Ptr&>(), "message_db"_a)
-        .def_prop_ro("logger", &oem::RangeDecompressor::GetLogger)
+        //.def_prop_ro("logger", &oem::RangeDecompressor::GetLogger)
         .def("reset", &oem::RangeDecompressor::Reset)
         .def(
             "decompress",

--- a/python/bindings/range_decompressor.cpp
+++ b/python/bindings/range_decompressor.cpp
@@ -15,7 +15,6 @@ void init_novatel_range_decompressor(nb::module_& m)
     nb::class_<oem::RangeDecompressor>(m, "RangeDecompressor")
         .def("__init__", [](oem::RangeDecompressor* t) { new (t) oem::RangeDecompressor(MessageDbSingleton::get()); }) // NOLINT(*.NewDeleteLeaks)
         .def(nb::init<PyMessageDatabase::Ptr&>(), "message_db"_a)
-        //.def_prop_ro("logger", &oem::RangeDecompressor::GetLogger)
         .def("reset", &oem::RangeDecompressor::Reset)
         .def(
             "decompress",

--- a/python/bindings/rxconfig_handler.cpp
+++ b/python/bindings/rxconfig_handler.cpp
@@ -15,7 +15,6 @@ void init_novatel_rxconfig_handler(nb::module_& m)
         .def("__init__", [](oem::RxConfigHandler* t) { new (t) oem::RxConfigHandler(MessageDbSingleton::get()); }) // NOLINT(*.NewDeleteLeaks)
         .def(nb::init<const PyMessageDatabase::Ptr&>(), "message_db"_a)
         .def("load_db", &oem::RxConfigHandler::LoadJsonDb, "message_db"_a)
-        //.def_prop_ro("logger", &oem::RxConfigHandler::GetLogger)
         .def("write", [](oem::RxConfigHandler& self,
                          const nb::bytes& data) { return self.Write(reinterpret_cast<uint8_t*>(const_cast<char*>(data.c_str())), data.size()); })
         .def(

--- a/python/bindings/rxconfig_handler.cpp
+++ b/python/bindings/rxconfig_handler.cpp
@@ -15,7 +15,7 @@ void init_novatel_rxconfig_handler(nb::module_& m)
         .def("__init__", [](oem::RxConfigHandler* t) { new (t) oem::RxConfigHandler(MessageDbSingleton::get()); }) // NOLINT(*.NewDeleteLeaks)
         .def(nb::init<const PyMessageDatabase::Ptr&>(), "message_db"_a)
         .def("load_db", &oem::RxConfigHandler::LoadJsonDb, "message_db"_a)
-        .def_prop_ro("logger", &oem::RxConfigHandler::GetLogger)
+        //.def_prop_ro("logger", &oem::RxConfigHandler::GetLogger)
         .def("write", [](oem::RxConfigHandler& self,
                          const nb::bytes& data) { return self.Write(reinterpret_cast<uint8_t*>(const_cast<char*>(data.c_str())), data.size()); })
         .def(

--- a/python/examples/common_setup.py
+++ b/python/examples/common_setup.py
@@ -1,0 +1,35 @@
+import os
+import logging
+import argparse
+
+from novatel_edie import string_to_encode_format, ENCODE_FORMAT
+
+def setup_example_logging(log_level):
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+    root_console_formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    root_console_handler = logging.StreamHandler()
+    root_console_handler.setFormatter(root_console_formatter)
+    root_console_handler.setLevel(log_level)
+    root_logger.addHandler(root_console_handler)
+
+def handle_args(logger) -> tuple[str, ENCODE_FORMAT]:
+    """Parse and confirm accuracy of CLI arguments."""
+    parser = argparse.ArgumentParser(description="Convert OEM log files using FileParser.")
+    parser.add_argument("input_file", help="Input file")
+    parser.add_argument("output_format", nargs="?",
+                        choices=["ASCII", "ABBREV_ASCII", "BINARY", "FLATTENED_BINARY", "JSON"],
+                        help="Output format", default="ASCII")
+    parser.add_argument("-V", "--version", action="store_true")
+    args = parser.parse_args()
+
+    if args.version:
+        exit(0)
+
+    if not os.path.exists(args.input_file):
+        logger.error(f'File "{args.input_file}" does not exist')
+        exit(1)
+
+    encode_format = string_to_encode_format(args.output_format)
+
+    return args.input_file, encode_format

--- a/python/examples/converter_components.py
+++ b/python/examples/converter_components.py
@@ -64,7 +64,6 @@ def format_frame(frame, frame_format):
 
 
 def main():
-    logger = ne.Logging.register_logger("converter")
     parser = argparse.ArgumentParser(description="Convert OEM log files using low-level components.")
     parser.add_argument("input_file", help="Input file")
     parser.add_argument(

--- a/python/examples/converter_components.py
+++ b/python/examples/converter_components.py
@@ -29,74 +29,47 @@
 # messages using the low-level components.
 ########################################################################
 
-import argparse
-import os
+import logging
 from binascii import hexlify
 
-import novatel_edie as ne
+from novatel_edie import HEADER_FORMAT, ENCODE_FORMAT, pretty_version, Framer, Decoder, Filter, Message, MESSAGE_SIZE_MAX
 from novatel_edie.messages import RANGE
-from novatel_edie import STATUS, ENCODE_FORMAT
 
-
-def read_frames(input_file, framer):
-    # Write unrecognized and incomplete messages to a separate file.
-    with open(input_file, "rb") as input_stream, open(f"{input_file}.UNKNOWN", "wb") as unknown_bytes_stream:
-        while read_data := input_stream.read(ne.MESSAGE_SIZE_MAX):
-            framer.write(read_data)
-            while True:
-                try:
-                    frame, meta = framer.get_frame()
-                except ne.BufferEmptyException:
-                    break
-                except ne.IncompleteException:
-                    break
-                except ne.UnknownException:
-                    continue
-                yield frame, meta
-        unknown_bytes_stream.write(framer.flush())
+from common_setup import setup_example_logging, handle_args
 
 
 def format_frame(frame, frame_format):
-    if frame_format in [ne.HEADER_FORMAT.BINARY, ne.HEADER_FORMAT.SHORT_BINARY, ne.HEADER_FORMAT.PROPRIETARY_BINARY,
-                        ne.ENCODE_FORMAT.BINARY, ne.ENCODE_FORMAT.FLATTENED_BINARY]:
+    """Format the frame into a human-readable string."""
+    if frame_format in [HEADER_FORMAT.BINARY, HEADER_FORMAT.SHORT_BINARY,
+                        HEADER_FORMAT.PROPRIETARY_BINARY,
+                        ENCODE_FORMAT.BINARY, ENCODE_FORMAT.FLATTENED_BINARY]:
         return hexlify(frame, sep=" ").decode("ascii").upper()
     return frame
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Convert OEM log files using low-level components.")
-    parser.add_argument("input_file", help="Input file")
-    parser.add_argument(
-        "output_format",
-        nargs="?",
-        choices=["ASCII", "ABBREV_ASCII", "BINARY", "FLATTENED_BINARY", "JSON"],
-        help="Output format",
-        default="ASCII",
-    )
-    parser.add_argument("-V", "--version", action="store_true")
-    args = parser.parse_args()
-    encode_format = ne.string_to_encode_format(args.output_format)
+    """Example framer usage."""
+    # Setup logging
+    setup_example_logging(logging.WARNING)
+    logger = logging.getLogger(__name__)
+    logger.info(f"Decoder library information:\n{pretty_version}")
 
-    logger.info(f"Decoder library information:\n{ne.pretty_version}")
-    if args.version:
-        exit(0)
-
-    if not os.path.exists(args.input_file):
-        logger.error(f'File "{args.input_file}" does not exist')
-        exit(1)
+    # Handle CLI arguments
+    input_file, encode_format = handle_args(logger)
 
     # Set up the EDIE components
-    framer = ne.Framer()
+    framer = Framer()
     framer.set_report_unknown_bytes(True)
     framer.set_payload_only(False)
     framer.set_frame_json(False)
-    decoder = ne.Decoder()
-    filter = ne.Filter()
+    decoder = Decoder()
+    my_filter = Filter()
 
-    with open(f"{args.input_file}.{encode_format}", "wb") as converted_logs_stream:
-        for frame, meta in read_frames(args.input_file, framer):
-            try:
-                if meta.format == ne.HEADER_FORMAT.UNKNOWN:
+    with open(input_file, "rb") as input_stream:
+        while read_data := input_stream.read(MESSAGE_SIZE_MAX):
+            framer.write(read_data)
+            for frame, meta in framer:
+                if meta.format == HEADER_FORMAT.UNKNOWN:
                     continue
                 logger.info(f"Framed ({len(frame)}): {format_frame(frame, meta.format)}")
 
@@ -104,7 +77,7 @@ def main():
                 header = decoder.decode_header(frame, meta)
 
                 # Filter the log, pass over it if we don't want it.
-                if not filter.do_filtering(meta):
+                if not my_filter.do_filtering(meta):
                     continue
 
                 # Decode the log body.
@@ -119,10 +92,8 @@ def main():
                         pass
 
                 # Re-encode the log
-                if isinstance(message, ne.Message):
+                if isinstance(message, Message):
                     encoded_message = message.to_ascii()
 
-            except Exception as e:
-                logger.warn(str(e))
 if __name__ == "__main__":
     main()

--- a/python/examples/converter_fileparser.py
+++ b/python/examples/converter_fileparser.py
@@ -40,10 +40,12 @@ import novatel_edie as ne
 from novatel_edie.messages import BESTPOS
 from common import setup_example_logging
 
+
 def main():
     setup_example_logging()
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
+    ne.disable_internal_logging()
 
     parser = argparse.ArgumentParser(description="Convert OEM log files using FileParser.")
     parser.add_argument("input_file", help="Input file")
@@ -63,25 +65,29 @@ def main():
     filter = ne.Filter()
     file_parser.filter = filter
 
-    # messages = 0
-    # start = timeit.default_timer()
-    # for message in file_parser:
-    #     if isinstance(message, ne.Message):
-    #         encoded_msg = message.encode(encode_format)
-    #         ascii_msg = message.to_ascii()
-    #         binary_msg = message.to_binary()
-    #         messages += 1
-    #         if isinstance(message, BESTPOS):
-    #             lat = message.latitude
-    #             lon = message.longitude
-    #     elif isinstance(message, ne.UnknownMessage):
-    #         unknown_id = message.header.message_id
-    #         payload = message.payload
-    #     elif isinstance(message, ne.UnknownBytes):
-    #         data = message.data
+    messages = 0
+    start = timeit.default_timer()
+    for message in file_parser:
+        if isinstance(message, ne.Message):
+            messages += 1
+        if messages > 100000:
+            break
+        # if isinstance(message, ne.Message):
+        #     encoded_msg = message.encode(encode_format)
+        #     ascii_msg = message.to_ascii()
+        #     binary_msg = message.to_binary()
+        #     messages += 1
+        #     if isinstance(message, BESTPOS):
+        #         lat = message.latitude
+        #         lon = message.longitude
+        # elif isinstance(message, ne.UnknownMessage):
+        #     unknown_id = message.header.message_id
+        #     payload = message.payload
+        # elif isinstance(message, ne.UnknownBytes):
+        #     data = message.data
 
-    # elapsed_seconds = timeit.default_timer() - start
-    # logger.info(f"Converted {messages} logs in {elapsed_seconds:.3f}s from {args.input_file}")
+    elapsed_seconds = timeit.default_timer() - start
+    logger.info(f"Converted {messages} logs in {elapsed_seconds:.3f}s from {args.input_file}")
 
 
 if __name__ == "__main__":

--- a/python/examples/converter_fileparser.py
+++ b/python/examples/converter_fileparser.py
@@ -42,10 +42,9 @@ from common import setup_example_logging
 
 
 def main():
-    setup_example_logging()
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.DEBUG)
-    ne.disable_internal_logging()
+    setup_example_logging(logging.WARNING)
+    logger = logging.getLogger(__name__)    \
+    # ne.disable_internal_logging()
 
     parser = argparse.ArgumentParser(description="Convert OEM log files using FileParser.")
     parser.add_argument("input_file", help="Input file")
@@ -72,22 +71,9 @@ def main():
             messages += 1
         if messages > 100000:
             break
-        # if isinstance(message, ne.Message):
-        #     encoded_msg = message.encode(encode_format)
-        #     ascii_msg = message.to_ascii()
-        #     binary_msg = message.to_binary()
-        #     messages += 1
-        #     if isinstance(message, BESTPOS):
-        #         lat = message.latitude
-        #         lon = message.longitude
-        # elif isinstance(message, ne.UnknownMessage):
-        #     unknown_id = message.header.message_id
-        #     payload = message.payload
-        # elif isinstance(message, ne.UnknownBytes):
-        #     data = message.data
 
     elapsed_seconds = timeit.default_timer() - start
-    logger.info(f"Converted {messages} logs in {elapsed_seconds:.3f}s from {args.input_file}")
+    logger.warning(f"Converted {messages} logs in {elapsed_seconds:.3f}s from {args.input_file}")
 
 
 if __name__ == "__main__":

--- a/python/examples/converter_fileparser.py
+++ b/python/examples/converter_fileparser.py
@@ -29,27 +29,21 @@
 # messages using the FileParser.
 ########################################################################
 
+import logging
 import argparse
 import atexit
 import os
 import timeit
+import pandas
 
 import novatel_edie as ne
-from novatel_edie import Logging, LogLevel
 from novatel_edie.messages import BESTPOS
-
-def _configure_logging(logger):
-    logger.set_level(LogLevel.DEBUG)
-    Logging.add_console_logging(logger)
-    Logging.add_rotating_file_logger(logger)
-
+from common import setup_example_logging
 
 def main():
-    logger = Logging().register_logger("converter")
-    _configure_logging(logger)
-    atexit.register(Logging.shutdown)
-
-    logger.info(f"Decoder library information:\n{ne.pretty_version}")
+    setup_example_logging()
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.DEBUG)
 
     parser = argparse.ArgumentParser(description="Convert OEM log files using FileParser.")
     parser.add_argument("input_file", help="Input file")
@@ -64,35 +58,30 @@ def main():
         exit(0)
 
     if not os.path.exists(args.input_file):
-        logger.error(f'File "{args.input_file}" does not exist')
         exit(1)
     file_parser = ne.FileParser(args.input_file)
     filter = ne.Filter()
     file_parser.filter = filter
-    _configure_logging(file_parser.logger)
-    _configure_logging(file_parser.filter.logger)
-    Logging.get("message_decoder").set_level(LogLevel.OFF)
 
+    # messages = 0
+    # start = timeit.default_timer()
+    # for message in file_parser:
+    #     if isinstance(message, ne.Message):
+    #         encoded_msg = message.encode(encode_format)
+    #         ascii_msg = message.to_ascii()
+    #         binary_msg = message.to_binary()
+    #         messages += 1
+    #         if isinstance(message, BESTPOS):
+    #             lat = message.latitude
+    #             lon = message.longitude
+    #     elif isinstance(message, ne.UnknownMessage):
+    #         unknown_id = message.header.message_id
+    #         payload = message.payload
+    #     elif isinstance(message, ne.UnknownBytes):
+    #         data = message.data
 
-    messages = 0
-    start = timeit.default_timer()
-    for message in file_parser:
-        if isinstance(message, ne.Message):
-            encoded_msg = message.encode(encode_format)
-            ascii_msg = message.to_ascii()
-            binary_msg = message.to_binary()
-            messages += 1
-            if isinstance(message, BESTPOS):
-                lat = message.latitude
-                lon = message.longitude
-        elif isinstance(message, ne.UnknownMessage):
-            unknown_id = message.header.message_id
-            payload = message.payload
-        elif isinstance(message, ne.UnknownBytes):
-            data = message.data
-
-    elapsed_seconds = timeit.default_timer() - start
-    logger.info(f"Converted {messages} logs in {elapsed_seconds:.3f}s from {args.input_file}")
+    # elapsed_seconds = timeit.default_timer() - start
+    # logger.info(f"Converted {messages} logs in {elapsed_seconds:.3f}s from {args.input_file}")
 
 
 if __name__ == "__main__":

--- a/python/examples/converter_fileparser.py
+++ b/python/examples/converter_fileparser.py
@@ -42,8 +42,8 @@ from common import setup_example_logging
 
 
 def main():
-    setup_example_logging(logging.WARNING)
-    logger = logging.getLogger(__name__)    \
+    setup_example_logging(logging.WARN)
+    logger = logging.getLogger(__name__)
     # ne.disable_internal_logging()
 
     parser = argparse.ArgumentParser(description="Convert OEM log files using FileParser.")

--- a/python/examples/converter_parser.py
+++ b/python/examples/converter_parser.py
@@ -29,87 +29,57 @@
 # messages using the Parser.
 ########################################################################
 
-import argparse
-import atexit
+import logging
 import timeit
 
-import novatel_edie as ne
-from novatel_edie import Logging, LogLevel
+from novatel_edie import Parser, pretty_version, MESSAGE_SIZE_MAX, Message, UnknownMessage, UnknownBytes
 from novatel_edie.messages import BESTPOS
 
-
+from common_setup import setup_example_logging, handle_args
 
 def main():
+    """Example Parser usage."""
+    # Setup logging
+    setup_example_logging(logging.INFO)
+    logger = logging.getLogger(__name__)
+    logger.info(f"Decoder library information:\n{pretty_version}")
 
+    # Handle CLI arguments
+    input_file, encode_format = handle_args(logger)
 
+    # Create a Parser
+    parser = Parser()
 
-    # parser = argparse.ArgumentParser(description="Convert OEM log files using Parser.")
-    # parser.add_argument("input_file", help="Input file")
-    # parser.add_argument("output_format", nargs="?",
-    #                     choices=["ASCII", "ABBREV_ASCII", "BINARY", "FLATTENED_BINARY", "JSON"],
-    #                     help="Output format", default="ASCII")
-    # parser.add_argument("append_msg_types", nargs="?", help="Additional message definitions to append to the database")
-    # parser.add_argument("-V", "--version", action="store_true")
-    # args = parser.parse_args()
-    # encode_format = ne.string_to_encode_format(args.output_format)
-
-    # Load the database
-    logger.info("Loading Database... ")
-    t0 = timeit.default_timer()
-    json_db = ne.get_default_database()
-    t1 = timeit.default_timer()
-    logger.info(f"Done in {(t1 - t0) * 1e3:.0f} ms")
-
-    # # Load the database
-    # encoder = ne.Encoder()
-    # logger.info("Loading Database... ")
-    # t0 = timeit.default_timer()
-    # json_db = ne.get_default_database()
-    # t1 = timeit.default_timer()
-    # logger.info(f"Done in {(t1 - t0) * 1e3:.0f} ms")
-
-    # if args.append_msg_types:
-    #     logger.info("Appending Message...")
-    #     start = timeit.default_timer()
-    #     json_db.append_messages(args.append_msg_types)
-    #     logger.info(f"Done in {timeit.default_timer() - start:.0f}ms")
-
-    parser = ne.Parser()
-    parser.write(b'#BESTPOSA,USB1,0,58.5,FINESTEERING,2209,502061.000,02000020,cdba,16809;SOL_COMPUTED,PPP,51.15043706870,-114.03067882331,1097.3462,-17.0001,WGS84,0.0154,0.0139,0.0288,"TSTR",11.000,0.000,43,39,39,38,')
-    try:
-        msg = parser.read()
-    except StopIteration:
-        pass
-    parser.write(b"00,00,7f,37*52483ac5\r\n")
-    msg = parser.read()
-    pass
-    parser.filter = ne.Filter()
-
-    with (open(args.input_file, "rb") as input_stream,
-          open(f"{args.input_file}.{encode_format}", "wb") as converted_logs_stream):
-        meta = ne.MetaData()
-        messages = 0
-        start = timeit.default_timer()
-        while read_data := input_stream.read(ne.MESSAGE_SIZE_MAX):
+    # Iterate through the messages
+    messages = 0
+    start = timeit.default_timer()
+    with open(input_file, "rb") as input_stream:
+        while read_data := input_stream.read(MESSAGE_SIZE_MAX):
             parser.write(read_data)
             for message in parser:
-                if isinstance(message, ne.Message):
+                # Handle messages that can be fully decoded
+                if isinstance(message, Message):
+                    # Encode the message into different formats
                     encoded_msg = message.encode(encode_format)
                     ascii_msg = message.to_ascii()
                     binary_msg = message.to_binary()
+                    dict_msg = message.to_dict()
                     messages += 1
+                    # Handle BESTPOS messages
                     if isinstance(message, BESTPOS):
+                        # Access specific fields
                         lat = message.latitude
                         lon = message.longitude
-                elif isinstance(message, ne.UnknownMessage):
+                # Handle messages that did not match any known definitions
+                elif isinstance(message, UnknownMessage):
                     unknown_id = message.header.message_id
                     payload = message.payload
-                elif isinstance(message, ne.UnknownBytes):
+                # Handle bytes that could not be parsed into a message
+                elif isinstance(message, UnknownBytes):
                     data = message.data
 
     elapsed_seconds = timeit.default_timer() - start
-    logger.info(f"Converted {messages} logs in {elapsed_seconds:.3f}s from {args.input_file}")
-    Logging.shutdown()
+    logger.info(f"Converted {messages} logs in {elapsed_seconds:.3f}s from {input_file}")
 
 
 if __name__ == "__main__":

--- a/python/examples/converter_parser.py
+++ b/python/examples/converter_parser.py
@@ -38,31 +38,20 @@ from novatel_edie import Logging, LogLevel
 from novatel_edie.messages import BESTPOS
 
 
-def _configure_logging(logger):
-    logger.set_level(LogLevel.DEBUG)
-    Logging.add_console_logging(logger)
-    Logging.add_rotating_file_logger(logger)
-
 
 def main():
-    logger = Logging().register_logger("converter")
-    _configure_logging(logger)
-    atexit.register(Logging.shutdown)
 
-    logger.info(f"Decoder library information:\n{ne.pretty_version}")
 
-    parser = argparse.ArgumentParser(description="Convert OEM log files using Parser.")
-    parser.add_argument("input_file", help="Input file")
-    parser.add_argument("output_format", nargs="?",
-                        choices=["ASCII", "ABBREV_ASCII", "BINARY", "FLATTENED_BINARY", "JSON"],
-                        help="Output format", default="ASCII")
-    parser.add_argument("append_msg_types", nargs="?", help="Additional message definitions to append to the database")
-    parser.add_argument("-V", "--version", action="store_true")
-    args = parser.parse_args()
-    encode_format = ne.string_to_encode_format(args.output_format)
 
-    if args.version:
-        exit(0)
+    # parser = argparse.ArgumentParser(description="Convert OEM log files using Parser.")
+    # parser.add_argument("input_file", help="Input file")
+    # parser.add_argument("output_format", nargs="?",
+    #                     choices=["ASCII", "ABBREV_ASCII", "BINARY", "FLATTENED_BINARY", "JSON"],
+    #                     help="Output format", default="ASCII")
+    # parser.add_argument("append_msg_types", nargs="?", help="Additional message definitions to append to the database")
+    # parser.add_argument("-V", "--version", action="store_true")
+    # args = parser.parse_args()
+    # encode_format = ne.string_to_encode_format(args.output_format)
 
     # Load the database
     logger.info("Loading Database... ")
@@ -71,16 +60,30 @@ def main():
     t1 = timeit.default_timer()
     logger.info(f"Done in {(t1 - t0) * 1e3:.0f} ms")
 
-    if args.append_msg_types:
-        logger.info("Appending Message...")
-        start = timeit.default_timer()
-        json_db.append_messages(args.append_msg_types)
-        logger.info(f"Done in {timeit.default_timer() - start:.0f}ms")
+    # # Load the database
+    # encoder = ne.Encoder()
+    # logger.info("Loading Database... ")
+    # t0 = timeit.default_timer()
+    # json_db = ne.get_default_database()
+    # t1 = timeit.default_timer()
+    # logger.info(f"Done in {(t1 - t0) * 1e3:.0f} ms")
 
-    parser = ne.Parser(json_db)
+    # if args.append_msg_types:
+    #     logger.info("Appending Message...")
+    #     start = timeit.default_timer()
+    #     json_db.append_messages(args.append_msg_types)
+    #     logger.info(f"Done in {timeit.default_timer() - start:.0f}ms")
+
+    parser = ne.Parser()
+    parser.write(b'#BESTPOSA,USB1,0,58.5,FINESTEERING,2209,502061.000,02000020,cdba,16809;SOL_COMPUTED,PPP,51.15043706870,-114.03067882331,1097.3462,-17.0001,WGS84,0.0154,0.0139,0.0288,"TSTR",11.000,0.000,43,39,39,38,')
+    try:
+        msg = parser.read()
+    except StopIteration:
+        pass
+    parser.write(b"00,00,7f,37*52483ac5\r\n")
+    msg = parser.read()
+    pass
     parser.filter = ne.Filter()
-    _configure_logging(parser.logger)
-    _configure_logging(parser.filter.logger)
 
     with (open(args.input_file, "rb") as input_stream,
           open(f"{args.input_file}.{encode_format}", "wb") as converted_logs_stream):

--- a/python/novatel_edie_files/__init__.py
+++ b/python/novatel_edie_files/__init__.py
@@ -43,7 +43,6 @@ from .bindings import (
     Oem4BinaryHeader, Oem4BinaryShortHeader, MetaData, MessageData, MessageDefinition, BaseField,
     Framer, Filter, Decoder, DecoderException, Commander, Parser, FileParser,
     RangeDecompressor, RxConfigHandler,
-    Logging, LogLevel,
     messages, enums, throw_exception_from_status,
     EnumField, EnumDataType,
     _internal

--- a/python/novatel_edie_files/__init__.py
+++ b/python/novatel_edie_files/__init__.py
@@ -38,6 +38,7 @@ from .bindings import (
     BufferFullException, BufferEmptyException, StreamEmptyException, UnsupportedException,
     MalformedInputException, DecompressionFailureException, JsonDbReaderException,
     string_to_encode_format, pretty_version,
+    enable_internal_logging, disable_internal_logging,
     UnknownBytes, Header, Field, UnknownMessage, Message,
     MessageDatabase, get_default_database,
     Oem4BinaryHeader, Oem4BinaryShortHeader, MetaData, MessageData, MessageDefinition, BaseField,

--- a/python/test/test_command_encode.py
+++ b/python/test/test_command_encode.py
@@ -41,19 +41,6 @@ def commander():
     return ne.Commander()
 
 # -------------------------------------------------------------------------------------------------------
-# Logger Command Encoding Unit Tests
-# -------------------------------------------------------------------------------------------------------
-@pytest.mark.skip(reason="Logging is still under development")
-def test_logger():
-    name = "novatel_commander"
-    level = ne.LogLevel.OFF
-    logger = ne.Commander().logger
-    logger.set_level(level)
-    assert logger.name == name
-    assert logger.level == level
-    assert ne.Logging.get(name) is not None
-
-# -------------------------------------------------------------------------------------------------------
 # ASCII Command Encoding Unit Tests
 # -------------------------------------------------------------------------------------------------------
 def test_command_encode_ascii_configcode(commander):

--- a/python/test/test_decode_encode.py
+++ b/python/test/test_decode_encode.py
@@ -33,10 +33,13 @@ from collections import namedtuple
 import novatel_edie as ne
 from novatel_edie import MessageData
 from novatel_edie.enums import SolStatus, SolType, Datum
+from novatel_edie import ENCODE_FORMAT
+from novatel_edie.messages import BESTPOS, GLOEPHEMERIS
+
 import pytest
-from novatel_edie import STATUS, ENCODE_FORMAT
-from novatel_edie.messages import *
 from pytest import approx
+
+# pylint: disable=redefined-outer-name
 
 
 # -------------------------------------------------------------------------------------------------------
@@ -246,34 +249,6 @@ def compare_message_data(test_md: ne.MessageData, expected_md: ExpectedMessageDa
         print("MessageData.body contents do not match")
         result = False
     return result
-
-
-# -------------------------------------------------------------------------------------------------------
-# Logger Decode/Encode Unit Tests
-# -------------------------------------------------------------------------------------------------------
-def test_decoder_loggers():
-    level = ne.LogLevel.OFF
-    decoder = ne.Decoder()
-    header_logger = decoder.header_logger
-    message_logger = decoder.message_logger
-    header_logger.set_level(level)
-    message_logger.set_level(level)
-    assert header_logger.name == 'novatel_header_decoder'
-    assert header_logger.level == level
-    assert message_logger.name == 'message_decoder'
-    assert message_logger.level == level
-
-    assert ne.Logging.get('novatel_header_decoder') is not None
-    assert ne.Logging.get('message_decoder') is not None
-
-@pytest.mark.skip(reason="Logging is still under development")
-def test_encoder_logger():
-    level = ne.LogLevel.OFF
-    logger.set_level(level)
-    assert logger.name == 'encoder'
-    assert logger.level == level
-    assert ne.Logging.get('encoder') is not None
-
 
 # -------------------------------------------------------------------------------------------------------
 # ASCII Log Decode/Encode Unit Tests

--- a/python/test/test_file_parser.py
+++ b/python/test/test_file_parser.py
@@ -42,18 +42,6 @@ def fp(test_gps_file):
 def test_gps_file(decoders_test_resources):
     return decoders_test_resources / "BESTUTMBIN.GPS"
 
-@pytest.mark.skip(reason="Logging is still under development")
-def test_logger(test_gps_file):
-    # FileParser logger
-    level = ne.LogLevel.OFF
-    file_parser = ne.FileParser(test_gps_file)
-    logger = file_parser.logger
-    logger.set_level(level)
-    assert logger.name == "novatel_file_parser"
-    assert logger.level == level
-    # Parser logger
-    file_parser.enable_framer_decoder_logging(level, "novatel_parser.log")
-
 
 @pytest.mark.skip(reason="Slow and redundant")
 def test_fileparser_instantiation(json_db, json_db_path):
@@ -79,7 +67,6 @@ def test_unknown_bytes(fp):
 
 def test_parse_file_with_filter(fp):
     fp.filter = ne.Filter()
-    fp.filter.logger.set_level(ne.LogLevel.DEBUG)
     msgs = []
     while True:
         try:
@@ -99,7 +86,6 @@ def test_parse_file_with_filter(fp):
 
 def test_file_parser_iterator(fp):
     fp.filter = ne.Filter()
-    fp.filter.logger.set_level(ne.LogLevel.DEBUG)
     msgs = [msg for msg in fp if isinstance(msg, ne.Message)]
     assert len(msgs) == 2
 

--- a/python/test/test_filter.py
+++ b/python/test/test_filter.py
@@ -54,16 +54,6 @@ def TestFilter(filter, decoder, message):
       pass
    return filter.do_filtering(meta_data)
 
-@pytest.mark.skip(reason="Logging is still under development")
-def test_logger():
-   name = "novatel_filter"
-   level = ne.LogLevel.OFF
-   logger = ne.Filter().logger
-   logger.set_level(level)
-   assert logger.name == name
-   assert logger.level == level
-   assert ne.Logging.get(name) is not None
-
 def test_none(filter, decoder):
    log = "#BESTPOSA,COM1,0,8.0,FINESTEERING,2180,313698.000,024000a0,cdba,32768;SOL_COMPUTED,SINGLE,51.15045046450,-114.03068725072,1097.2706,-17.0000,WGS84,1.3811,1.1629,3.1178,\"\",0.000,0.000,24,22,22,0,00,02,11,11*c64c3d4a\r\n"
    assert TestFilter(filter, decoder, log)

--- a/python/test/test_framer.py
+++ b/python/test/test_framer.py
@@ -91,20 +91,6 @@ def compare_metadata(test_md, expected_md, ignore_length=False):
 
 
 # -------------------------------------------------------------------------------------------------------
-# Logger Framer Unit Tests
-#  -------------------------------------------------------------------------------------------------------
-@pytest.mark.skip(reason="Logging is still under development")
-def test_logger():
-    name = "novatel_framer"
-    level = ne.LogLevel.OFF
-    logger = ne.Framer().logger
-    logger.set_level(level)
-    assert logger.name == name
-    assert logger.level == level
-    assert ne.Logging.get(name) is not None
-
-
-# -------------------------------------------------------------------------------------------------------
 # ASCII Framer Unit Tests
 # -------------------------------------------------------------------------------------------------------
 def test_ascii_complete(helper):

--- a/python/test/test_logging.py
+++ b/python/test/test_logging.py
@@ -55,7 +55,7 @@ def test_example_log(logger_tester, caplog):
     assert record.name == 'novatel_edie.logger_tester'
     assert record.filename == 'logger_tester.cpp'
     assert isinstance(record.lineno, int)
-    assert record.funcName == 'PyLoggerTester::LogInfo'
+    assert record.funcName.endswith('LogInfo') # Namespace may also be present
 
 
 @pytest.mark.parametrize('config_point', [

--- a/python/test/test_logging.py
+++ b/python/test/test_logging.py
@@ -1,0 +1,76 @@
+################################################################################
+#
+# COPYRIGHT NovAtel Inc, 2022. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+#                            DESCRIPTION
+#
+# \brief Unit tests for Logging.
+################################################################################
+
+import logging
+
+import pytest
+
+from novatel_edie import _internal
+
+LOG_LEVELS = [
+    logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL
+]
+
+@pytest.fixture(scope='function')
+def logger_tester():
+    tester = _internal.LoggerTester()
+    # Reset the log configuration to a default state
+    logging.getLogger().setLevel(logging.DEBUG)
+    logging.getLogger('novatel_edie').setLevel(logging.NOTSET)
+    logging.getLogger('novatel_edie.logger_tester').setLevel(logging.NOTSET)
+    return tester
+
+def test_example_log(logger_tester, caplog):
+    # Act
+    logger_tester.LogInfo('Info message')
+    # Assert
+    record = caplog.records[0]
+    assert record.levelno == logging.INFO
+    assert record.message == 'Info message'
+    assert record.name == 'novatel_edie.logger_tester'
+    assert record.filename == 'logger_tester.cpp'
+    assert isinstance(record.lineno, int)
+    assert record.funcName == 'PyLoggerTester::LogInfo'
+
+
+@pytest.mark.parametrize('config_point', [
+    'root', 'novatel_edie', 'novatel_edie.logger_tester'])
+@pytest.mark.parametrize('log_level', LOG_LEVELS)
+def test_log_level_config(log_level, config_point, logger_tester, caplog):
+    """Tests that the correct messages are logged."""
+    # Arrange
+    logging.getLogger(config_point).setLevel(log_level)
+    exp_log_levels = [level for level in LOG_LEVELS if level >= log_level]
+    # Act
+    logger_tester.LogDebug('Debug message')
+    logger_tester.LogInfo('Info message')
+    logger_tester.LogWarn('Warn message')
+    logger_tester.LogError('Error message')
+    logger_tester.LogCritical('Critical message')
+    # Assert
+    assert [rec.levelno for rec in caplog.records] == exp_log_levels

--- a/python/test/test_logging.py
+++ b/python/test/test_logging.py
@@ -121,3 +121,23 @@ def test_toggle_internal_logging(logger_tester, caplog):
     logger_tester.LogInfo('Log message')
     # Assert
     assert [record.message for record in caplog.records] == ['Log message']
+
+@pytest.mark.parametrize('logger_name', ['root', 'novatel_edie', 'novatel_edie.logger_tester'])
+@pytest.mark.parametrize('func_input, exp_result', [
+    ('INVALID', ValueError), ('DEBUG', logging.DEBUG), ('INFO', logging.INFO),
+    ('WARNING', logging.WARNING), ('WARN', logging.WARN), ('ERROR', logging.ERROR),
+    ('CRITICAL', logging.CRITICAL), ('NOTSET', logging.NOTSET),
+    (32.31, TypeError), ((logging.ERROR, 'ERROR'), TypeError)
+])
+def test_set_level(func_input, logger_name, exp_result, logger_tester):
+    """Tests default behavior of setLevel is not impacted by update hook."""
+    # Arrange
+    func_input = (func_input,) if not isinstance(func_input, tuple) else func_input
+    logger = logging.getLogger(logger_name)
+    # Act and Assert
+    if isinstance(exp_result, type) and issubclass(exp_result, Exception):
+        with pytest.raises(exp_result):
+            logger.setLevel(*func_input)
+    else:
+        logger.setLevel(*func_input)
+        assert logger.level == exp_result

--- a/python/test/test_logging.py
+++ b/python/test/test_logging.py
@@ -30,7 +30,7 @@ import logging
 
 import pytest
 
-from novatel_edie import _internal
+from novatel_edie import _internal, enable_internal_logging, disable_internal_logging
 
 LOG_LEVELS = [
     logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL
@@ -40,6 +40,7 @@ LOG_LEVELS = [
 def logger_tester():
     tester = _internal.LoggerTester()
     # Reset the log configuration to a default state
+    enable_internal_logging()
     logging.getLogger().setLevel(logging.DEBUG)
     logging.getLogger('novatel_edie').setLevel(logging.NOTSET)
     logging.getLogger('novatel_edie.logger_tester').setLevel(logging.NOTSET)
@@ -57,6 +58,14 @@ def test_example_log(logger_tester, caplog):
     assert isinstance(record.lineno, int)
     assert record.funcName.endswith('LogInfo') # Namespace may also be present
 
+def test_toggle_internal_logging(logger_tester, caplog):
+    # Act
+    disable_internal_logging()
+    logger_tester.LogInfo('No log message')
+    enable_internal_logging()
+    logger_tester.LogInfo('Log message')
+    # Assert
+    assert [record.message for record in caplog.records] == ['Log message']
 
 @pytest.mark.parametrize('config_point', [
     'root', 'novatel_edie', 'novatel_edie.logger_tester'])

--- a/python/test/test_logging.py
+++ b/python/test/test_logging.py
@@ -32,12 +32,15 @@ import pytest
 
 from novatel_edie import _internal, enable_internal_logging, disable_internal_logging
 
+# pylint: disable=redefined-outer-name
+
 LOG_LEVELS = [
     logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL
 ]
 
 @pytest.fixture(scope='function')
 def logger_tester():
+    """A helper object for logging within C++ code."""
     tester = _internal.LoggerTester()
     # Reset the log configuration to a default state
     enable_internal_logging()
@@ -47,6 +50,7 @@ def logger_tester():
     return tester
 
 def test_example_log(logger_tester, caplog):
+    """Tests that an example log message is logged correctly."""
     # Act
     logger_tester.LogInfo('Info message')
     # Assert
@@ -59,6 +63,7 @@ def test_example_log(logger_tester, caplog):
     assert record.funcName.endswith('LogInfo') # Namespace may also be present
 
 def test_toggle_internal_logging(logger_tester, caplog):
+    """Tests turning internal logging off and on has the intended effect."""
     # Act
     disable_internal_logging()
     logger_tester.LogInfo('No log message')

--- a/python/test/test_parser.py
+++ b/python/test/test_parser.py
@@ -41,18 +41,6 @@ def parser():
 def test_gps_file(decoders_test_resources):
     return decoders_test_resources / "BESTUTMBIN.GPS"
 
-@pytest.mark.skip(reason="Logging is still under development")
-def test_logger():
-    # Parser logger
-    level = ne.LogLevel.OFF
-    parser = ne.Parser()
-    logger = parser.logger
-    logger.set_level(level)
-    assert logger.name == "novatel_parser"
-    assert logger.level == level
-    # Parser logger
-    parser.enable_framer_decoder_logging(level, "novatel_parser.log")
-
 
 @pytest.mark.skip(reason="Slow and redundant")
 def test_parser_instantiation(json_db, json_db_path):
@@ -78,7 +66,6 @@ def test_unknown_bytes(parser):
 
 def test_parse_file_with_filter(parser, test_gps_file):
     parser.filter = ne.Filter()
-    parser.filter.logger.set_level(ne.LogLevel.DEBUG)
     msgs = []
     with test_gps_file.open("rb") as f:
         while chunk := f.read(32):

--- a/python/test/test_rangecmp.py
+++ b/python/test/test_rangecmp.py
@@ -61,19 +61,6 @@ RANGECMP4_MSG_ID = 2050
 RANGECMP5_MSG_ID = 2537
 
 # -------------------------------------------------------------------------------------------------------
-# Logging Framer Unit Tests
-# -------------------------------------------------------------------------------------------------------
-@pytest.mark.skip(reason="Logging is still under development")
-def test_logger():
-    name = "range_decompressor"
-    level = ne.LogLevel.OFF
-    logger = ne.RangeDecompressor().logger
-    logger.set_level(level)
-    assert logger.name == name
-    assert logger.level == level
-    assert ne.Logging.get(name) is not None
-
-# -------------------------------------------------------------------------------------------------------
 # Channel Tracking Status structure unit tests
 # -------------------------------------------------------------------------------------------------------
 def test_channel_tracking_status_word_1():

--- a/python/test/test_rxconfig.py
+++ b/python/test/test_rxconfig.py
@@ -55,19 +55,6 @@ def TestSameFormatCompare(rx_config_handler, format_, expected_rx_config_message
     return True
 
 # -------------------------------------------------------------------------------------------------------
-# Logging Framer Unit Tests
-# -------------------------------------------------------------------------------------------------------
-@pytest.mark.skip(reason="Logging is still under development")
-def test_logger():
-    name = "rxconfig_handler"
-    level = ne.LogLevel.OFF
-    logger = ne.RxConfigHandler().logger
-    logger.set_level(level)
-    assert logger.name == name
-    assert logger.level == level
-    assert ne.Logging.get(name) is not None
-
-# -------------------------------------------------------------------------------------------------------
 # Round-trip unit tests.
 # -------------------------------------------------------------------------------------------------------
 def test_rxconfig_roundtrip_ascii(rx_config_handler):

--- a/src/common/src/logger.cpp
+++ b/src/common/src/logger.cpp
@@ -1,0 +1,11 @@
+#include "novatel_edie/common/logger.hpp"
+
+
+LoggerManager::~LoggerManager() {};
+
+std::unique_ptr<LoggerManager> pclLoggerManager = std::make_unique<CPPLoggerManager>();
+
+CPPLoggerManager* GetLoggerManager() {
+    CPPLoggerManager* pclManager = dynamic_cast<CPPLoggerManager*>(pclLoggerManager.get());
+    return pclManager;
+}

--- a/src/common/src/logger.cpp
+++ b/src/common/src/logger.cpp
@@ -6,6 +6,5 @@ std::unique_ptr<LoggerManager> pclLoggerManager = std::make_unique<CPPLoggerMana
 
 CPPLoggerManager* GetLoggerManager()
 {
-    CPPLoggerManager* pclManager = dynamic_cast<CPPLoggerManager*>(pclLoggerManager.get());
-    return pclManager;
+    return dynamic_cast<CPPLoggerManager*>(pclLoggerManager.get());
 }

--- a/src/common/src/logger.cpp
+++ b/src/common/src/logger.cpp
@@ -1,7 +1,5 @@
 #include "novatel_edie/common/logger.hpp"
 
-LoggerManager::~LoggerManager() = default;
-
 std::unique_ptr<LoggerManager> pclLoggerManager = std::make_unique<CPPLoggerManager>();
 
 CPPLoggerManager* GetLoggerManager() { return dynamic_cast<CPPLoggerManager*>(pclLoggerManager.get()); }

--- a/src/common/src/logger.cpp
+++ b/src/common/src/logger.cpp
@@ -4,7 +4,4 @@ LoggerManager::~LoggerManager() = default;
 
 std::unique_ptr<LoggerManager> pclLoggerManager = std::make_unique<CPPLoggerManager>();
 
-CPPLoggerManager* GetLoggerManager()
-{
-    return dynamic_cast<CPPLoggerManager*>(pclLoggerManager.get());
-}
+CPPLoggerManager* GetLoggerManager() { return dynamic_cast<CPPLoggerManager*>(pclLoggerManager.get()); }

--- a/src/common/src/logger.cpp
+++ b/src/common/src/logger.cpp
@@ -1,11 +1,11 @@
 #include "novatel_edie/common/logger.hpp"
 
-
-LoggerManager::~LoggerManager() {};
+LoggerManager::~LoggerManager() = default;
 
 std::unique_ptr<LoggerManager> pclLoggerManager = std::make_unique<CPPLoggerManager>();
 
-CPPLoggerManager* GetLoggerManager() {
+CPPLoggerManager* GetLoggerManager()
+{
     CPPLoggerManager* pclManager = dynamic_cast<CPPLoggerManager*>(pclLoggerManager.get());
     return pclManager;
 }

--- a/src/common/src/logger.cpp
+++ b/src/common/src/logger.cpp
@@ -1,5 +1,7 @@
 #include "novatel_edie/common/logger.hpp"
 
+LoggerManager::~LoggerManager() = default;
+
 std::unique_ptr<LoggerManager> pclLoggerManager = std::make_unique<CPPLoggerManager>();
 
 CPPLoggerManager* GetLoggerManager() { return dynamic_cast<CPPLoggerManager*>(pclLoggerManager.get()); }

--- a/src/common/test/main.cpp
+++ b/src/common/test/main.cpp
@@ -31,6 +31,7 @@
 int main(int argc, char** argv)
 {
     testing::InitGoogleTest(&argc, argv);
-    Logger::InitLogger();
+    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
+    pclMyLoggerManager->InitLogger();
     return RUN_ALL_TESTS();
 }

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -727,7 +727,7 @@ MessageDecoderBase::Decode(const unsigned char* pucMessage_, std::vector<FieldCo
 
         if (vMsgDef == nullptr)
         {
-            pclMyLogger->warn("No log definition for ID {}", stMetaData_.usMessageId);
+            SPDLOG_LOGGER_INFO(pclMyLogger, "No log definition for ID {}", stMetaData_.usMessageId);
             return STATUS::NO_DEFINITION;
         }
 

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -295,6 +295,11 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
                                  std::vector<FieldContainer>& vIntermediateFormat_, const uint32_t uiMessageLength_) const
 {
     const unsigned char* pucTempStart = *ppucLogBuf_;
+    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoding started");
+    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoding started");
+    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoding started");
+    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoding started");
+    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoding started");
 
     for (const auto& field : vMsgDefFields_)
     {
@@ -386,6 +391,7 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
 
         if (*ppucLogBuf_ - pucTempStart >= static_cast<int32_t>(uiMessageLength_)) { return STATUS::SUCCESS; }
     }
+    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoded successfully");
     SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoded successfully");
     return STATUS::SUCCESS;
 }

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -295,11 +295,6 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
                                  std::vector<FieldContainer>& vIntermediateFormat_, const uint32_t uiMessageLength_) const
 {
     const unsigned char* pucTempStart = *ppucLogBuf_;
-    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoding started");
-    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoding started");
-    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoding started");
-    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoding started");
-    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoding started");
 
     for (const auto& field : vMsgDefFields_)
     {
@@ -391,8 +386,6 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
 
         if (*ppucLogBuf_ - pucTempStart >= static_cast<int32_t>(uiMessageLength_)) { return STATUS::SUCCESS; }
     }
-    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoded successfully");
-    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoded successfully");
     return STATUS::SUCCESS;
 }
 

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -386,7 +386,7 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
 
         if (*ppucLogBuf_ - pucTempStart >= static_cast<int32_t>(uiMessageLength_)) { return STATUS::SUCCESS; }
     }
-
+    SPDLOG_LOGGER_DEBUG(pclMyLogger, "Binary decoded successfully");
     return STATUS::SUCCESS;
 }
 

--- a/src/decoders/common/test/main.cpp
+++ b/src/decoders/common/test/main.cpp
@@ -34,7 +34,8 @@
 int main(int argc, char** argv)
 {
     testing::InitGoogleTest(&argc, argv);
-    Logger::InitLogger();
+    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
+    pclMyLoggerManager->InitLogger();
 
     std::filesystem::path pathSourceFile = __FILE__;
     std::filesystem::path pathRepoDir = pathSourceFile.parent_path().parent_path().parent_path().parent_path().parent_path();

--- a/src/decoders/common/test/message_decoder_unit_test.cpp
+++ b/src/decoders/common/test/message_decoder_unit_test.cpp
@@ -178,7 +178,7 @@ class MessageDecoderTypesTest : public ::testing::Test
 
     void TearDown() override
     {
-        Logger::Shutdown();
+        GetLoggerManager()->Shutdown();
         MsgDefFields.clear();
     }
 

--- a/src/decoders/oem/src/file_parser.cpp
+++ b/src/decoders/oem/src/file_parser.cpp
@@ -37,7 +37,7 @@ FileParser::FileParser(const std::filesystem::path& sDbPath_) : clMyParser(Parse
 // -------------------------------------------------------------------------------------------------------
 FileParser::FileParser(const MessageDatabase::Ptr& pclMessageDb_) : clMyParser(Parser(pclMessageDb_))
 {
-    pclMyLogger = Logger::RegisterLogger("novatel_file_parser");
+    pclMyLogger = pclLoggerManager->RegisterLogger("novatel_file_parser");
     pclMyLogger->debug("FileParser initialized");
 }
 

--- a/src/decoders/oem/src/parser.cpp
+++ b/src/decoders/oem/src/parser.cpp
@@ -74,21 +74,6 @@ void Parser::LoadJsonDb(MessageDatabase::Ptr pclMessageDb_)
 }
 
 // -------------------------------------------------------------------------------------------------------
-void Parser::EnableFramerDecoderLogging(spdlog::level::level_enum eLevel_, const std::string& sFileName_)
-{
-    clMyFramer.SetLoggerLevel(eLevel_);
-    clMyHeaderDecoder.SetLoggerLevel(eLevel_);
-    clMyMessageDecoder.SetLoggerLevel(eLevel_);
-
-    Logger::AddConsoleLogging(clMyFramer.GetLogger());
-    Logger::AddConsoleLogging(clMyHeaderDecoder.GetLogger());
-    Logger::AddConsoleLogging(clMyMessageDecoder.GetLogger());
-    Logger::AddRotatingFileLogger(clMyFramer.GetLogger(), eLevel_, sFileName_);
-    Logger::AddRotatingFileLogger(clMyHeaderDecoder.GetLogger(), eLevel_, sFileName_);
-    Logger::AddRotatingFileLogger(clMyMessageDecoder.GetLogger(), eLevel_, sFileName_);
-}
-
-// -------------------------------------------------------------------------------------------------------
 MessageDatabase::ConstPtr Parser::MessageDb() const { return std::const_pointer_cast<const MessageDatabase>(pclMyMessageDb); }
 
 // -------------------------------------------------------------------------------------------------------

--- a/src/decoders/oem/src/parser.cpp
+++ b/src/decoders/oem/src/parser.cpp
@@ -74,6 +74,22 @@ void Parser::LoadJsonDb(MessageDatabase::Ptr pclMessageDb_)
 }
 
 // -------------------------------------------------------------------------------------------------------
+void Parser::EnableFramerDecoderLogging(spdlog::level::level_enum eLevel_, const std::string& sFileName_)
+{
+    clMyFramer.SetLoggerLevel(eLevel_);
+    clMyHeaderDecoder.SetLoggerLevel(eLevel_);
+    clMyMessageDecoder.SetLoggerLevel(eLevel_);
+
+    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
+    pclMyLoggerManager->AddConsoleLogging(clMyFramer.GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clMyHeaderDecoder.GetLogger());
+    pclMyLoggerManager->AddConsoleLogging(clMyMessageDecoder.GetLogger());
+    pclMyLoggerManager->AddRotatingFileLogger(clMyFramer.GetLogger(), eLevel_, sFileName_);
+    pclMyLoggerManager->AddRotatingFileLogger(clMyHeaderDecoder.GetLogger(), eLevel_, sFileName_);
+    pclMyLoggerManager->AddRotatingFileLogger(clMyMessageDecoder.GetLogger(), eLevel_, sFileName_);
+}
+
+// -------------------------------------------------------------------------------------------------------
 MessageDatabase::ConstPtr Parser::MessageDb() const { return std::const_pointer_cast<const MessageDatabase>(pclMyMessageDb); }
 
 // -------------------------------------------------------------------------------------------------------

--- a/src/decoders/oem/src/rangecmp/range_decompressor.cpp
+++ b/src/decoders/oem/src/rangecmp/range_decompressor.cpp
@@ -35,7 +35,7 @@ using namespace novatel::edie::oem;
 RangeDecompressor::RangeDecompressor(MessageDatabase::Ptr pclJsonDb_)
     : clMyHeaderDecoder(pclJsonDb_), clMyMessageDecoder(pclJsonDb_), clMyEncoder(pclJsonDb_)
 {
-    pclMyLogger = Logger::RegisterLogger("range_decompressor");
+    pclMyLogger = pclLoggerManager->RegisterLogger("range_decompressor");
     pclMyLogger->debug("RangeDecompressor initializing...");
 
     if (pclJsonDb_ != nullptr) { LoadJsonDb(pclJsonDb_); }

--- a/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
+++ b/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
@@ -35,7 +35,7 @@ RxConfigHandler::RxConfigHandler(const MessageDatabase::Ptr& pclMessageDb_)
       pcMyFrameBuffer(std::make_unique<unsigned char[]>(uiInternalBufferSize)),
       pcMyEncodeBuffer(std::make_unique<unsigned char[]>(uiInternalBufferSize))
 {
-    pclMyLogger = Logger::RegisterLogger("rxconfig_handler");
+    pclMyLogger = pclLoggerManager->RegisterLogger("rxconfig_handler");
 
     pclMyLogger->debug("RxConfigHandler initializing...");
 

--- a/src/decoders/oem/test/main.cpp
+++ b/src/decoders/oem/test/main.cpp
@@ -34,7 +34,8 @@
 int main(int argc, char** argv)
 {
     testing::InitGoogleTest(&argc, argv);
-    Logger::InitLogger();
+    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
+    pclMyLoggerManager->InitLogger();
 
     std::filesystem::path pathSourceFile = __FILE__;
     std::filesystem::path pathRepoDir = pathSourceFile.parent_path().parent_path().parent_path().parent_path().parent_path();

--- a/src/decoders/oem/test/main.cpp
+++ b/src/decoders/oem/test/main.cpp
@@ -34,8 +34,7 @@
 int main(int argc, char** argv)
 {
     testing::InitGoogleTest(&argc, argv);
-    CPPLoggerManager* pclMyLoggerManager = GetLoggerManager();
-    pclMyLoggerManager->InitLogger();
+    LOGGER_MANAGER->InitLogger();
 
     std::filesystem::path pathSourceFile = __FILE__;
     std::filesystem::path pathRepoDir = pathSourceFile.parent_path().parent_path().parent_path().parent_path().parent_path();

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -62,7 +62,7 @@ class FramerTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
+    static void TearDownTestSuite() { LOGGER_MANAGER->Shutdown(); }
 
     // Per-test setup
     void SetUp() override { FlushFramer(); }
@@ -943,7 +943,7 @@ class DecodeEncodeTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
+    static void TearDownTestSuite() { LOGGER_MANAGER->Shutdown(); }
 
   public:
     using logChecker = void (*)(char*, char*);
@@ -2162,7 +2162,7 @@ class CommandEncodeTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
+    static void TearDownTestSuite() { LOGGER_MANAGER->Shutdown(); }
 
   public:
     static STATUS TestCommandConversion(std::string sCommandToEncode_, char* pcEncodedCommandBuffer_, uint32_t uiEncodedCommandBufferSize_, ENCODE_FORMAT eFormat_)
@@ -2296,7 +2296,7 @@ class FilterTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
+    static void TearDownTestSuite() { LOGGER_MANAGER->Shutdown(); }
 
     void SetUp() override { pclMyFilter->ClearFilters(); }
 
@@ -2693,7 +2693,7 @@ class FileParserTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
+    static void TearDownTestSuite() { LOGGER_MANAGER->Shutdown(); }
 };
 
 std::unique_ptr<FileParser> FileParserTest::pclFp = nullptr;
@@ -2832,7 +2832,7 @@ class ParserTest : public ::testing::Test
         }
     }
 
-    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
+    static void TearDownTestSuite() { LOGGER_MANAGER->Shutdown(); }
 };
 
 std::unique_ptr<Parser> ParserTest::pclParser = nullptr;
@@ -3034,7 +3034,7 @@ class NovatelTypesTest : public ::testing::Test
         }
     }
 
-    void TearDown() override { GetLoggerManager()->Shutdown(); }
+    void TearDown() override { LOGGER_MANAGER->Shutdown(); }
 
     void CreateEnumField(std::string_view strName, std::string_view strDescription, int32_t iValue)
     {

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -62,7 +62,7 @@ class FramerTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { Logger::Shutdown(); }
+    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
 
     // Per-test setup
     void SetUp() override { FlushFramer(); }
@@ -943,7 +943,7 @@ class DecodeEncodeTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { Logger::Shutdown(); }
+    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
 
   public:
     using logChecker = void (*)(char*, char*);
@@ -2162,7 +2162,7 @@ class CommandEncodeTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { Logger::Shutdown(); }
+    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
 
   public:
     static STATUS TestCommandConversion(std::string sCommandToEncode_, char* pcEncodedCommandBuffer_, uint32_t uiEncodedCommandBufferSize_, ENCODE_FORMAT eFormat_)
@@ -2296,7 +2296,7 @@ class FilterTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { Logger::Shutdown(); }
+    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
 
     void SetUp() override { pclMyFilter->ClearFilters(); }
 
@@ -2693,7 +2693,7 @@ class FileParserTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { Logger::Shutdown(); }
+    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
 };
 
 std::unique_ptr<FileParser> FileParserTest::pclFp = nullptr;
@@ -2710,7 +2710,7 @@ TEST_F(FileParserTest, LOGGER)
 
     // Parser logger
     ASSERT_NE(spdlog::get("novatel_parser"), nullptr);
-    ASSERT_NO_THROW(pclFp->EnableFramerDecoderLogging(eLevel, "novatel_parser.log"));
+    //ASSERT_NO_THROW(pclFp->EnableFramerDecoderLogging(eLevel, "novatel_parser.log"));
 }
 
 TEST_F(FileParserTest, FILEPARSER_INSTANTIATION)
@@ -2832,7 +2832,7 @@ class ParserTest : public ::testing::Test
         }
     }
 
-    static void TearDownTestSuite() { Logger::Shutdown(); }
+    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
 };
 
 std::unique_ptr<Parser> ParserTest::pclParser = nullptr;
@@ -3034,7 +3034,7 @@ class NovatelTypesTest : public ::testing::Test
         }
     }
 
-    void TearDown() override { Logger::Shutdown(); }
+    void TearDown() override { GetLoggerManager()->Shutdown(); }
 
     void CreateEnumField(std::string_view strName, std::string_view strDescription, int32_t iValue)
     {

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -2710,7 +2710,7 @@ TEST_F(FileParserTest, LOGGER)
 
     // Parser logger
     ASSERT_NE(spdlog::get("novatel_parser"), nullptr);
-    //ASSERT_NO_THROW(pclFp->EnableFramerDecoderLogging(eLevel, "novatel_parser.log"));
+    ASSERT_NO_THROW(pclFp->EnableFramerDecoderLogging(eLevel, "novatel_parser.log"));
 }
 
 TEST_F(FileParserTest, FILEPARSER_INSTANTIATION)

--- a/src/decoders/oem/test/proprietary_test.cpp
+++ b/src/decoders/oem/test/proprietary_test.cpp
@@ -50,7 +50,7 @@ class ProprietaryFramerTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { Logger::Shutdown(); }
+    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
 
     // Per-test setup
     void SetUp() override { FlushFramer(); }

--- a/src/decoders/oem/test/proprietary_test.cpp
+++ b/src/decoders/oem/test/proprietary_test.cpp
@@ -50,7 +50,7 @@ class ProprietaryFramerTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
+    static void TearDownTestSuite() { LOGGER_MANAGER->Shutdown(); }
 
     // Per-test setup
     void SetUp() override { FlushFramer(); }

--- a/src/decoders/oem/test/range_cmp_test.cpp
+++ b/src/decoders/oem/test/range_cmp_test.cpp
@@ -46,7 +46,7 @@ class RangeCmpTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
+    static void TearDownTestSuite() { LOGGER_MANAGER->Shutdown(); }
 
     void SetUp() override { pclMyRangeDecompressor->Reset(); }
 

--- a/src/decoders/oem/test/range_cmp_test.cpp
+++ b/src/decoders/oem/test/range_cmp_test.cpp
@@ -46,7 +46,7 @@ class RangeCmpTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { Logger::Shutdown(); }
+    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
 
     void SetUp() override { pclMyRangeDecompressor->Reset(); }
 

--- a/src/decoders/oem/test/rx_config_test.cpp
+++ b/src/decoders/oem/test/rx_config_test.cpp
@@ -51,7 +51,7 @@ class RxConfigTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { Logger::Shutdown(); }
+    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
 
     // Per-test setup
     void SetUp() override { pclMyRxConfigHandler->Flush(); }

--- a/src/decoders/oem/test/rx_config_test.cpp
+++ b/src/decoders/oem/test/rx_config_test.cpp
@@ -51,7 +51,7 @@ class RxConfigTest : public ::testing::Test
     }
 
     // Per-test-suite teardown
-    static void TearDownTestSuite() { GetLoggerManager()->Shutdown(); }
+    static void TearDownTestSuite() { LOGGER_MANAGER->Shutdown(); }
 
     // Per-test setup
     void SetUp() override { pclMyRxConfigHandler->Flush(); }


### PR DESCRIPTION
Updated logging mechanism to be fully manageable on Python side via the standard library `logging` module.

On the C++ side I refactored the `Logger` static class into a `LoggingManager` singleton class. At runtime the `LoggingManager` singleton instance `pclLoggerManager` will be either a `CPPLoggerManager` or a `PyLoggerManager` depending on whether the Python API has been initialized. Classes register their loggers using the `pclLoggerManager` singleton to allow polymorphic behavior.

```mermaid
classDiagram
    class LoggerManager{
        +RegisterLogger(std::string& name)
        +Shutdown()
    }

    class CPPLoggerManager {
    }

    class PyLoggerManager {
    }

   class Logger {
   }

    LoggerManager<|-- CPPLoggerManager
    LoggerManager<|-- PyLoggerManager
    Logger ..> CPPLoggerManager : wraps
```


C++ users can interact with the `LoggingManager` by using the `GetLoggerManager` function to receive a pointer to the the global manager as a `CPPLoggerManager` instance, or they can do this indirectly using the old `Logger` interface which is remapped to use `GetLoggerManager` under the hood.

```
GetLoggerManager->InitLogger();
or
Logger::InitLogger();
```

Python users can simply access each logger with the `logging.getLogger` function and configure them as they would a regular Python logger. 
```
ne_logger = logging.getLogger('novatel_edie')
decoder_logger = logging.getLogger('novatel_edie.decoder')

ne_logger.setLevel(logging.INFO)
decoder_logger.setLevel(logging.WARNING)
```
Under the hood this is achieved by setting up all C++ spdloggers with a custom sink which sends messages to a corresponding Python logger. 

```mermaid
classDiagram
    class spdlog_logger {
    }

    class base_sink {
    }

    class python_sink {
        -logger: handle
    }
    spdlog_logger o-- base_sink
    base_sink<|-- python_sink 
```

For performance reasons the code also inserts a callback hook into the `setLevel` method of each Python logger which is associated with a spdlogger, allowing the C++ code to cache the Python logger level and avoid costly calls to check the level on each logging attempt. 
![Untitled-2024-09-05-1007](https://github.com/user-attachments/assets/b89d3398-60d7-4cd7-8212-0b5748d1e373)

Added unit tests included to validate that Python logging interface matches expected behavior.

```
Benchmarking overview for parsing 100k messages:

- Log level too high for anything to be logged
    - With unchanged log attempts: 
        - Old: 3.289s
        - New: 3.119s
    - With additional log per message decoded: 
        - Old: 3.496s
        - New: 3.194s
- Log level allows logging:
    - With unchanged log attempts: 
        - Old: 8.444s
        - New: 6.599s
    - With additional log per message decoded (approximated from 10k messages): 
        - Old: ~700s
        - New: ~400s
```