### PR TITLE
Use default API endpoint

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -45,6 +45,5 @@ jobs:
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://pypi.org/legacy/
           verbose: true
           packages-dir: all_wheels/


### PR DESCRIPTION
Manually specified API endpoint seems to be wrong, switch to just not specifying it so the default will be used.