### PR TITLE
Update Python Wheel Build Versions

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -13,6 +13,6 @@ jobs:
   build-python:
     uses: ./.github/workflows/build_python.yml
     with:
-        python_versions: cp39* cp310* cp311* cp312*
+        python_versions: cp39* cp310* cp311* cp312* cp313*
   build-cpp:
     uses: ./.github/workflows/build_cpp.yml

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -12,5 +12,7 @@ on:
 jobs:
   build-python:
     uses: ./.github/workflows/build_python.yml
+    with:
+        python_versions: cp39* cp310* cp311* cp312*
   build-cpp:
     uses: ./.github/workflows/build_cpp.yml

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -12,7 +12,5 @@ on:
 jobs:
   build-python:
     uses: ./.github/workflows/build_python.yml
-    with:
-        python_versions: cp39* cp310* cp311* cp312* cp313*
   build-cpp:
     uses: ./.github/workflows/build_cpp.yml

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install cibuildwheel
         run: python -m pip install --upgrade cibuildwheel

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -7,7 +7,7 @@ on:
       python_versions:
         description: 'Which versions to build wheels for'
         required: false
-        default: cp39-* cp312-*
+        default: cp39* cp313*
         type: string
 
 

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -7,7 +7,7 @@ on:
       python_versions:
         description: 'Which versions to build wheels for'
         required: false
-        default: cp37-* cp312-*
+        default: cp39-* cp312-*
         type: string
 
 

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -3,6 +3,13 @@ name: Python Build
 
 on:
   workflow_call:
+    inputs:
+      python_versions:
+        description: 'Which versions to build wheels for'
+        required: false
+        default: cp37-* cp312-*
+        type: string
+
 
 jobs:
   build:
@@ -45,7 +52,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS: ${{ matrix.platform[2] }}
-          CIBW_BUILD: cp39* cp312*
+          CIBW_BUILD: ${{ inputs.python_versions }}
           CIBW_SKIP: "*-musllinux*"
 
       - name: Inspect

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     uses: ./.github/workflows/build_python.yml
     with:
-        python_versions: cp37* cp38* cp39* cp10* cp11* cp12*
+        python_versions: cp39* cp10* cp11* cp12*
   publish:
     name: Publish release to PyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     uses: ./.github/workflows/build_python.yml
     with:
-        python_versions: cp39* cp10* cp11* cp12*
+        python_versions: cp39* cp10* cp11* cp12* cp13*
   publish:
     name: Publish release to PyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build_python.yml
+    with:
+        python_versions: cp37* cp38* cp39* cp10* cp11* cp12*
   publish:
     name: Publish release to PyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     uses: ./.github/workflows/build_python.yml
     with:
-        python_versions: cp39* cp10* cp11* cp12* cp13*
+        python_versions: cp39* cp310* cp311* cp312* cp313*
   publish:
     name: Publish release to PyPI
     runs-on: ubuntu-latest


### PR DESCRIPTION
Build the wheel for the oldest supported version `3.9` and newest version `3.13` in most pipelines.

In release pipeline build all supported versions `3.9`, `3.10`, `3.11`, `3.12`, and `3.13`.