### PR TITLE
Improve ascii header tokenization

### DIFF
--- a/include/novatel_edie/decoders/oem/header_decoder.hpp
+++ b/include/novatel_edie/decoders/oem/header_decoder.hpp
@@ -36,9 +36,6 @@
 
 namespace novatel::edie::oem {
 
-
-
-
 //============================================================================
 //! \class HeaderDecoder
 //! \brief Decode framed OEM message headers.

--- a/include/novatel_edie/decoders/oem/header_decoder.hpp
+++ b/include/novatel_edie/decoders/oem/header_decoder.hpp
@@ -51,8 +51,10 @@ class HeaderDecoder
     MessageDefinition stMyResponseDefinition;
 
     // Decode novatel headers
-    template <ASCII_HEADER eField> [[nodiscard]] bool DecodeAsciiHeaderField(IntermediateHeader& stInterHeader_, const char** ppcLogBuf_) const;
-    template <ASCII_HEADER... eFields> [[nodiscard]] bool DecodeAsciiHeaderFields(IntermediateHeader& stInterHeader_, const char** ppcLogBuf_) const;
+    template <const char* delimiter, ASCII_HEADER eField>
+    [[nodiscard]] bool DecodeAsciiHeaderField(IntermediateHeader& stInterHeader_, const char** ppcLogBuf_) const;
+    template <const char* pcDelimiter, ASCII_HEADER... eFields>
+    [[nodiscard]] bool DecodeAsciiHeaderFields(IntermediateHeader& stInterHeader_, const char** ppcLogBuf_) const;
     void DecodeJsonHeader(nlohmann::json clJsonHeader_, IntermediateHeader& stInterHeader_) const;
 
   public:

--- a/include/novatel_edie/decoders/oem/header_decoder.hpp
+++ b/include/novatel_edie/decoders/oem/header_decoder.hpp
@@ -36,6 +36,9 @@
 
 namespace novatel::edie::oem {
 
+
+
+
 //============================================================================
 //! \class HeaderDecoder
 //! \brief Decode framed OEM message headers.
@@ -51,9 +54,9 @@ class HeaderDecoder
     MessageDefinition stMyResponseDefinition;
 
     // Decode novatel headers
-    template <const char* delimiter, ASCII_HEADER eField>
+    template <const char pcDelimiter[], size_t ullDelimiterSize, ASCII_HEADER eField>
     [[nodiscard]] bool DecodeAsciiHeaderField(IntermediateHeader& stInterHeader_, const char** ppcLogBuf_) const;
-    template <const char* pcDelimiter, ASCII_HEADER... eFields>
+    template <const char pcDelimiter[], size_t ullDelimiterSize, ASCII_HEADER... eFields>
     [[nodiscard]] bool DecodeAsciiHeaderFields(IntermediateHeader& stInterHeader_, const char** ppcLogBuf_) const;
     void DecodeJsonHeader(nlohmann::json clJsonHeader_, IntermediateHeader& stInterHeader_) const;
 

--- a/include/novatel_edie/decoders/oem/header_decoder.hpp
+++ b/include/novatel_edie/decoders/oem/header_decoder.hpp
@@ -54,9 +54,9 @@ class HeaderDecoder
     MessageDefinition stMyResponseDefinition;
 
     // Decode novatel headers
-    template <const char pcDelimiter[], size_t ullDelimiterSize, ASCII_HEADER eField>
+    template <const char pcDelimiter[], ASCII_HEADER eField>
     [[nodiscard]] bool DecodeAsciiHeaderField(IntermediateHeader& stInterHeader_, const char** ppcLogBuf_) const;
-    template <const char pcDelimiter[], size_t ullDelimiterSize, ASCII_HEADER... eFields>
+    template <const char pcDelimiter[], ASCII_HEADER... eFields>
     [[nodiscard]] bool DecodeAsciiHeaderFields(IntermediateHeader& stInterHeader_, const char** ppcLogBuf_) const;
     void DecodeJsonHeader(nlohmann::json clJsonHeader_, IntermediateHeader& stInterHeader_) const;
 

--- a/src/decoders/oem/src/header_decoder.cpp
+++ b/src/decoders/oem/src/header_decoder.cpp
@@ -174,13 +174,10 @@ STATUS HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader
     {
     case HEADER_FORMAT::ASCII:
         ++pcTempBuf; // Move the input buffer past the sync char '#'
-        if (!DecodeAsciiHeaderFields<pcAsciiRegDelimiter, ASCII_HEADER::MESSAGE_NAME, ASCII_HEADER::PORT,
-                                     ASCII_HEADER::SEQUENCE, ASCII_HEADER::IDLE_TIME, ASCII_HEADER::TIME_STATUS, ASCII_HEADER::WEEK,
-                                     ASCII_HEADER::SECONDS, ASCII_HEADER::RECEIVER_STATUS, ASCII_HEADER::MSG_DEF_CRC>(stInterHeader_, &pcTempBuf))
-        {
-            return STATUS::FAILURE;
-        }
-        if (!DecodeAsciiHeaderField<pcAsciiFinalDelimiter, ASCII_HEADER::RECEIVER_SW_VERSION>(stInterHeader_, &pcTempBuf))
+        if (!DecodeAsciiHeaderFields<pcAsciiRegDelimiter, ASCII_HEADER::MESSAGE_NAME, ASCII_HEADER::PORT, ASCII_HEADER::SEQUENCE,
+                                     ASCII_HEADER::IDLE_TIME, ASCII_HEADER::TIME_STATUS, ASCII_HEADER::WEEK, ASCII_HEADER::SECONDS,
+                                     ASCII_HEADER::RECEIVER_STATUS, ASCII_HEADER::MSG_DEF_CRC>(stInterHeader_, &pcTempBuf) ||
+            !DecodeAsciiHeaderField<pcAsciiFinalDelimiter, ASCII_HEADER::RECEIVER_SW_VERSION>(stInterHeader_, &pcTempBuf))
         {
             return STATUS::FAILURE;
         }
@@ -190,19 +187,14 @@ STATUS HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader
         ++pcTempBuf; // Move the input buffer past the sync char '<'
         // At this point, we do not know if the format is short or not, but both have a message
         // field
-        if (!DecodeAsciiHeaderField<pcAbbrevAsciiRegDelimiter, ASCII_HEADER::MESSAGE_NAME>(stInterHeader_, &pcTempBuf))
-        {
-            return STATUS::FAILURE;
-        }
+        if (!DecodeAsciiHeaderField<pcAbbrevAsciiRegDelimiter, ASCII_HEADER::MESSAGE_NAME>(stInterHeader_, &pcTempBuf)) { return STATUS::FAILURE; }
         if (DecodeAsciiHeaderField<pcAbbrevAsciiRegDelimiter, ASCII_HEADER::PORT>(stInterHeader_, &pcTempBuf))
         {
             // Port field succeeded, so this is not short format
-            if (!DecodeAsciiHeaderFields<pcAbbrevAsciiRegDelimiter, ASCII_HEADER::SEQUENCE, ASCII_HEADER::IDLE_TIME,
-                                         ASCII_HEADER::TIME_STATUS,
+            if (!DecodeAsciiHeaderFields<pcAbbrevAsciiRegDelimiter, ASCII_HEADER::SEQUENCE, ASCII_HEADER::IDLE_TIME, ASCII_HEADER::TIME_STATUS,
                                          ASCII_HEADER::WEEK, ASCII_HEADER::SECONDS, ASCII_HEADER::RECEIVER_STATUS, ASCII_HEADER::MSG_DEF_CRC>(
                     stInterHeader_, &pcTempBuf) ||
-                !DecodeAsciiHeaderField<pcAbbrevAsciiFinalDelimiter, ASCII_HEADER::RECEIVER_SW_VERSION>(stInterHeader_,
-                                                                                                                                  &pcTempBuf))
+                !DecodeAsciiHeaderField<pcAbbrevAsciiFinalDelimiter, ASCII_HEADER::RECEIVER_SW_VERSION>(stInterHeader_, &pcTempBuf))
             {
                 return STATUS::FAILURE;
             }
@@ -221,8 +213,7 @@ STATUS HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader
 
     case HEADER_FORMAT::SHORT_ASCII:
         ++pcTempBuf; // Move the input buffer past the sync char '%'
-        if (!DecodeAsciiHeaderFields<pcAsciiRegDelimiter, ASCII_HEADER::MESSAGE_NAME, ASCII_HEADER::WEEK>(stInterHeader_,
-                                                                                                                                     &pcTempBuf) ||
+        if (!DecodeAsciiHeaderFields<pcAsciiRegDelimiter, ASCII_HEADER::MESSAGE_NAME, ASCII_HEADER::WEEK>(stInterHeader_, &pcTempBuf) ||
             !DecodeAsciiHeaderField<pcAsciiFinalDelimiter, ASCII_HEADER::SECONDS>(stInterHeader_, &pcTempBuf))
         {
             return STATUS::FAILURE;

--- a/src/decoders/oem/src/header_decoder.cpp
+++ b/src/decoders/oem/src/header_decoder.cpp
@@ -174,14 +174,13 @@ HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader& stInt
     case HEADER_FORMAT::ASCII:
         ++pcTempBuf; // Move the input buffer past the sync char '#'
         if (!DecodeAsciiHeaderFields<pcAsciiRegularDelim, ASCII_HEADER::MESSAGE_NAME, ASCII_HEADER::PORT, ASCII_HEADER::SEQUENCE,
-                                     ASCII_HEADER::IDLE_TIME,
-                                     ASCII_HEADER::TIME_STATUS, ASCII_HEADER::WEEK, ASCII_HEADER::SECONDS, ASCII_HEADER::RECEIVER_STATUS,
-                                     ASCII_HEADER::MSG_DEF_CRC, ASCII_HEADER::RECEIVER_SW_VERSION>(stInterHeader_, &pcTempBuf))
+                                     ASCII_HEADER::IDLE_TIME, ASCII_HEADER::TIME_STATUS, ASCII_HEADER::WEEK, ASCII_HEADER::SECONDS,
+                                     ASCII_HEADER::RECEIVER_STATUS, ASCII_HEADER::MSG_DEF_CRC, ASCII_HEADER::RECEIVER_SW_VERSION>(stInterHeader_,
+                                                                                                                                  &pcTempBuf))
         {
             return STATUS::FAILURE;
         }
-        if (!DecodeAsciiHeaderField<pcAsciiFinalDelim, ASCII_HEADER::RECEIVER_SW_VERSION>(stInterHeader_, &pcTempBuf)) { return STATUS::FAILURE;
-        }
+        if (!DecodeAsciiHeaderField<pcAsciiFinalDelim, ASCII_HEADER::RECEIVER_SW_VERSION>(stInterHeader_, &pcTempBuf)) { return STATUS::FAILURE; }
         break;
 
     case HEADER_FORMAT::ABB_ASCII:

--- a/src/decoders/oem/src/header_decoder.cpp
+++ b/src/decoders/oem/src/header_decoder.cpp
@@ -76,10 +76,18 @@ bool HeaderDecoder::DecodeAsciiHeaderField(IntermediateHeader& stInterHeader_, c
 
     // Find next delimiter
     const char* pcNextDelimiter = strchr(*ppcLogBuf_, pcDelimiter[0]);
-    if (pcNextDelimiter == nullptr) { return false; }
+    if (pcNextDelimiter == nullptr)
+    {
+        SPDLOG_LOGGER_ERROR(pclMyLogger, "Message header could not be decoded as the expected field delimiter could not be found.");
+        return false;
+    }
 
     // Check that full delimiter is correct
-    if (ullDelimiterSize > 1 && std::strncmp(pcNextDelimiter, pcDelimiter, ullDelimiterSize) != 0) { return false; };
+    if (ullDelimiterSize > 1 && std::strncmp(pcNextDelimiter, pcDelimiter, ullDelimiterSize) != 0)
+    {
+        SPDLOG_LOGGER_ERROR(pclMyLogger, "Message header could not be decoded due to an invalid delimiter.");
+        return false;
+    };
 
     // Process field value up until delimiter
     size_t ullTokenLength = pcNextDelimiter - *ppcLogBuf_;

--- a/src/decoders/oem/src/header_decoder.cpp
+++ b/src/decoders/oem/src/header_decoder.cpp
@@ -146,12 +146,14 @@ void HeaderDecoder::DecodeJsonHeader(json clJsonHeader_, IntermediateHeader& stI
 
 // -------------------------------------------------------------------------------------------------------
 
-constexpr char pcAsciiRegDelimiter[] = ",";
-constexpr char pcAsciiFinalDelimiter[] = ";";
-constexpr char pcAbbrevAsciiRegDelimiter[] = " ";
-constexpr char pcAbbrevAsciiFinalDelimiter[] = "\r\n";
+
 STATUS HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader& stInterHeader_, MetaDataStruct& stMetaData_) const
 {
+    static constexpr char pcAsciiRegDelimiter[] = ",";
+    static constexpr char pcAsciiFinalDelimiter[] = ";";
+    static constexpr char pcAbbrevAsciiRegDelimiter[] = " ";
+    static constexpr char pcAbbrevAsciiFinalDelimiter[] = "\r\n";
+
     if (pucLogBuf_ == nullptr) { return STATUS::NULL_PROVIDED; }
 
     if (pclMyMsgDb == nullptr) { return STATUS::NO_DATABASE; }

--- a/src/decoders/oem/src/header_decoder.cpp
+++ b/src/decoders/oem/src/header_decoder.cpp
@@ -146,7 +146,6 @@ void HeaderDecoder::DecodeJsonHeader(json clJsonHeader_, IntermediateHeader& stI
 
 // -------------------------------------------------------------------------------------------------------
 
-
 STATUS HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader& stInterHeader_, MetaDataStruct& stMetaData_) const
 {
     static constexpr char pcAsciiRegDelimiter[] = ",";

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -1273,6 +1273,21 @@ TEST_F(DecodeEncodeTest, ABBREV_ASCII_EMPTY_ARRAY)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, TestSameFormatCompare(ENCODE_FORMAT::ABBREV_ASCII, &stExpectedMessageData));
 }
 
+TEST_F(DecodeEncodeTest, ABBREV_ASCII_NULL_IN_HEADER)
+{
+    unsigned char aucLog[] = {
+        '<', 'P', 'P', 'P', 'S', 'A', 'T', 'S', ' ', 'C', 'O', 'M', '1', ' ', '0', ' ', '7', '4', '.', '0', ' ', 'F', 'I', 'N', 'E', 'S', 'T', 'E', 'E', 'R', 'I', 'N', 'G', ' ',
+             '2', '3', '5', '8', ' ', '1', '9', '1', '5', '0', '.', '0', '0', '0', ' ', '1', 'a', '0', '0', '8', '0', '0', '0', ' ', 'c', 'e', '3', 'f', ' ', 
+             '1', '\0', '7', '3', '4', '5', '\r', '\n',
+        '<', ' ', ' ', ' ', ' ', '2', '\r', '\n',
+        '<', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', 'G', 'P', 'S', ' ', '1', '8', ' ', 'G', 'O', 'O', 'D', ' ', '0', '0', '0', '0', '0', '0', '0', '7', '\r', '\n',
+        '<', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', 'G', 'P', 'S', ' ', '1', '6', ' ', 'G', 'O', 'O', 'D', ' ', '0', '0', '0', '0', '0', '0', '0', '3', '\r', '\n'
+    };
+    MessageDataStruct stExpectedMessageData(aucLog, sizeof(aucLog) - 1, 69);
+    ASSERT_EQ(DecodeEncodeTest::HEADER_DECODER_ERROR, TestSameFormatCompare(ENCODE_FORMAT::ABBREV_ASCII, &stExpectedMessageData));
+
+}
+
 // -------------------------------------------------------------------------------------------------------
 // BINARY Log Decode/Encode Unit Tests
 // -------------------------------------------------------------------------------------------------------

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -1285,7 +1285,6 @@ TEST_F(DecodeEncodeTest, ABBREV_ASCII_NULL_IN_HEADER)
     };
     MessageDataStruct stExpectedMessageData(aucLog, sizeof(aucLog) - 1, 69);
     ASSERT_EQ(DecodeEncodeTest::HEADER_DECODER_ERROR, TestSameFormatCompare(ENCODE_FORMAT::ABBREV_ASCII, &stExpectedMessageData));
-
 }
 
 // -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Problem:
If extraneous delimiters are introduced to a otherwise valid header, the header decoder will still return success, although the actual decoded data will be incorrect. I saw this occur in a dataset which somehow became corrupted with some randomly occurring `NULL` characters. The old `strcspn` function essentially treated these `NULL` characters as valid delimiters.

Solution:
I've updated the `DecodeAsciiHeaderField` function to return failure if it does not encounter the exact delimiter its looking for.