### PR TITLE
Header object improvements

### DIFF
--- a/python/bindings/decoder.cpp
+++ b/python/bindings/decoder.cpp
@@ -59,6 +59,7 @@ void init_novatel_decoder(nb::module_& m)
                 return header;
             },
             "raw_header"_a, nb::arg("metadata") = nb::none(),
+            nb::sig("def decode_header(self, raw_header: bytes, metadata: MetaData | None = None) -> Header"),
             R"doc(
             Decode the header from a piece of framed data.
 
@@ -85,12 +86,13 @@ void init_novatel_decoder(nb::module_& m)
                     default_metadata.usMessageId = header.usMessageId;
                     default_metadata.messageName = decoder.database->MsgIdToMsgName(CreateMsgId(
                         header.usMessageId, static_cast<uint32_t>(MEASUREMENT_SOURCE::PRIMARY), static_cast<uint32_t>(MESSAGE_FORMAT::ABBREV), 0U));
-                    default_metadata.bResponse = header.GetPyMessageType().IsResponse();
+                    default_metadata.bResponse = ((header.ucMessageType & static_cast<uint8_t>(MESSAGE_TYPE_MASK::RESPONSE)) != 0);
                     metadata = &default_metadata;
                 }
                 return decoder.DecodeMessage(raw_payload, header, *metadata);
             },
             "raw_body"_a, "decoded_header"_a, nb::arg("metadata") = nb::none(),
+            nb::sig("def decode_payload(self, raw_payload: bytes, header: Header, metadata: MetaData | None = None) -> Message"),
             R"doc(
             Decode the payload of a message given the associated header.
 
@@ -124,7 +126,7 @@ void init_novatel_decoder(nb::module_& m)
                 default: throw_exception_from_status(status);
                 }
             },
-            "message"_a,
+            "message"_a, nb::sig("def decode_payload(self, raw_message: bytes) -> Message"),
             R"doc(
             Decode the payload of a message given the associated header.
 

--- a/python/bindings/file_parser.cpp
+++ b/python/bindings/file_parser.cpp
@@ -83,8 +83,7 @@ void init_novatel_file_parser(nb::module_& m)
                 if (!message_db) { message_db = MessageDbSingleton::get(); }
                 new (self) oem::PyFileParser(file_path, message_db);
             },
-            "file_path"_a,
-            nb::arg("message_db") = nb::none(),
+            "file_path"_a, nb::arg("message_db") = nb::none(),
             R"doc(
              Initializes a FileParser.
 
@@ -107,9 +106,8 @@ void init_novatel_file_parser(nb::module_& m)
                 return std::static_pointer_cast<oem::PyFilter>(self.GetFilter());
             },
             [](oem::PyFileParser& self, oem::PyFilter::Ptr filter) { self.SetFilter(filter); },
-            "The filter which controls which data is skipped over."
-            )
-        .def("read", &oem::PyFileParser::PyRead, nb::sig("def read() ->  Message | UnknownMessage | UnknownBytes"),
+            "The filter which controls which data is skipped over.")
+        .def("read", &oem::PyFileParser::PyRead, nb::sig("def read(self) ->  Message | UnknownMessage | UnknownBytes"),
              R"doc(
             Attempts to read a message from remaining data in the file.
 
@@ -123,14 +121,16 @@ void init_novatel_file_parser(nb::module_& m)
                 StreamEmptyException: There is insufficient data in the remaining 
                     in the file to decode a message.
             )doc")
-        .def("__iter__", [](nb::handle_t<oem::PyFileParser> self) { return self; },
-             R"doc(
+        .def(
+            "__iter__", [](nb::handle_t<oem::PyFileParser> self) { return self; },
+            nb::sig("def __iter__(self) -> Iterator[Message|UnknownMessage|UnknownBytes]"),
+            R"doc(
             Marks FileParser as Iterable.
 
             Returns:
                 The FileParser itself as an Iterator.
             )doc")
-        .def("__next__", &oem::PyFileParser::PyIterRead, nb::sig("def __next__() -> Message | UnknownMessage | UnknownBytes"),
+        .def("__next__", &oem::PyFileParser::PyIterRead, nb::sig("def __next__(self) -> Message | UnknownMessage | UnknownBytes"),
              R"doc(
             Attempts to read the next message from remaining data in the file.
 
@@ -158,8 +158,9 @@ void init_novatel_file_parser(nb::module_& m)
                 StreamEmptyException: There is insufficient data in the remaining 
                     in the file to decode a message.
             )doc")
-        .def("iter_convert", [](oem::PyFileParser& self, ENCODE_FORMAT fmt) { return oem::FileConversionIterator(self, fmt); }, "fmt"_a,
-             R"doc(
+        .def(
+            "iter_convert", [](oem::PyFileParser& self, ENCODE_FORMAT fmt) { return oem::FileConversionIterator(self, fmt); }, "fmt"_a,
+            R"doc(
             Creates an iterator which parses and converts messages to a specified format.
 
             Args:
@@ -193,8 +194,9 @@ void init_novatel_file_parser(nb::module_& m)
             )doc");
 
     nb::class_<oem::FileConversionIterator>(m, "FileConversionIterator")
-        .def("__iter__", [](nb::handle_t<oem::FileConversionIterator> self) { return self; },
-             R"doc(
+        .def(
+            "__iter__", [](nb::handle_t<oem::FileConversionIterator> self) { return self; }, nb::sig("def __iter__(self) -> Iterator[MessageData]"),
+            R"doc(
             Marks FileConversionIterator as Iterable.
 
             Returns:

--- a/python/bindings/framer.cpp
+++ b/python/bindings/framer.cpp
@@ -75,13 +75,14 @@ void init_novatel_framer(nb::module_& m)
             )doc")
         .def(
             "__iter__", [](nb::handle_t<oem::PyFramer> self) { return self; },
+            nb::sig("def __iter__(self) -> Iterator[tuple[bytes, MetaData]]"),
             R"doc(
             Marks Framer as Iterable.
 
             Returns:
                 The Framer itself as an Iterator.
             )doc")
-        .def("__next__", &oem::PyFramer::PyIterGetFrame, nb::sig("def __next__() -> tuple[bytes, MetaData]"),
+        .def("__next__", &oem::PyFramer::PyIterGetFrame, nb::sig("def __next__(self) -> tuple[bytes, MetaData]"),
              R"doc(
             Attempts to get the next frame from the Framer's buffer.
 

--- a/python/bindings/parser.cpp
+++ b/python/bindings/parser.cpp
@@ -118,8 +118,7 @@ void init_novatel_parser(nb::module_& m)
                 // This static cast is safe so long as the Parser's filter is set only via the Python interface
                 return std::static_pointer_cast<oem::PyFilter>(self.GetFilter());
             },
-            [](oem::PyParser& self, oem::PyFilter::Ptr filter) { self.SetFilter(filter); },
-            "The filter which controls which data is skipped over.")
+            [](oem::PyParser& self, oem::PyFilter::Ptr filter) { self.SetFilter(filter); }, "The filter which controls which data is skipped over.")
         .def(
             "write",
             [](oem::PyParser& self, const nb::bytes& data) { return self.Write(reinterpret_cast<const uint8_t*>(data.c_str()), data.size()); },
@@ -143,7 +142,7 @@ void init_novatel_parser(nb::module_& m)
                  buffer to decode a message.
             )doc")
         .def("read", &oem::PyParser::PyRead, "decode_incomplete_abbreviated"_a = false,
-             nb::sig("def read(decode_incomplete_abbreviated=False) -> Message | UnknownMessage | UnknownBytes"),
+             nb::sig("def read(self, decode_incomplete_abbreviated: bool = False) -> Message | UnknownMessage | UnknownBytes"),
              R"doc(
             Attempts to read a message from data in the Parser's buffer.
 
@@ -165,13 +164,14 @@ void init_novatel_parser(nb::module_& m)
             )doc")
         .def(
             "__iter__", [](nb::handle_t<oem::PyParser> self) { return self; },
+            nb::sig("def __iter__(self) -> Iterator[Message|UnknownMessage|UnknownBytes]"),
             R"doc(
             Marks Parser as Iterable.
 
             Returns:
                 The Parser itself as an Iterator.
             )doc")
-        .def("__next__", &oem::PyParser::PyIterRead, nb::sig("def __next__() -> Message | UnknownMessage | UnknownBytes"),
+        .def("__next__", &oem::PyParser::PyIterRead, nb::sig("def __next__(self) -> Message | UnknownMessage | UnknownBytes"),
              R"doc(
             Attempts to read the next message from data in the Parser's buffer.
 
@@ -236,7 +236,8 @@ void init_novatel_parser(nb::module_& m)
             )doc");
 
     nb::class_<oem::ConversionIterator>(m, "ConversionIterator")
-        .def("__iter__", [](nb::handle_t<oem::ConversionIterator> self) { return self; },
+        .def(
+            "__iter__", [](nb::handle_t<oem::ConversionIterator> self) { return self; }, nb::sig("def __iter__(self) -> Iterator[MessageData]"),
             R"doc(
             Marks ConversionIterator as Iterable.
 

--- a/python/bindings/py_message_objects.cpp
+++ b/python/bindings/py_message_objects.cpp
@@ -335,6 +335,43 @@ nb::object oem::create_message_instance(PyHeader& header, std::vector<FieldConta
 
 void init_header_objects(nb::module_& m)
 {
+    nb::class_<oem::PyRecieverStatus>(m, "RecieverStatus", "Boolean values indicating information about the state of the reciever.")
+        .def_ro("raw_value", &oem::PyRecieverStatus::value)
+        .def_prop_ro("reciever_error", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00000001) != 0; })
+        .def_prop_ro("temperature_warning", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00000002) != 0; })
+        .def_prop_ro("voltage_warning", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00000004) != 0; })
+        .def_prop_ro("antenna_powered", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00000008) != 0; })
+        .def_prop_ro("lna_failure", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00000010) != 0; })
+        .def_prop_ro("antenna_open_circuit", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00000020) != 0; })
+        .def_prop_ro("antenna_short_circuit", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00000040) != 0; })
+        .def_prop_ro("cpu_overload", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00000080) != 0; })
+        .def_prop_ro("com_buffer_overrun", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00000100) != 0; })
+        .def_prop_ro("spoofing_detected", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00000200) != 0; })
+        // Reserved flag does not need a function
+        .def_prop_ro("link_overrun", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00000800) != 0; })
+        .def_prop_ro("input_overrun", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00001000) != 0; })
+        .def_prop_ro("aux_transmit_overrun", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00002000) != 0; })
+        .def_prop_ro("antenna_gain_out_of_range", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00004000) != 0; })
+        .def_prop_ro("jammer_detected", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00008000) != 0; })
+        .def_prop_ro("ins_reset", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00010000) != 0; })
+        .def_prop_ro("imu_communication_failure", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00020000) != 0; })
+        .def_prop_ro("gps_almanac_invalid", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00040000) != 0; })
+        .def_prop_ro("position_solution_invalid", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00080000) != 0; })
+        .def_prop_ro("position_fixed", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00100000) != 0; })
+        .def_prop_ro("clock_steering_disabled", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00200000) != 0; })
+        .def_prop_ro("clock_model_invalid", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00400000) != 0; })
+        .def_prop_ro("external_oscillator_locked", [](const oem::PyRecieverStatus& self) { return (self.value & 0x00800000) != 0; })
+        .def_prop_ro("software_resource_warning", [](const oem::PyRecieverStatus& self) { return (self.value & 0x01000000) != 0; })
+        .def_prop_ro("tracking_mode_hdr", [](const oem::PyRecieverStatus& self) { return (self.value & 0x08000000) != 0; })
+        .def_prop_ro("digital_filtering_enabled", [](const oem::PyRecieverStatus& self) { return (self.value & 0x10000000) != 0; })
+        .def_prop_ro("auxiliary_3_event", [](const oem::PyRecieverStatus& self) { return (self.value & 0x20000000) != 0; })
+        .def_prop_ro("auxiliary_2_event", [](const oem::PyRecieverStatus& self) { return (self.value & 0x40000000) != 0; })
+        .def_prop_ro("auxiliary_1_event", [](const oem::PyRecieverStatus& self) { return (self.value & 0x80000000) != 0; })
+        .def_prop_ro("version_bits", [](const oem::PyRecieverStatus& self) { return (self.value >> 25) & 0x06000000; })
+        .def("__repr__", [](const oem::PyRecieverStatus& self) {
+            return nb::str("RecieverStatus(") + nb::str(nb::module_::import_("builtins").attr("hex")(self.value)) + nb::str(")");
+        });
+
     nb::class_<oem::PyMessageTypeField>(m, "MessageType",
                                         "A message field which provides information about its source, format, and whether it is a response.")
         .def("__repr__",
@@ -351,15 +388,17 @@ void init_header_objects(nb::module_& m)
 
     nb::class_<oem::PyHeader>(m, "Header")
         .def_ro("message_id", &oem::PyHeader::usMessageId, "The Message ID number.")
-        .def_prop_ro("message_type", &oem::PyHeader::GetPyMessageType, "Information regarding the type of the message.")
+        .def_prop_ro("message_type", &oem::PyHeader::GetPyMessageType, nb::sig("def message_type(self) -> MessageType"),
+                     "Information regarding the type of the message.")
         .def_ro("port_address", &oem::PyHeader::uiPortAddress, "The port the message was sent from.")
         .def_ro("length", &oem::PyHeader::usLength, "The length of the message. Will be 0 if unknown.")
         .def_ro("sequence", &oem::PyHeader::usSequence, "Number of remaning related messages following this one. Will be 0 for most messages.")
         .def_ro("idle_time", &oem::PyHeader::ucIdleTime, "Time that the processor is idle. Divide by two to get the percentage.")
-        .def_ro("time_status", &oem::PyHeader::uiTimeStatus, "The quality of the GPS reference time.")
+        .def_prop_ro(
+            "time_status", [](const oem::PyHeader& self) { return TIME_STATUS(self.uiTimeStatus); }, "The quality of the GPS reference time.")
         .def_ro("week", &oem::PyHeader::usWeek, "GPS reference wekk number.")
         .def_ro("milliseconds", &oem::PyHeader::dMilliseconds, "Milliseconds from the beginning of the GPS reference week.")
-        .def_ro("receiver_status", &oem::PyHeader::uiReceiverStatus,
+        .def_prop_ro("receiver_status", &oem::PyHeader::GetRecieverStatus,
                 "32-bits representing the status of various hardware and software components of the receiver.")
         .def_ro("message_definition_crc", &oem::PyHeader::uiMessageDefinitionCrc, "A value for validating the message definition used for decoding.")
         .def_ro("receiver_sw_version", &oem::PyHeader::usReceiverSwVersion, "A value (0 - 65535) representing the receiver software build number.")
@@ -372,13 +411,26 @@ void init_header_objects(nb::module_& m)
                 A dictionary representation of the header.
             )doc")
         .def("__repr__", [](const nb::handle self) {
-            auto& header = nb::cast<oem::PyHeader&>(self);
-            return nb::str("Header(message_id={!r}, message_type={!r}, port_address={!r}, length={!r}, sequence={!r}, "
-                           "idle_time={!r}, time_status={!r}, week={!r}, milliseconds={!r}, receiver_status={!r}, "
-                           "message_definition_crc={!r}, receiver_sw_version={!r})")
-                .format(header.usMessageId, header.ucMessageType, header.uiPortAddress, header.usLength, header.usSequence, header.ucIdleTime,
-                        header.uiTimeStatus, header.usWeek, header.dMilliseconds, header.uiReceiverStatus, header.uiMessageDefinitionCrc,
-                        header.usReceiverSwVersion);
+            std::vector<nb::str> fields = {nb::str("message_id"),
+                                           nb::str("message_type"),
+                                           nb::str("port_address"),
+                                           nb::str("length"),
+                                           nb::str("sequence"),
+                                           nb::str("idle_time"),
+                                           nb::str("time_status"),
+                                           nb::str("week"),
+                                           nb::str("milliseconds"),
+                                           nb::str("receiver_status"),
+                                           nb::str("message_definition_crc"),
+                                           nb::str("receiver_sw_version")};
+            nb::str header_repr = nb::str("Header(");
+            for (size_t i = 0; i < fields.size(); ++i)
+            {
+                header_repr += fields[i] + nb::str("=") + nb::repr(self.attr(fields[i]));
+                if (i != fields.size() - 1) { header_repr += nb::str(", "); }
+            }
+            header_repr += nb::str(")");
+            return header_repr;
         });
 }
 

--- a/python/bindings/py_message_objects.hpp
+++ b/python/bindings/py_message_objects.hpp
@@ -38,6 +38,19 @@ struct PyUnknownBytes
     explicit PyUnknownBytes(nb::bytes data_) : data(std::move(data_)) {}
 };
 
+
+//============================================================================
+//! \class PyRecieverStatus
+//! \brief The field in a message header which gives type information.
+//============================================================================
+struct PyRecieverStatus
+{
+    uint32_t value;
+
+    PyRecieverStatus(uint32_t value_) : value(value_) {}
+};
+
+
 //============================================================================
 //! \class PyMessageTypeField
 //! \brief The field in a message header which gives type information.
@@ -45,6 +58,9 @@ struct PyUnknownBytes
 struct PyMessageTypeField
 {
     uint8_t value;
+
+    PyMessageTypeField(uint8_t value_) : value(value_) {}
+
     bool IsResponse() { return (value & static_cast<uint8_t>(MESSAGE_TYPE_MASK::RESPONSE)) != 0; }
     MESSAGE_FORMAT GetFormat() { return static_cast<MESSAGE_FORMAT>((value & static_cast<uint8_t>(MESSAGE_TYPE_MASK::MSGFORMAT)) >> 5); }
     MEASUREMENT_SOURCE GetMeasurementSource() { return static_cast<MEASUREMENT_SOURCE>((value & static_cast<uint8_t>(MESSAGE_TYPE_MASK::MEASSRC))); }
@@ -57,13 +73,15 @@ struct PyMessageTypeField
 struct PyHeader : public IntermediateHeader
 {
     HEADER_FORMAT format;
-    PyMessageTypeField message_type;
     uint32_t raw_length;
 
     PyMessageTypeField GetPyMessageType()
     {
-        message_type.value = ucMessageType;
-        return message_type;
+        return PyMessageTypeField(ucMessageType);
+    }
+    PyRecieverStatus GetRecieverStatus()
+    {
+        return PyRecieverStatus(uiReceiverStatus);
     }
 
     nb::dict to_dict() const;

--- a/python/examples/converter_fileparser.py
+++ b/python/examples/converter_fileparser.py
@@ -34,7 +34,7 @@ import logging
 import os
 import timeit
 
-from novatel_edie import Message, UnknownMessage, UnknownBytes, Filter, FileParser, pretty_version
+from novatel_edie import Message, UnknownMessage, UnknownBytes, Filter, FileParser, CPP_PRETTY_VERSION
 from novatel_edie.messages import BESTPOS
 
 from common_setup import setup_example_logging, handle_args
@@ -44,7 +44,7 @@ def main():
     # Setup logging
     setup_example_logging(logging.WARNING)
     logger = logging.getLogger(__name__)
-    logger.info(f"Decoder library information:\n{pretty_version}")
+    logger.info(f"Decoder library information:\n{CPP_PRETTY_VERSION}")
 
     # Handle CLI arguments
     input_file, encode_format = handle_args(logger)

--- a/python/examples/converter_parser.py
+++ b/python/examples/converter_parser.py
@@ -32,7 +32,7 @@
 import logging
 import timeit
 
-from novatel_edie import Parser, pretty_version, MESSAGE_SIZE_MAX, Message, UnknownMessage, UnknownBytes
+from novatel_edie import Parser, CPP_PRETTY_VERSION, MAX_MESSAGE_LENGTH, Message, UnknownMessage, UnknownBytes
 from novatel_edie.messages import BESTPOS
 
 from common_setup import setup_example_logging, handle_args
@@ -42,7 +42,7 @@ def main():
     # Setup logging
     setup_example_logging(logging.INFO)
     logger = logging.getLogger(__name__)
-    logger.info(f"Decoder library information:\n{pretty_version}")
+    logger.info(f"Decoder library information:\n{CPP_PRETTY_VERSION}")
 
     # Handle CLI arguments
     input_file, encode_format = handle_args(logger)
@@ -54,7 +54,7 @@ def main():
     messages = 0
     start = timeit.default_timer()
     with open(input_file, "rb") as input_stream:
-        while read_data := input_stream.read(MESSAGE_SIZE_MAX):
+        while read_data := input_stream.read(MAX_MESSAGE_LENGTH):
             parser.write(read_data)
             for message in parser:
                 # Handle messages that can be fully decoded

--- a/python/stubgen_pattern.txt
+++ b/python/stubgen_pattern.txt
@@ -1,3 +1,6 @@
+bindings.__prefix__:
+    from typing import Iterator
+
 bindings.Filter.(lower|upper)_time_bound:
     @property
     def \1_time_bound(self) -> GpsTime | None:


### PR DESCRIPTION
This PR improves upon the python `Header` object by giving it a better string repr and introducing a wrapper class for its `reciever_status` field.


Also fixes a couple outdated aspects of example files and introduces some minor type hinting improvements.

Addresses #130