### PR TITLE
Improve handling of responses

### DIFF
--- a/python/bindings/file_parser.cpp
+++ b/python/bindings/file_parser.cpp
@@ -15,8 +15,8 @@ using namespace novatel::edie;
 
 nb::object oem::PyFileParser::PyRead()
 {
-    MetaDataStruct metadata;
-    MessageDataStruct message_data;
+    static MetaDataStruct metadata;
+    static MessageDataStruct message_data;
     PyHeader header;
     std::vector<FieldContainer> message_fields;
 

--- a/python/bindings/parser.cpp
+++ b/python/bindings/parser.cpp
@@ -30,8 +30,8 @@ nb::object oem::HandlePythonReadStatus(STATUS status_, MessageDataStruct& messag
 
 nb::object oem::PyParser::PyRead(bool decode_incomplete)
 {
-    oem::MetaDataStruct metadata;
-    MessageDataStruct message_data;
+    static oem::MetaDataStruct metadata;
+    static MessageDataStruct message_data;
     oem::PyHeader header;
     std::vector<FieldContainer> message_fields;
 

--- a/python/bindings/py_message_objects.cpp
+++ b/python/bindings/py_message_objects.cpp
@@ -248,6 +248,8 @@ PyMessageData PyMessage::encode(ENCODE_FORMAT fmt) { return PyEncode(*this, this
 
 PyMessageData PyMessage::to_ascii() { return PyEncode(*this, this->parent_db_.get(), ENCODE_FORMAT::ASCII); }
 
+PyMessageData PyMessage::to_abbrev_ascii() { return PyEncode(*this, this->parent_db_.get(), ENCODE_FORMAT::ABBREV_ASCII); }
+
 PyMessageData PyMessage::to_binary() { return PyEncode(*this, this->parent_db_.get(), ENCODE_FORMAT::BINARY); }
 
 PyMessageData PyMessage::to_flattened_binary() { return PyEncode(*this, this->parent_db_.get(), ENCODE_FORMAT::BINARY); }
@@ -460,6 +462,7 @@ void init_message_objects(nb::module_& m)
     nb::class_<PyMessage, PyField>(m, "Message")
         .def("encode", &PyMessage::encode)
         .def("to_ascii", &PyMessage::to_ascii)
+        .def("to_abbrev_ascii", &PyMessage::to_ascii)
         .def("to_binary", &PyMessage::to_binary)
         .def("to_flattended_binary", &PyMessage::to_flattened_binary)
         .def("to_json", &PyMessage::to_json)
@@ -484,7 +487,8 @@ void init_message_objects(nb::module_& m)
         .def_ro("header", &PyMessage::header, "The header of the message.")
         .def_ro("name", &PyMessage::name, "The type of message it is.");
 
-    nb::class_<PyResponse, PyField>(m, "Response")
+    nb::class_<PyResponse, PyMessage>(m, "Response")
+        // Class typehinting signature defined in stubgen_pattern.txt
         .def(
             "to_dict",
             [](const PyResponse& self, bool include_header) {

--- a/python/bindings/py_message_objects.hpp
+++ b/python/bindings/py_message_objects.hpp
@@ -134,6 +134,7 @@ struct PyMessage : public PyField
 
     PyMessageData encode(ENCODE_FORMAT fmt);
     PyMessageData to_ascii();
+    PyMessageData to_abbrev_ascii();
     PyMessageData to_binary();
     PyMessageData to_flattened_binary();
     PyMessageData to_json();
@@ -147,13 +148,12 @@ nb::object create_message_instance(PyHeader& header, std::vector<FieldContainer>
                                    PyMessageDatabase::ConstPtr database);
 
 
-struct PyResponse : public PyField
+struct PyResponse : public PyMessage
 {
-    PyHeader header;
 
     explicit PyResponse(std::string name_, std::vector<FieldContainer> fields_, PyMessageDatabase::ConstPtr parent_db_,
                         PyHeader header_)
-        : PyField(std::move(name_), false, std::move(fields_), std::move(parent_db_)), header(std::move(header_)) {};
+        : PyMessage(std::move(name_), false, std::move(fields_), std::move(parent_db_), std::move(header_)) {};
 };
 
 } // namespace novatel::edie::oem

--- a/python/bindings/py_message_objects.hpp
+++ b/python/bindings/py_message_objects.hpp
@@ -160,7 +160,7 @@ nb::object create_message_instance(PyHeader& header, std::vector<FieldContainer>
 
 //============================================================================
 //! \class PyResponse
-//! \brief A python representation for a single fully decoded message.
+//! \brief A python representation for a single decoded message response.
 //============================================================================
 struct PyResponse : public PyEncodableField
 {

--- a/python/bindings/py_message_objects.hpp
+++ b/python/bindings/py_message_objects.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "novatel_edie/decoders/oem/filter.hpp"
-
-
 #include "bindings_core.hpp"
-#include "py_database.hpp"
 #include "message_db_singleton.hpp"
+#include "novatel_edie/decoders/oem/filter.hpp"
+#include "py_database.hpp"
 #include "py_message_data.hpp"
 
 namespace nb = nanobind;
@@ -147,5 +145,15 @@ nb::object create_unknown_message_instance(nb::bytes data, PyHeader& header, PyM
 
 nb::object create_message_instance(PyHeader& header, std::vector<FieldContainer>& message_fields, MetaDataStruct& metadata,
                                    PyMessageDatabase::ConstPtr database);
+
+
+struct PyResponse : public PyField
+{
+    PyHeader header;
+
+    explicit PyResponse(std::string name_, std::vector<FieldContainer> fields_, PyMessageDatabase::ConstPtr parent_db_,
+                        PyHeader header_)
+        : PyField(std::move(name_), false, std::move(fields_), std::move(parent_db_)), header(std::move(header_)) {};
+};
 
 } // namespace novatel::edie::oem

--- a/python/bindings/py_message_objects.hpp
+++ b/python/bindings/py_message_objects.hpp
@@ -161,6 +161,9 @@ nb::object create_message_instance(PyHeader& header, std::vector<FieldContainer>
 //============================================================================
 //! \class PyResponse
 //! \brief A python representation for a single decoded message response.
+//! 
+//! This class makes the assumption that `fields` is a vector of field with the 
+//! definitions generated in `void MessageDecoderBase::CreateResponseMsgDefinitions()`
 //============================================================================
 struct PyResponse : public PyEncodableField
 {
@@ -169,8 +172,10 @@ struct PyResponse : public PyEncodableField
                         bool complete_)
         : PyEncodableField(std::move(name_), false, std::move(fields_), std::move(parent_db_), std::move(header_)), complete(complete_) {};
 
+    // Retrieve response ID from first field of response
     int32_t GetResponseId() { return std::get<int>(fields[0].fieldValue); }
 
+    // Retrieve response string from second field of response
     std::string GetResponseString() const { return std::get<std::string>(fields[1].fieldValue); }
 
     nb::object GetEnumValue()

--- a/python/novatel_edie_files/__init__.py
+++ b/python/novatel_edie_files/__init__.py
@@ -39,7 +39,7 @@ from .bindings import (
     MalformedInputException, DecompressionFailureException, JsonDbReaderException,
     CPP_VERSION, CPP_PRETTY_VERSION, GIT_SHA, GIT_BRANCH, GIT_IS_DIRTY, BUILD_TIMESTAMP, 
     enable_internal_logging, disable_internal_logging,
-    UnknownBytes, Header, Field, UnknownMessage, Message, GpsTime,
+    UnknownBytes, Header, Field, UnknownMessage, Message, Response, GpsTime,
     MessageDatabase, get_default_database,
     Oem4BinaryHeader, Oem4BinaryShortHeader, MetaData, MessageData, MessageDefinition, BaseField,
     Framer, Filter, Decoder, Commander, Parser, FileParser,

--- a/python/stubgen_pattern.txt
+++ b/python/stubgen_pattern.txt
@@ -14,10 +14,9 @@ bindings.Filter.decimation_period$:
     @decimation_period.setter
     def decimation_period(self, value: int | None) -> None: ...
 
-bindings.Response:
-    class Response(Message):
-        @property
-        def response_str(self) -> str:
-
-        @property
-        def response_id(self) -> int:
+bindings.Response.response_enum:
+    from typing import TYPE_CHECKING
+    if TYPE_CHECKING:
+        from novatel_edie.enums import Responses
+    @property
+    def response_enum(self) -> Responses

--- a/python/stubgen_pattern.txt
+++ b/python/stubgen_pattern.txt
@@ -13,3 +13,11 @@ bindings.Filter.decimation_period$:
 
     @decimation_period.setter
     def decimation_period(self, value: int | None) -> None: ...
+
+bindings.Response:
+    class Response(Message):
+        @property
+        def response_str(self) -> str:
+
+        @property
+        def response_id(self) -> int:

--- a/python/test/test_decode_encode.py
+++ b/python/test/test_decode_encode.py
@@ -869,17 +869,17 @@ def test_binary_response_error(helper):
 # -------------------------------------------------------------------------------------------------------
 def test_abbrev_ascii_response(helper):
     log = b"<OK\r\n"
-    assert helper.TestDecodeEncode(ENCODE_FORMAT.ABBREV_ASCII, log) == Result.HEADER_DECODER_ERROR
+    assert helper.TestDecodeEncode(ENCODE_FORMAT.ABBREV_ASCII, log) == Result.SUCCESS
 
 
 def test_abbrev_ascii_response_more_data(helper):
     log = b"<OK\r\nGARBAGE"
-    assert helper.TestDecodeEncode(ENCODE_FORMAT.ABBREV_ASCII, log) == Result.HEADER_DECODER_ERROR
+    assert helper.TestDecodeEncode(ENCODE_FORMAT.ABBREV_ASCII, log) == Result.SUCCESS
 
 
 def test_abbrev_ascii_response_error(helper):
     log = b"<ERROR:Invalid Message. Field = 1\r\n"
-    assert helper.TestDecodeEncode(ENCODE_FORMAT.ABBREV_ASCII, log) == Result.HEADER_DECODER_ERROR
+    assert helper.TestDecodeEncode(ENCODE_FORMAT.ABBREV_ASCII, log) == Result.SUCCESS
 
 
 # -------------------------------------------------------------------------------------------------------

--- a/python/test/test_framer.py
+++ b/python/test/test_framer.py
@@ -793,7 +793,7 @@ def test_abbrev_ascii_empty_array(helper):
     helper.test_framer(HEADER_FORMAT.ABB_ASCII, len(data) - 6)
 
 
-@pytest.mark.parametrize("response_str, context", [("OK", b"\r\n<OK\r\nfdfa")])
+@pytest.mark.parametrize("response_frame, context", [(b"<OK\r\n", b"\r\n<OK\r\nfdfa")])
 def test_parse_abbrev_ascii_resp(response_frame, context, helper):
     # Arrange
     permutations = [(context[:i], context[i:]) for i in range(len(context) + 1)]

--- a/python/test/test_framer.py
+++ b/python/test/test_framer.py
@@ -793,6 +793,27 @@ def test_abbrev_ascii_empty_array(helper):
     helper.test_framer(HEADER_FORMAT.ABB_ASCII, len(data) - 6)
 
 
+@pytest.mark.parametrize("response_str, context", [("OK", b"\r\n<OK\r\nfdfa")])
+def test_parse_abbrev_ascii_resp(response_frame, context, helper):
+    # Arrange
+    permutations = [(context[:i], context[i:]) for i in range(len(context) + 1)]
+
+    # Act
+    for part1, part2 in permutations:
+        helper.write_bytes_to_framer(part1)
+        data = list(helper.framer)
+        helper.write_bytes_to_framer(part2)
+        new_data = list(helper.framer)
+        data.extend(new_data)
+
+    # Assert
+    frames = [datum[0] for datum in data]
+    assert response_frame in frames
+
+    md = data[frames.index(response_frame)][1]
+    assert md.format == HEADER_FORMAT.ABB_ASCII
+    assert md.response is True
+
 # -------------------------------------------------------------------------------------------------------
 # JSON Framer Unit Tests
 # -------------------------------------------------------------------------------------------------------

--- a/python/test/test_parser.py
+++ b/python/test/test_parser.py
@@ -106,7 +106,7 @@ def test_parse_abbrev_ascii_resp(response_str, context, ignore_responses, parser
             if ignore_responses:
                 assert len(responses) == 0
             else:
-                assert responses[0].response_str == response_str
+                assert responses[0].response_string == response_str
         except AssertionError as e:
             raise AssertionError(
                 f"Failure at permutation {permutations[i]}: {e}") from e

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -711,7 +711,7 @@ MessageDecoderBase::Decode(const unsigned char* pucMessage_, std::vector<FieldCo
     {
         if (stMetaData_.eFormat != HEADER_FORMAT::BINARY && stMetaData_.eFormat != HEADER_FORMAT::SHORT_BINARY &&
             stMetaData_.eFormat != HEADER_FORMAT::ASCII && stMetaData_.eFormat != HEADER_FORMAT::SHORT_ASCII &&
-            stMetaData_.eFormat != HEADER_FORMAT::SHORT_ABB_ASCII)
+            stMetaData_.eFormat != HEADER_FORMAT::ABB_ASCII && stMetaData_.eFormat != HEADER_FORMAT::SHORT_ABB_ASCII)
         {
             return STATUS::NO_DEFINITION;
         }

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -221,6 +221,7 @@ void MessageDecoderBase::InitFieldMaps()
 // -------------------------------------------------------------------------------------------------------
 void MessageDecoderBase::CreateResponseMsgDefinitions()
 {
+    // TODO: It would be more logical for this to live in the database rather than the decoder.
     // Numerical response ID
     SimpleDataType stRespIdDataType;
     stRespIdDataType.description = "Response as numerical id";

--- a/src/decoders/oem/src/header_decoder.cpp
+++ b/src/decoders/oem/src/header_decoder.cpp
@@ -196,10 +196,12 @@ STATUS HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader
         ++pcTempBuf; // Move the input buffer past the sync char '<'
 
         // Abbreviated ascii responses have no headers
-        if (stMetaData_.bResponse)
+        if (strncmp(pcTempBuf, "OK", 2) == 0 || strncmp(pcTempBuf, "ERROR", 5) == 0)
         {
+            stMetaData_.bResponse = true;
             stMetaData_.messageName = "UNKNOWN";
             stMetaData_.uiHeaderLength = static_cast<uint32_t>(pcTempBuf - reinterpret_cast<const char*>(pucLogBuf_));
+            stInterHeader_.ucMessageType = static_cast<uint8_t>(MESSAGE_TYPE_MASK::RESPONSE);
 
             return STATUS::SUCCESS;
         }

--- a/src/decoders/oem/src/header_decoder.cpp
+++ b/src/decoders/oem/src/header_decoder.cpp
@@ -194,6 +194,16 @@ STATUS HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader
 
     case HEADER_FORMAT::ABB_ASCII:
         ++pcTempBuf; // Move the input buffer past the sync char '<'
+
+        // Abbreviated ascii responses have no headers
+        if (stMetaData_.bResponse)
+        {
+            stMetaData_.messageName = "UNKNOWN";
+            stMetaData_.uiHeaderLength = static_cast<uint32_t>(pcTempBuf - reinterpret_cast<const char*>(pucLogBuf_));
+
+            return STATUS::SUCCESS;
+        }
+
         // At this point, we do not know if the format is short or not, but both have a message
         // field
         if (!DecodeAsciiHeaderField<pcAbbrevAsciiRegDelimiter, ASCII_HEADER::MESSAGE_NAME>(stInterHeader_, &pcTempBuf)) { return STATUS::FAILURE; }

--- a/src/decoders/oem/src/parser.cpp
+++ b/src/decoders/oem/src/parser.cpp
@@ -135,15 +135,10 @@ Parser::ReadIntermediate(MessageDataStruct& stMessageData_, IntermediateHeader& 
         }
         else if (eStatus == STATUS::SUCCESS)
         {
-            if ((!bMyIgnoreAbbreviatedAsciiResponse) && (stMetaData_.bResponse) && (stMetaData_.eFormat == HEADER_FORMAT::ABB_ASCII))
+            if (stMetaData_.bResponse && stMetaData_.eFormat == HEADER_FORMAT::ABB_ASCII && bMyIgnoreAbbreviatedAsciiResponse)
             {
-                stMessageData_.uiMessageHeaderLength = 0;
-                stMessageData_.pucMessageHeader = nullptr;
-                stMessageData_.uiMessageBodyLength = 0;
-                stMessageData_.pucMessageBody = nullptr;
-                stMessageData_.pucMessage = pucMyFrameBufferPointer;
-                stMessageData_.uiMessageLength = stMetaData_.uiLength;
-                return STATUS::SUCCESS;
+                pclMyLogger->debug("Abbreviated ascii response ignored");
+                continue;
             }
 
             eStatus = clMyHeaderDecoder.Decode(pucMyFrameBufferPointer, stHeader_, stMetaData_);

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -1919,19 +1919,19 @@ TEST_F(DecodeEncodeTest, BINARY_RESPONSE_ERROR)
 TEST_F(DecodeEncodeTest, ABBREV_ASCII_RESPONSE)
 {
     unsigned char aucLog[] = "<OK\r\n";
-    ASSERT_EQ(DecodeEncodeTest::HEADER_DECODER_ERROR, TestDecodeEncode(ENCODE_FORMAT::ABBREV_ASCII, aucLog));
+    ASSERT_EQ(DecodeEncodeTest::SUCCESS, TestDecodeEncode(ENCODE_FORMAT::ABBREV_ASCII, aucLog));
 }
 
 TEST_F(DecodeEncodeTest, ABBREV_ASCII_RESPONSE_MORE_DATA)
 {
     unsigned char aucLog[] = "<OK\r\nGARBAGE";
-    ASSERT_EQ(DecodeEncodeTest::HEADER_DECODER_ERROR, TestDecodeEncode(ENCODE_FORMAT::ABBREV_ASCII, aucLog));
+    ASSERT_EQ(DecodeEncodeTest::SUCCESS, TestDecodeEncode(ENCODE_FORMAT::ABBREV_ASCII, aucLog));
 }
 
 TEST_F(DecodeEncodeTest, ABBREV_ASCII_RESPONSE_ERROR)
 {
     unsigned char aucLog[] = "<ERROR:Invalid Message. Field = 1\r\n";
-    ASSERT_EQ(DecodeEncodeTest::HEADER_DECODER_ERROR, TestDecodeEncode(ENCODE_FORMAT::ABBREV_ASCII, aucLog));
+    ASSERT_EQ(DecodeEncodeTest::SUCCESS, TestDecodeEncode(ENCODE_FORMAT::ABBREV_ASCII, aucLog));
 }
 
 // -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Problem:
Responses currently are given the same type as regular messages. E.g. a BESTPOS response has a `novatel_edie.messages.BESTPOS` type. This means that the fields don't match the type.

Abbreviated ascii responses are also handled poorly. They aren't decoded into a useable format and can't be encoded.

Solution:
Introduce a `Response` type. Use the `name` field to indicate which message its associated with. 

Make abbreviated ascii responses decode to an empty header (with the response bit set) and set the name as `UNKNOWN`. Encoding a response to abbreviated ascii is also now supported.