### PR TITLE
Add RXCONFIG decode failure notice

### DIFF
--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -733,6 +733,11 @@ MessageDecoderBase::Decode(const unsigned char* pucMessage_, std::vector<FieldCo
         pvCurrentMsgFields = vMsgDef->GetMsgDefFromCrc(*pclMyLogger, stMetaData_.uiMessageCrc);
     }
 
+    if (stMetaData_.messageName == "RXCONFIG") { 
+        SPDLOG_LOGGER_INFO(pclMyLogger, "RXCONFIG payload decoding is unsupported by this version of EDIE. Support coming soon!");
+        return STATUS::UNSUPPORTED;
+    }
+
     // Expand the intermediate format vector to prevent the copy constructor from being called when the vector grows in size
     stInterMessage_.clear();
     stInterMessage_.reserve(pvCurrentMsgFields.size());

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -733,7 +733,8 @@ MessageDecoderBase::Decode(const unsigned char* pucMessage_, std::vector<FieldCo
         pvCurrentMsgFields = vMsgDef->GetMsgDefFromCrc(*pclMyLogger, stMetaData_.uiMessageCrc);
     }
 
-    if (stMetaData_.messageName == "RXCONFIG") { 
+    if (stMetaData_.messageName == "RXCONFIG")
+    {
         SPDLOG_LOGGER_INFO(pclMyLogger, "RXCONFIG payload decoding is unsupported by this version of EDIE. Support coming soon!");
         return STATUS::UNSUPPORTED;
     }


### PR DESCRIPTION
RXCONFIG handling is currently only properly supported when using the `RxConfigHandler`. This can cause exceptions to be raised when parsing through mixed log messages including RXCONFIG.

Eventually RXCONFIG decoding and encoding functionality should be incorporated directly into the standard decoder and encoder classes to provide full support. For now this pull-request makes the decode failure explicit by returning an UNSUPPORTED status, allowing parsing to continue past undecodable RXCONFIG logs.