### PR TITLE
Fix ConsumeAbbrevFormatting logic

### DIFF
--- a/include/novatel_edie/decoders/common/common.hpp
+++ b/include/novatel_edie/decoders/common/common.hpp
@@ -354,16 +354,11 @@ int32_t GetResponseId(const novatel::edie::EnumDefinition::ConstPtr& stRespDef_,
 //! \brief Strip abbreviated ASCII formatting from the front of the
 //! log buffer.
 //
-//! \param[in] ullTokenLength_ The length of the message contained in
-//! ppcMessageBuffer_
 //! \param[in] ppcMessageBuffer_ A pointer to the buffer containing the
 //! message to have abbreviated ASCII formatting stripped.
-//
-//! \return A boolean describing if the formatting found was abbreviated
-//! ASCII or not. Regardless of this return, the function will attempt
-//! to strip any abbreviated ASCII bytes.
+//! Message is assumed to be null terminated.
 //-----------------------------------------------------------------------
-bool ConsumeAbbrevFormatting(uint64_t ullTokenLength_, const char** ppcMessageBuffer_);
+void ConsumeAbbrevFormatting(const char** ppcMessageBuffer_);
 
 //-----------------------------------------------------------------------
 //! \struct SatelliteId

--- a/src/decoders/common/src/common.cpp
+++ b/src/decoders/common/src/common.cpp
@@ -114,32 +114,17 @@ int32_t GetResponseId(const std::shared_ptr<const EnumDefinition>& stRespDef_, s
 }
 
 //-----------------------------------------------------------------------
-bool ConsumeAbbrevFormatting(const uint64_t ullTokenLength_, const char** ppcMessageBuffer_)
+void ConsumeAbbrevFormatting(const char** ppcMessageBuffer_)
 {
-    bool bIsAbbrev = false;
-
-    if ((ullTokenLength_ == 0 || ullTokenLength_ == 1) &&
-        (static_cast<int8_t>(**ppcMessageBuffer_) == '\r' || static_cast<int8_t>(**ppcMessageBuffer_) == '\n' ||
-         static_cast<int8_t>(**ppcMessageBuffer_) == '<'))
+    while (true)
     {
-        // Skip over '\r\n<     '
-        while (true)
+        switch (**ppcMessageBuffer_)
         {
-            switch (**ppcMessageBuffer_)
-            {
-            case '\r': [[fallthrough]];
-            case '\n': *ppcMessageBuffer_ += sizeof(int8_t); break;
-            case '<':
-                *ppcMessageBuffer_ += sizeof(int8_t);
-                bIsAbbrev = true;
-                break;
-            case ' ':
-                if (bIsAbbrev) { *ppcMessageBuffer_ += sizeof(int8_t); }
-                break;
-            default: return bIsAbbrev;
-            }
+        case '<': [[fallthrough]];
+        case ' ': [[fallthrough]];
+        case '\r': [[fallthrough]];
+        case '\n': *ppcMessageBuffer_ += sizeof(int8_t); break;
+        default: return;
         }
     }
-
-    return bIsAbbrev;
 }

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -407,14 +407,10 @@ STATUS MessageDecoderBase::DecodeAscii(const std::vector<BaseField::Ptr>& vMsgDe
     {
         if (*ppcLogBuf_ >= pcBufEnd) { return STATUS::MALFORMED_INPUT; } // We encountered the end of the buffer unexpectedly
 
+        if constexpr (Abbreviated) { ConsumeAbbrevFormatting(ppcLogBuf_); }
+
         size_t tokenLength = strcspn(*ppcLogBuf_, tokenDelimiters.data());
-
-        if constexpr (Abbreviated)
-        {
-            if (ConsumeAbbrevFormatting(tokenLength, ppcLogBuf_)) { tokenLength = strcspn(*ppcLogBuf_, tokenDelimiters.data()); }
-
-            if (tokenLength == 0) { return STATUS::MALFORMED_INPUT; }
-        }
+        if (tokenLength == 0) { return STATUS::MALFORMED_INPUT; }
 
         bool bEarlyEndOfMessage = (*(*ppcLogBuf_ + tokenLength) == delimiters[1]);
 

--- a/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
+++ b/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
@@ -95,7 +95,7 @@ RxConfigHandler::Convert(MessageDataStruct& stRxConfigMessageData_, MetaDataStru
         // Abbreviated ASCII RXCONFIG logs have indentations on the embedded header. The
         // HeaderDecoder does not expect this and the spaces must be removed. Remove "<     ", then
         // put '<' back at the beginning so the header is treated correctly.
-        ConsumeAbbrevFormatting(0, const_cast<const char**>(reinterpret_cast<char**>(&pucTempMessagePointer)));
+        ConsumeAbbrevFormatting(const_cast<const char**>(reinterpret_cast<char**>(&pucTempMessagePointer)));
         pucTempMessagePointer -= OEM4_ASCII_SYNC_LENGTH;
         *pucTempMessagePointer = OEM4_ABBREV_ASCII_SYNC;
     }


### PR DESCRIPTION
Problem:
The `ConsumeAbbrevFormatting` function will not return if it encounters a `' '` character before `'<'`. The logic of this function is overly complex and its return value doesn't have a clear meaning. It being false could mean that no characters are consumed or that the abbreviated ascii delimiters not organized in a valid way.

Solution:
Make the `ConsumeAbbrevFormatting` just move the buffer forward until it reaches a non-delimiting character. Update the logic around the call slightly to ensure that no test cases are broken.

Note: There's potential for unidentified errors if you get a sequence like `{valid subfield}<\r {garbled mess}` . In such a case the error will be raised when trying to decode `{garbled mess}` into fields when it could have been identified earlier by the invalid delimiter sequence. Ultimately I don't think this matters too much and would prefer to get a fix out for the more pressing defect of indefinite hanging.