### PR TITLE
Propagate BUILD_SHARED_LIBS setting from CMAKE to conan

### DIFF
--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -7,13 +7,20 @@ endif()
 cmake_dependent_option(USE_CONAN "Use Conan to automatically manage dependencies" ON
     "NOT DEFINED VCPKG_TOOLCHAIN AND NOT CONAN_ALREADY_ACTIVE" OFF)
 
+# Set the default profile for Conan if not already set  
+
+set(CONAN_BUILD_SHARED "False")  
+if(BUILD_SHARED_LIBS)  
+   set(CONAN_BUILD_SHARED "True")  
+endif()
+
 if(USE_CONAN)
     if(CMAKE_VERSION VERSION_LESS 3.24)
         message(FATAL_ERROR "Automatic Conan integration requires CMake 3.24 or later.")
     endif()
     include("${CMAKE_CURRENT_LIST_DIR}/SetDefaultProfile.cmake")
     # Set build cppstd for patchelf
-    set(CONAN_INSTALL_ARGS --build missing --settings:build compiler.cppstd=17 CACHE INTERNAL "")
+    set(CONAN_INSTALL_ARGS --build missing -o shared=${CONAN_BUILD_SHARED} --settings:build compiler.cppstd=17 CACHE INTERNAL "")
     list(APPEND CMAKE_PROJECT_TOP_LEVEL_INCLUDES ${CMAKE_CURRENT_LIST_DIR}/conan_provider.cmake)
 endif()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,6 +38,7 @@ class NovatelEdieConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        print(f"Configuring conan with the following options: {self.options}")
         if self.options.shared:
             self.options.rm_safe("fPIC")
             self.options["spdlog"].shared = True


### PR DESCRIPTION
Problem:
If `novatel_edie` is built as a shared dll but `spdlog` is included as a static dependency the unit tests will fail.  I believe this is because the `spdlog` logger registry is not shared between the test code and the dll code. Using a dynamic dependency on `spdlog` solves the issues.

Solution:
The `conan.py` file already has configuration logic stating that if conan is called with the `shared=True` flag, the `spdlog` dependency should be a shared one also. The only problem is that conan does not receive this flag when the project is built directly through CMAKE. This pull request sets the flags value based on whether the `BUILD_SHARED_LIBS` variable is set in CMAKE.