### PR TITLE
Allow other jobs to complete on benchmark failure

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   benchmark-comparison:
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     steps:
       - name: Checkout main branch

--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -237,7 +237,7 @@ static void DecompressRangeCmp5(benchmark::State& state) { DecompressRangeCmp(st
 BENCHMARK(Parse);
 BENCHMARK(FrameAscii);
 BENCHMARK(FrameAbbAscii);
-BENCHMARK(FrameBinary);
+BENCHMARK(FrameBinary)->MinTime(2.0);
 BENCHMARK(FrameJson)->MinTime(2.0);
 BENCHMARK(DecodeAsciiLog);
 BENCHMARK(DecodeAbbrevAsciiLog);

--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -238,7 +238,7 @@ BENCHMARK(Parse);
 BENCHMARK(FrameAscii);
 BENCHMARK(FrameAbbAscii);
 BENCHMARK(FrameBinary);
-BENCHMARK(FrameJson);
+BENCHMARK(FrameJson)->MinTime(2.0);
 BENCHMARK(DecodeAsciiLog);
 BENCHMARK(DecodeAbbrevAsciiLog);
 BENCHMARK(DecodeBinaryLog);

--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -235,8 +235,8 @@ static void DecompressRangeCmp4(benchmark::State& state) { DecompressRangeCmp(st
 static void DecompressRangeCmp5(benchmark::State& state) { DecompressRangeCmp(state, RANGECMP5_MSG_ID, rangecmp5Log.data()); }
 
 BENCHMARK(Parse);
-BENCHMARK(FrameAscii);
-BENCHMARK(FrameAbbAscii);
+BENCHMARK(FrameAscii)->MinTime(2.0);
+BENCHMARK(FrameAbbAscii)->MinTime(2.0);
 BENCHMARK(FrameBinary)->MinTime(2.0);
 BENCHMARK(FrameJson)->MinTime(2.0);
 BENCHMARK(DecodeAsciiLog);


### PR DESCRIPTION
Keeping benchmark requirements in place as is for now, updating workflow so that job does not have any possibility of cancelling other jobs if it fails.