### PR TITLE
Allow whitespace padded ascii values to be decoded

### DIFF
--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -118,6 +118,8 @@ class MessageDecoderBase
         T value;
         std::from_chars_result result;
 
+        // As of 6/26/2025 spaces may appear within ascii fields of OUTPUTDATUM and SETALIGNMENTVEL as they use conversion strings with width values.
+        // EDIE supports decoding of this data but will never pad fields with spaces during encoding.
         uint32_t offset = 0;
         while ((token[offset] == ' ') && (offset < tokenLength - 1)) { ++offset; }
 

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -118,8 +118,11 @@ class MessageDecoderBase
         T value;
         std::from_chars_result result;
 
-        if constexpr (std::is_integral_v<T>) { result = std::from_chars(token, token + tokenLength, value, R); }
-        else if constexpr (std::is_floating_point_v<T>) { result = std::from_chars(token, token + tokenLength, value); }
+        uint32_t offset = 0;
+        while ((token[offset] == ' ') && (offset < tokenLength - 1)) { ++offset; }
+
+        if constexpr (std::is_integral_v<T>) { result = std::from_chars(token + offset, token + tokenLength, value, R); }
+        else if constexpr (std::is_floating_point_v<T>) { result = std::from_chars(token + offset, token + tokenLength, value); }
 
         if (result.ec != std::errc()) { throw std::runtime_error("Failed to parse numeric value"); }
 


### PR DESCRIPTION
Certain logs may be output by the receiver with whitespace preceding an integer or float value. This pull request updates the decoder to allow for this. On encoding the whitespace will be removed.