### PR TITLE
Make PyMessageDB aggregate MessageDB to simplify ownership dynamics

### DIFF
--- a/include/novatel_edie/decoders/common/encoder.hpp
+++ b/include/novatel_edie/decoders/common/encoder.hpp
@@ -272,8 +272,7 @@ template <typename Derived> class EncoderBase
 {
   protected:
     std::shared_ptr<spdlog::logger> pclMyLogger{GetBaseLoggerManager()->RegisterLogger("encoder")};
-    MessageDatabase::ConstPtr pclMyMsgDbStrongRef{nullptr};
-    const MessageDatabase* pclMyMsgDb{nullptr};
+    MessageDatabase::ConstPtr pclMyMsgDb{nullptr};
 
     EnumDefinition::ConstPtr vMyCommandDefinitions{nullptr};
     EnumDefinition::ConstPtr vMyPortAddressDefinitions{nullptr};
@@ -762,16 +761,10 @@ template <typename Derived> class EncoderBase
     //
     //! \param[in] pclMessageDb_ A pointer to a MessageDatabase object. Defaults to nullptr.
     //----------------------------------------------------------------------------
-    EncoderBase(const MessageDatabase* pclMessageDb_ = nullptr)
+    EncoderBase(MessageDatabase::ConstPtr pclMessageDb_ = nullptr)
     {
         static_cast<Derived*>(this)->InitFieldMaps();
         if (pclMessageDb_ != nullptr) { LoadJsonDb(pclMessageDb_); }
-    }
-
-    EncoderBase(MessageDatabase::ConstPtr pclMessageDb_)
-    {
-        static_cast<Derived*>(this)->InitFieldMaps();
-        if (pclMessageDb_ != nullptr) { LoadSharedJsonDb(pclMessageDb_); }
     }
 
     //----------------------------------------------------------------------------
@@ -784,16 +777,10 @@ template <typename Derived> class EncoderBase
     //
     //! \param[in] pclMessageDb_ A pointer to a MessageDatabase object.
     //----------------------------------------------------------------------------
-    void LoadJsonDb(const MessageDatabase* pclMessageDb_)
+    void LoadJsonDb(MessageDatabase::ConstPtr pclMessageDb_)
     {
         pclMyMsgDb = pclMessageDb_;
         static_cast<Derived*>(this)->InitEnumDefinitions();
-    }
-
-    void LoadSharedJsonDb(MessageDatabase::ConstPtr pclMessageDb_)
-    {
-        pclMyMsgDbStrongRef = pclMessageDb_;
-        LoadJsonDb(pclMessageDb_.get());
     }
 
     //----------------------------------------------------------------------------

--- a/include/novatel_edie/decoders/oem/encoder.hpp
+++ b/include/novatel_edie/decoders/oem/encoder.hpp
@@ -75,9 +75,7 @@ class Encoder : public EncoderBase<Encoder>
     //
     //! \param[in] pclMessageDb_ A pointer to a MessageDatabase object. Defaults to nullptr.
     //----------------------------------------------------------------------------
-    Encoder(MessageDatabase* pclMessageDb_ = nullptr);
-
-    Encoder(MessageDatabase::ConstPtr pclMessageDb_);
+    Encoder(MessageDatabase::ConstPtr pclMessageDb_ = nullptr);
 
     //----------------------------------------------------------------------------
     //! \brief Encode an OEM message from the provided intermediate structures.

--- a/python/bindings/commander.cpp
+++ b/python/bindings/commander.cpp
@@ -18,7 +18,6 @@ void init_novatel_commander(nb::module_& m)
                 new (t) oem::Commander(message_db->GetCoreDatabase());
             },
             nb::arg("message_db") = nb::none()) // NOLINT(*.NewDeleteLeaks)
-        .def("load_db", &oem::Commander::LoadJsonDb, "message_db"_a)
         .def(
             "encode",
             [](oem::Commander& commander, const nb::bytes& command, const ENCODE_FORMAT format) {

--- a/python/bindings/commander.cpp
+++ b/python/bindings/commander.cpp
@@ -1,8 +1,8 @@
 #include "novatel_edie/decoders/oem/commander.hpp"
 
 #include "bindings_core.hpp"
-#include "message_db_singleton.hpp"
 #include "exceptions.hpp"
+#include "message_db_singleton.hpp"
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -11,8 +11,13 @@ using namespace novatel::edie;
 void init_novatel_commander(nb::module_& m)
 {
     nb::class_<oem::Commander>(m, "Commander")
-        .def("__init__", [](oem::Commander* t) { new (t) oem::Commander(MessageDbSingleton::get()); }) // NOLINT(*.NewDeleteLeaks)
-        .def(nb::init<PyMessageDatabase::Ptr&>(), "message_db"_a)
+        .def(
+            "__init__",
+            [](oem::Commander* t, PyMessageDatabase::Ptr message_db) {
+                if (!message_db) { message_db = MessageDbSingleton::get(); };
+                new (t) oem::Commander(message_db->GetCoreDatabase());
+            },
+            nb::arg("message_db") = nb::none()) // NOLINT(*.NewDeleteLeaks)
         .def("load_db", &oem::Commander::LoadJsonDb, "message_db"_a)
         .def(
             "encode",

--- a/python/bindings/decoder.hpp
+++ b/python/bindings/decoder.hpp
@@ -19,7 +19,7 @@ class PyDecoder
     HeaderDecoder header_decoder;
     MessageDecoder message_decoder;
 
-    PyDecoder(PyMessageDatabase::Ptr pclMessageDb_) : database(pclMessageDb_), header_decoder(pclMessageDb_), message_decoder(pclMessageDb_) {}
+    PyDecoder(PyMessageDatabase::Ptr pclMessageDb_) : database(pclMessageDb_), header_decoder(pclMessageDb_->GetCoreDatabase()), message_decoder(pclMessageDb_->GetCoreDatabase()) {}
 
     nb::object DecodeMessage(const nb::bytes raw_body, oem::PyHeader& header, oem::MetaDataStruct& metadata) const;
 };

--- a/python/bindings/file_parser.cpp
+++ b/python/bindings/file_parser.cpp
@@ -22,8 +22,7 @@ nb::object oem::PyFileParser::PyRead()
 
     STATUS status = ReadIntermediate(message_data, header, message_fields, metadata);
 
-    return HandlePythonReadStatus(status, message_data, header, std::move(message_fields), metadata,
-                                  std::static_pointer_cast<const PyMessageDatabase>(this->MessageDb()));
+    return HandlePythonReadStatus(status, message_data, header, std::move(message_fields), metadata, pclPyMessageDb);
 }
 
 nb::object oem::PyFileParser::PyIterRead()

--- a/python/bindings/file_parser.hpp
+++ b/python/bindings/file_parser.hpp
@@ -17,6 +17,7 @@ namespace novatel::edie::oem {
 class PyFileParser : public FileParser
 {
   private:
+    PyMessageDatabase::Ptr pclPyMessageDb;
     void SetStreamByPath(const std::filesystem::path& filepath_)
     {
         auto ifs = std::make_shared<std::ifstream>(filepath_, std::ios::binary);
@@ -27,7 +28,8 @@ class PyFileParser : public FileParser
   public:
     PyFileParser(const std::filesystem::path& filepath_) : PyFileParser(filepath_, MessageDbSingleton::get()) {};
 
-    PyFileParser(const std::filesystem::path& filepath_, const PyMessageDatabase::Ptr& message_db_pointer) : FileParser(message_db_pointer)
+    PyFileParser(const std::filesystem::path& filepath_, const PyMessageDatabase::Ptr& message_db_pointer)
+        : FileParser(message_db_pointer->GetCoreDatabase()), pclPyMessageDb(message_db_pointer)
     {
         SetStreamByPath(filepath_);
     }

--- a/python/bindings/internal/decoder_tester.cpp
+++ b/python/bindings/internal/decoder_tester.cpp
@@ -37,7 +37,11 @@ class DecoderTester : public oem::MessageDecoder
 void init_decoder_tester(nb::module_ &m)
 {
     nb::class_<DecoderTester>(m, "DecoderTester")
-        .def(nb::init<const PyMessageDatabase::Ptr&>(), "json_db"_a)
+        .def("__init__",
+             [](DecoderTester* t, PyMessageDatabase::Ptr message_db) {
+                 if (!message_db) { message_db = MessageDbSingleton::get(); };
+                 new (t) DecoderTester(message_db->GetCoreDatabase());
+             }) // NOLINT(*.NewDeleteLeaks)
         .def(
             "decode_ascii",
             [](DecoderTester& decoder, const std::vector<BaseField::Ptr>& msg_def_fields, const nb::bytes& message_body) {

--- a/python/bindings/message_database.cpp
+++ b/python/bindings/message_database.cpp
@@ -214,23 +214,23 @@ PyMessageDatabaseCore::PyMessageDatabaseCore(const MessageDatabase&& message_db)
     UpdatePythonMessageTypes();
 }
 
-PyMessageDatabase::PyMessageDatabase() : pclMessageDb(std::make_shared<PyMessageDatabaseCore>()) { pclEncoder = std::make_shared<oem::Encoder>(this->pclMessageDb); }
+PyMessageDatabase::PyMessageDatabase() : pclMessageDb(std::make_shared<PyMessageDatabaseCore>()) { pclEncoder = std::make_unique<oem::Encoder>(this->pclMessageDb); }
 
 PyMessageDatabase::PyMessageDatabase(std::vector<MessageDefinition::ConstPtr> vMessageDefinitions_,
                                      std::vector<EnumDefinition::ConstPtr> vEnumDefinitions_)
     : pclMessageDb(std::make_shared<PyMessageDatabaseCore>(std::move(vMessageDefinitions_), std::move(vEnumDefinitions_)))
 {
-    pclEncoder = std::make_shared<oem::Encoder>(this->pclMessageDb);
+    pclEncoder = std::make_unique<oem::Encoder>(this->pclMessageDb);
 }
 
 PyMessageDatabase::PyMessageDatabase(const MessageDatabase& message_db) noexcept : pclMessageDb(std::make_shared<PyMessageDatabaseCore>(message_db)) {
-    pclEncoder = std::make_shared<oem::Encoder>(this->pclMessageDb);
+    pclEncoder = std::make_unique<oem::Encoder>(this->pclMessageDb);
 }
 
 PyMessageDatabase::PyMessageDatabase(const MessageDatabase&& message_db) noexcept
-    : pclMessageDb(std::make_shared<PyMessageDatabaseCore>(std::move(message_db)))
+    : pclMessageDb(std::make_shared<PyMessageDatabaseCore>(message_db))
 {
-    pclEncoder = std::make_shared<oem::Encoder>(this->pclMessageDb);
+    pclEncoder = std::make_unique<oem::Encoder>(this->pclMessageDb);
 }
 
 void PyMessageDatabaseCore::GenerateMessageMappings()

--- a/python/bindings/message_database.cpp
+++ b/python/bindings/message_database.cpp
@@ -192,7 +192,6 @@ PyMessageDatabaseCore::PyMessageDatabaseCore()
 {
     UpdatePythonEnums();
     UpdatePythonMessageTypes();
-    encoder = std::make_shared<oem::Encoder>(this);
 }
 
 PyMessageDatabaseCore::PyMessageDatabaseCore(std::vector<MessageDefinition::ConstPtr> vMessageDefinitions_,
@@ -201,36 +200,37 @@ PyMessageDatabaseCore::PyMessageDatabaseCore(std::vector<MessageDefinition::Cons
 {
     UpdatePythonEnums();
     UpdatePythonMessageTypes();
-    encoder = std::make_shared<oem::Encoder>(this);
 }
 
 PyMessageDatabaseCore::PyMessageDatabaseCore(const MessageDatabase& message_db) noexcept : MessageDatabase(message_db)
 {
     UpdatePythonEnums();
     UpdatePythonMessageTypes();
-    encoder = std::make_shared<oem::Encoder>(this);
 }
 
 PyMessageDatabaseCore::PyMessageDatabaseCore(const MessageDatabase&& message_db) noexcept : MessageDatabase(message_db)
 {
     UpdatePythonEnums();
     UpdatePythonMessageTypes();
-    encoder = std::make_shared<oem::Encoder>(this);
 }
 
-PyMessageDatabase::PyMessageDatabase() : message_db(std::make_shared<PyMessageDatabaseCore>()) {}
+PyMessageDatabase::PyMessageDatabase() : pclMessageDb(std::make_shared<PyMessageDatabaseCore>()) { pclEncoder = std::make_shared<oem::Encoder>(this->pclMessageDb); }
 
 PyMessageDatabase::PyMessageDatabase(std::vector<MessageDefinition::ConstPtr> vMessageDefinitions_,
                                      std::vector<EnumDefinition::ConstPtr> vEnumDefinitions_)
-    : message_db(std::make_shared<PyMessageDatabaseCore>(std::move(vMessageDefinitions_), std::move(vEnumDefinitions_)))
+    : pclMessageDb(std::make_shared<PyMessageDatabaseCore>(std::move(vMessageDefinitions_), std::move(vEnumDefinitions_)))
 {
+    pclEncoder = std::make_shared<oem::Encoder>(this->pclMessageDb);
 }
 
-PyMessageDatabase::PyMessageDatabase(const MessageDatabase& message_db) noexcept : message_db(std::make_shared<PyMessageDatabaseCore>(message_db)) {}
+PyMessageDatabase::PyMessageDatabase(const MessageDatabase& message_db) noexcept : pclMessageDb(std::make_shared<PyMessageDatabaseCore>(message_db)) {
+    pclEncoder = std::make_shared<oem::Encoder>(this->pclMessageDb);
+}
 
 PyMessageDatabase::PyMessageDatabase(const MessageDatabase&& message_db) noexcept
-    : message_db(std::make_shared<PyMessageDatabaseCore>(std::move(message_db)))
+    : pclMessageDb(std::make_shared<PyMessageDatabaseCore>(std::move(message_db)))
 {
+    pclEncoder = std::make_shared<oem::Encoder>(this->pclMessageDb);
 }
 
 void PyMessageDatabaseCore::GenerateMessageMappings()

--- a/python/bindings/message_database.cpp
+++ b/python/bindings/message_database.cpp
@@ -188,16 +188,15 @@ void init_common_message_database(nb::module_& m)
         .def("get_enum_type_by_id", [](PyMessageDatabase& self, std::string id) { return self.GetEnumsByIdDict().at(id); }, "id"_a);
 }
 
-
-PyMessageDatabase::PyMessageDatabase()
+PyMessageDatabaseCore::PyMessageDatabaseCore()
 {
     UpdatePythonEnums();
     UpdatePythonMessageTypes();
     encoder = std::make_shared<oem::Encoder>(this);
 }
 
-PyMessageDatabase::PyMessageDatabase(std::vector<MessageDefinition::ConstPtr> vMessageDefinitions_,
-                                     std::vector<EnumDefinition::ConstPtr> vEnumDefinitions_)
+PyMessageDatabaseCore::PyMessageDatabaseCore(std::vector<MessageDefinition::ConstPtr> vMessageDefinitions_,
+                                             std::vector<EnumDefinition::ConstPtr> vEnumDefinitions_)
     : MessageDatabase(std::move(vMessageDefinitions_), std::move(vEnumDefinitions_))
 {
     UpdatePythonEnums();
@@ -205,27 +204,42 @@ PyMessageDatabase::PyMessageDatabase(std::vector<MessageDefinition::ConstPtr> vM
     encoder = std::make_shared<oem::Encoder>(this);
 }
 
-PyMessageDatabase::PyMessageDatabase(const MessageDatabase& message_db) noexcept : MessageDatabase(message_db)
+PyMessageDatabaseCore::PyMessageDatabaseCore(const MessageDatabase& message_db) noexcept : MessageDatabase(message_db)
 {
     UpdatePythonEnums();
     UpdatePythonMessageTypes();
     encoder = std::make_shared<oem::Encoder>(this);
 }
 
-PyMessageDatabase::PyMessageDatabase(const MessageDatabase&& message_db) noexcept : MessageDatabase(message_db)
+PyMessageDatabaseCore::PyMessageDatabaseCore(const MessageDatabase&& message_db) noexcept : MessageDatabase(message_db)
 {
     UpdatePythonEnums();
     UpdatePythonMessageTypes();
     encoder = std::make_shared<oem::Encoder>(this);
 }
 
-void PyMessageDatabase::GenerateMessageMappings()
+PyMessageDatabase::PyMessageDatabase() : message_db(std::make_shared<PyMessageDatabaseCore>()) {}
+
+PyMessageDatabase::PyMessageDatabase(std::vector<MessageDefinition::ConstPtr> vMessageDefinitions_,
+                                     std::vector<EnumDefinition::ConstPtr> vEnumDefinitions_)
+    : message_db(std::make_shared<PyMessageDatabaseCore>(std::move(vMessageDefinitions_), std::move(vEnumDefinitions_)))
+{
+}
+
+PyMessageDatabase::PyMessageDatabase(const MessageDatabase& message_db) noexcept : message_db(std::make_shared<PyMessageDatabaseCore>(message_db)) {}
+
+PyMessageDatabase::PyMessageDatabase(const MessageDatabase&& message_db) noexcept
+    : message_db(std::make_shared<PyMessageDatabaseCore>(std::move(message_db)))
+{
+}
+
+void PyMessageDatabaseCore::GenerateMessageMappings()
 {
     MessageDatabase::GenerateMessageMappings();
     UpdatePythonMessageTypes();
 }
 
-void PyMessageDatabase::GenerateEnumMappings()
+void PyMessageDatabaseCore::GenerateEnumMappings()
 {
     MessageDatabase::GenerateEnumMappings();
     UpdatePythonEnums();
@@ -241,7 +255,7 @@ void cleanString(std::string& str)
     if (isdigit(str[0])) { str = "_" + str; }
 }
 
-inline void PyMessageDatabase::UpdatePythonEnums()
+inline void PyMessageDatabaseCore::UpdatePythonEnums()
 {
     nb::object IntEnum = nb::module_::import_("enum").attr("IntEnum");
     enums_by_id.clear();
@@ -264,8 +278,8 @@ inline void PyMessageDatabase::UpdatePythonEnums()
     }
 }
 
-void PyMessageDatabase::AddFieldType(std::vector<std::shared_ptr<BaseField>> fields, std::string base_name, nb::handle type_constructor,
-                                     nb::handle type_tuple, nb::handle type_dict)
+void PyMessageDatabaseCore::AddFieldType(std::vector<std::shared_ptr<BaseField>> fields, std::string base_name, nb::handle type_constructor,
+                                         nb::handle type_tuple, nb::handle type_dict)
 {
     // rescursively add field types for each field array element within the provided vector
     for (const auto& field : fields)
@@ -281,7 +295,7 @@ void PyMessageDatabase::AddFieldType(std::vector<std::shared_ptr<BaseField>> fie
     }
 }
 
-void PyMessageDatabase::UpdatePythonMessageTypes()
+void PyMessageDatabaseCore::UpdatePythonMessageTypes()
 {
     // clear existing definitions
     messages_by_name.clear();

--- a/python/bindings/parser.cpp
+++ b/python/bindings/parser.cpp
@@ -36,8 +36,7 @@ nb::object oem::PyParser::PyRead(bool decode_incomplete)
     std::vector<FieldContainer> message_fields;
 
     STATUS status = ReadIntermediate(message_data, header, message_fields, metadata, decode_incomplete);
-    return HandlePythonReadStatus(status, message_data, header, std::move(message_fields), metadata,
-                                  std::static_pointer_cast<const PyMessageDatabase>(MessageDb()));
+    return HandlePythonReadStatus(status, message_data, header, std::move(message_fields), metadata, pclPyMessageDb);
 }
 
 nb::object oem::PyParser::PyIterRead()

--- a/python/bindings/parser.hpp
+++ b/python/bindings/parser.hpp
@@ -16,9 +16,12 @@ nb::object HandlePythonReadStatus(STATUS status_, MessageDataStruct& message_dat
 
 class PyParser : public Parser
 {
+  private:
+    PyMessageDatabase::Ptr pclPyMessageDb;
+
   public:
     // inherit constructors
-    using Parser::Parser;
+    PyParser(PyMessageDatabase::Ptr& pclMessageDb_) : Parser(pclMessageDb_->GetCoreDatabase()), pclPyMessageDb(pclMessageDb_) {}
 
     nb::object PyRead(bool decode_incomplete);
     nb::object PyIterRead();

--- a/python/bindings/py_database.hpp
+++ b/python/bindings/py_database.hpp
@@ -97,15 +97,15 @@ class PyMessageDatabase
     [[nodiscard]] const std::unordered_map<std::string, nb::object>& GetEnumsByNameDict() const { return pclMessageDb->GetEnumsByNameDict(); }
 
   private:
-    PyMessageDatabaseCore::Ptr pclMessageDb; // This is the base MessageDatabase that this class wraps
-    std::shared_ptr<oem::Encoder> pclEncoder;
+    PyMessageDatabaseCore::Ptr pclMessageDb; // This is the MessageDatabase that this class wraps
+    std::unique_ptr<oem::Encoder> pclEncoder;
 
   public:
     using Ptr = std::shared_ptr<PyMessageDatabase>;
     using ConstPtr = std::shared_ptr<const PyMessageDatabase>;
 
     PyMessageDatabaseCore::Ptr GetCoreDatabase() const { return pclMessageDb; }
-    std::shared_ptr<const oem::Encoder> GetEncoder() const { return pclEncoder; }
+    const oem::Encoder* GetEncoder() const { return pclEncoder.get(); }
 };
 
 } // namespace novatel::edie

--- a/python/bindings/py_database.hpp
+++ b/python/bindings/py_database.hpp
@@ -57,11 +57,7 @@ class PyMessageDatabaseCore : public MessageDatabase
     std::unordered_map<std::string, nb::object> enums_by_id{};
     std::unordered_map<std::string, nb::object> enums_by_name{};
 
-    std::shared_ptr<oem::Encoder> encoder;
-
   public:
-    std::shared_ptr<const oem::Encoder> get_encoder() const { return encoder; }
-
     using Ptr = std::shared_ptr<PyMessageDatabaseCore>;
     using ConstPtr = std::shared_ptr<const PyMessageDatabaseCore>;
 };
@@ -74,42 +70,42 @@ class PyMessageDatabase
     explicit PyMessageDatabase(const MessageDatabase& message_db) noexcept;
     explicit PyMessageDatabase(const MessageDatabase&& message_db) noexcept;
 
-    std::shared_ptr<const oem::Encoder> get_encoder() const { return message_db->get_encoder(); }
+    [[nodiscard]] std::string MsgIdToMsgName(uint32_t uiMessageId_) const { return pclMessageDb->MsgIdToMsgName(uiMessageId_); };
 
-    [[nodiscard]] std::string MsgIdToMsgName(uint32_t uiMessageId_) const { message_db->MsgIdToMsgName(uiMessageId_); };
+    void PyAppendMessages(const std::vector<MessageDefinition::ConstPtr>& vMessageDefinitions_) { pclMessageDb->AppendMessages(vMessageDefinitions_); }
 
-    void PyAppendMessages(const std::vector<MessageDefinition::ConstPtr>& vMessageDefinitions_) { message_db->AppendMessages(vMessageDefinitions_); }
+    void PyAppendEnumerations(const std::vector<EnumDefinition::ConstPtr>& vEnumDefinitions_) { pclMessageDb->AppendEnumerations(vEnumDefinitions_); }
 
-    void PyAppendEnumerations(const std::vector<EnumDefinition::ConstPtr>& vEnumDefinitions_) { message_db->AppendEnumerations(vEnumDefinitions_); }
+    void PyRemoveMessage(const uint32_t iMsgId_) { pclMessageDb->RemoveMessage(iMsgId_); }
 
-    void PyRemoveMessage(const uint32_t iMsgId_) { message_db->RemoveMessage(iMsgId_); }
-
-    void PyRemoveEnumeration(std::string_view strEnumeration_) { message_db->RemoveEnumeration(strEnumeration_); }
+    void PyRemoveEnumeration(std::string_view strEnumeration_) { pclMessageDb->RemoveEnumeration(strEnumeration_); }
 
     // MessageDatabase wrappers
-    [[nodiscard]] MessageDefinition::ConstPtr GetMsgDef(std::string_view strMsgName_) const { return message_db->GetMsgDef(strMsgName_); }
-    [[nodiscard]] MessageDefinition::ConstPtr GetMsgDef(int32_t iMsgId_) const { return message_db->GetMsgDef(iMsgId_); }
+    [[nodiscard]] MessageDefinition::ConstPtr GetMsgDef(std::string_view strMsgName_) const { return pclMessageDb->GetMsgDef(strMsgName_); }
+    [[nodiscard]] MessageDefinition::ConstPtr GetMsgDef(int32_t iMsgId_) const { return pclMessageDb->GetMsgDef(iMsgId_); }
 
-    [[nodiscard]] EnumDefinition::ConstPtr GetEnumDefId(std::string& strEnumId_) const { return message_db->GetEnumDefId(strEnumId_); }
-    [[nodiscard]] EnumDefinition::ConstPtr GetEnumDefName(std::string& strEnumName_) const { return message_db->GetEnumDefName(strEnumName_); }
+    [[nodiscard]] EnumDefinition::ConstPtr GetEnumDefId(std::string& strEnumId_) const { return pclMessageDb->GetEnumDefId(strEnumId_); }
+    [[nodiscard]] EnumDefinition::ConstPtr GetEnumDefName(std::string& strEnumName_) const { return pclMessageDb->GetEnumDefName(strEnumName_); }
 
-    void Merge(const MessageDatabase& other_) { message_db->Merge(other_); }
+    void Merge(const MessageDatabase& other_) { pclMessageDb->Merge(other_); }
 
     // PyMessageDatabaseCore wrappers
-    [[nodiscard]] const std::unordered_map<std::string, PyMessageType*>& GetMessagesByNameDict() const { return message_db->GetMessagesByNameDict(); }
-    [[nodiscard]] const std::unordered_map<std::string, nb::object>& GetFieldsByNameDict() const { return message_db->GetFieldsByNameDict(); }
+    [[nodiscard]] const std::unordered_map<std::string, PyMessageType*>& GetMessagesByNameDict() const { return pclMessageDb->GetMessagesByNameDict(); }
+    [[nodiscard]] const std::unordered_map<std::string, nb::object>& GetFieldsByNameDict() const { return pclMessageDb->GetFieldsByNameDict(); }
 
-    [[nodiscard]] const std::unordered_map<std::string, nb::object>& GetEnumsByIdDict() const { return message_db->GetEnumsByIdDict(); }
-    [[nodiscard]] const std::unordered_map<std::string, nb::object>& GetEnumsByNameDict() const { return message_db->GetEnumsByNameDict(); }
+    [[nodiscard]] const std::unordered_map<std::string, nb::object>& GetEnumsByIdDict() const { return pclMessageDb->GetEnumsByIdDict(); }
+    [[nodiscard]] const std::unordered_map<std::string, nb::object>& GetEnumsByNameDict() const { return pclMessageDb->GetEnumsByNameDict(); }
 
   private:
-    PyMessageDatabaseCore::Ptr message_db; // This is the base MessageDatabase that this class wraps
+    PyMessageDatabaseCore::Ptr pclMessageDb; // This is the base MessageDatabase that this class wraps
+    std::shared_ptr<oem::Encoder> pclEncoder;
 
   public:
     using Ptr = std::shared_ptr<PyMessageDatabase>;
     using ConstPtr = std::shared_ptr<const PyMessageDatabase>;
 
-    PyMessageDatabaseCore::Ptr GetCoreDatabase() const { return message_db; }
+    PyMessageDatabaseCore::Ptr GetCoreDatabase() const { return pclMessageDb; }
+    std::shared_ptr<const oem::Encoder> GetEncoder() const { return pclEncoder; }
 };
 
 } // namespace novatel::edie

--- a/python/bindings/py_message_objects.cpp
+++ b/python/bindings/py_message_objects.cpp
@@ -257,7 +257,7 @@ oem::PyMessageData PyEncode(PyEncodableField& py_message, const PyMessageDatabas
 {
     STATUS status;
     MessageDataStruct message_data = MessageDataStruct();
-    std::shared_ptr<const Encoder> encoder = db->get_encoder();
+    std::shared_ptr<const Encoder> encoder = db->GetEncoder();
 
     if (format == ENCODE_FORMAT::JSON)
     {

--- a/python/bindings/py_message_objects.cpp
+++ b/python/bindings/py_message_objects.cpp
@@ -253,11 +253,10 @@ std::string PyField::repr() const
 
 #pragma region PyMessageMethods
 
-oem::PyMessageData PyEncode(PyEncodableField& py_message, const PyMessageDatabase* db, ENCODE_FORMAT format)
+oem::PyMessageData PyEncode(PyEncodableField& py_message, const Encoder* encoder, ENCODE_FORMAT format)
 {
     STATUS status;
     MessageDataStruct message_data = MessageDataStruct();
-    std::shared_ptr<const Encoder> encoder = db->GetEncoder();
 
     if (format == ENCODE_FORMAT::JSON)
     {
@@ -280,17 +279,17 @@ oem::PyMessageData PyEncode(PyEncodableField& py_message, const PyMessageDatabas
     return PyMessageData(message_data);
 }
 
-PyMessageData PyEncodableField::encode(ENCODE_FORMAT fmt) { return PyEncode(*this, this->parent_db_.get(), fmt); }
+PyMessageData PyEncodableField::encode(ENCODE_FORMAT fmt) { return PyEncode(*this, this->parent_db_->GetEncoder(), fmt); }
 
-PyMessageData PyEncodableField::to_ascii() { return PyEncode(*this, this->parent_db_.get(), ENCODE_FORMAT::ASCII); }
+PyMessageData PyEncodableField::to_ascii() { return PyEncode(*this, this->parent_db_->GetEncoder(), ENCODE_FORMAT::ASCII); }
 
-PyMessageData PyEncodableField::to_abbrev_ascii() { return PyEncode(*this, this->parent_db_.get(), ENCODE_FORMAT::ABBREV_ASCII); }
+PyMessageData PyEncodableField::to_abbrev_ascii() { return PyEncode(*this, this->parent_db_->GetEncoder(), ENCODE_FORMAT::ABBREV_ASCII); }
 
-PyMessageData PyEncodableField::to_binary() { return PyEncode(*this, this->parent_db_.get(), ENCODE_FORMAT::BINARY); }
+PyMessageData PyEncodableField::to_binary() { return PyEncode(*this, this->parent_db_->GetEncoder(), ENCODE_FORMAT::BINARY); }
 
-PyMessageData PyEncodableField::to_flattened_binary() { return PyEncode(*this, this->parent_db_.get(), ENCODE_FORMAT::FLATTENED_BINARY); }
+PyMessageData PyEncodableField::to_flattened_binary() { return PyEncode(*this, this->parent_db_->GetEncoder(), ENCODE_FORMAT::FLATTENED_BINARY); }
 
-PyMessageData PyEncodableField::to_json() { return PyEncode(*this, this->parent_db_.get(), ENCODE_FORMAT::JSON); }
+PyMessageData PyEncodableField::to_json() { return PyEncode(*this, this->parent_db_->GetEncoder(), ENCODE_FORMAT::JSON); }
 
 #pragma endregion
 
@@ -527,7 +526,7 @@ void init_message_objects(nb::module_& m)
                 The name of every top-level field within the message payload.      
             )doc")
         .def("get_field_values", &PyField::get_values,
-            R"doc(
+             R"doc(
             Retrieves the values of every top-level field within the payload of this message.
 
             Returns:

--- a/python/bindings/range_decompressor.cpp
+++ b/python/bindings/range_decompressor.cpp
@@ -13,13 +13,15 @@ using namespace novatel::edie;
 void init_novatel_range_decompressor(nb::module_& m)
 {
     nb::class_<oem::RangeDecompressor>(m, "RangeDecompressor")
-        .def("__init__",
-             [](oem::RangeDecompressor* t) {
-                 new (t) oem::RangeDecompressor(MessageDbSingleton::get());
-                 t->GetLogger()->warn(
-                     "The RangeDecompressor interface is currently unstable! It may undergo breaking changes between minor version increments.");
-             }) // NOLINT(*.NewDeleteLeaks)
-        .def(nb::init<PyMessageDatabase::Ptr&>(), "message_db"_a)
+        .def(
+            "__init__",
+            [](oem::RangeDecompressor* t, PyMessageDatabase::Ptr message_db) {
+                if (!message_db) { message_db = MessageDbSingleton::get(); };
+                new (t) oem::RangeDecompressor(message_db->GetCoreDatabase());
+                t->GetLogger()->warn(
+                    "The RangeDecompressor interface is currently unstable! It may undergo breaking changes between minor version increments.");
+            },
+            nb::arg("message_db") = nb::none()) // NOLINT(*.NewDeleteLeaks)
         .def("reset", &oem::RangeDecompressor::Reset)
         .def(
             "decompress",

--- a/python/bindings/rxconfig_handler.cpp
+++ b/python/bindings/rxconfig_handler.cpp
@@ -12,13 +12,16 @@ using namespace novatel::edie;
 void init_novatel_rxconfig_handler(nb::module_& m)
 {
     nb::class_<oem::RxConfigHandler>(m, "RxConfigHandler")
-        .def("__init__",
-             [](oem::RxConfigHandler* t) {
-                 new (t) oem::RxConfigHandler(MessageDbSingleton::get());
-                 t->GetLogger()->warn(
-                     "The RXConfigHandler interface is currently unstable! It may undergo breaking changes between minor version increments.");
-             }) // NOLINT(*.NewDeleteLeaks)
-        .def(nb::init<const PyMessageDatabase::Ptr&>(), "message_db"_a)
+        .def(
+            "__init__",
+            [](oem::RxConfigHandler* t, PyMessageDatabase::Ptr message_db) {
+                if (!message_db) { message_db = MessageDbSingleton::get(); };
+                new (t) oem::RxConfigHandler(message_db->GetCoreDatabase());
+                t->GetLogger()->warn(
+                    "The RXConfigHandler interface is currently unstable! It may undergo breaking changes between minor version increments.");
+            },
+            nb::arg("message_db") = nb::none()) // NOLINT(*.NewDeleteLeaks)
+        // TODO: Fix any bindings that take a regular message database pointer!
         .def("load_db", &oem::RxConfigHandler::LoadJsonDb, "message_db"_a)
         .def("write", [](oem::RxConfigHandler& self,
                          const nb::bytes& data) { return self.Write(reinterpret_cast<uint8_t*>(const_cast<char*>(data.c_str())), data.size()); })

--- a/python/bindings/rxconfig_handler.cpp
+++ b/python/bindings/rxconfig_handler.cpp
@@ -21,8 +21,6 @@ void init_novatel_rxconfig_handler(nb::module_& m)
                     "The RXConfigHandler interface is currently unstable! It may undergo breaking changes between minor version increments.");
             },
             nb::arg("message_db") = nb::none()) // NOLINT(*.NewDeleteLeaks)
-        // TODO: Fix any bindings that take a regular message database pointer!
-        .def("load_db", &oem::RxConfigHandler::LoadJsonDb, "message_db"_a)
         .def("write", [](oem::RxConfigHandler& self,
                          const nb::bytes& data) { return self.Write(reinterpret_cast<uint8_t*>(const_cast<char*>(data.c_str())), data.size()); })
         .def(

--- a/src/decoders/oem/src/encoder.cpp
+++ b/src/decoders/oem/src/encoder.cpp
@@ -53,8 +53,6 @@ void AppendSiblingId(std::string& sMsgName_, const IntermediateHeader& stInterHe
 }
 
 // -------------------------------------------------------------------------------------------------------
-Encoder::Encoder(MessageDatabase* pclMessageDb_) : EncoderBase(pclMessageDb_) {}
-
 Encoder::Encoder(MessageDatabase::ConstPtr pclMessageDb_) : EncoderBase(pclMessageDb_) {}
 
 // -------------------------------------------------------------------------------------------------------

--- a/src/decoders/oem/src/parser.cpp
+++ b/src/decoders/oem/src/parser.cpp
@@ -53,7 +53,7 @@ void Parser::LoadJsonDb(MessageDatabase::Ptr pclMessageDb_)
     {
         clMyHeaderDecoder.LoadJsonDb(pclMessageDb_);
         clMyMessageDecoder.LoadJsonDb(pclMessageDb_);
-        clMyEncoder.LoadSharedJsonDb(pclMessageDb_);
+        clMyEncoder.LoadJsonDb(pclMessageDb_);
         clMyRangeDecompressor.LoadJsonDb(pclMessageDb_);
         clMyRxConfigHandler.LoadJsonDb(pclMessageDb_);
 

--- a/src/decoders/oem/src/rangecmp/range_decompressor.cpp
+++ b/src/decoders/oem/src/rangecmp/range_decompressor.cpp
@@ -55,7 +55,7 @@ void RangeDecompressor::LoadJsonDb(MessageDatabase::Ptr pclJsonDb_)
     pclMyMsgDB = pclJsonDb_;
     clMyHeaderDecoder.LoadJsonDb(pclJsonDb_);
     clMyMessageDecoder.LoadJsonDb(pclJsonDb_);
-    clMyEncoder.LoadSharedJsonDb(pclJsonDb_);
+    clMyEncoder.LoadJsonDb(pclJsonDb_);
 }
 
 //------------------------------------------------------------------------------

--- a/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
+++ b/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
@@ -50,7 +50,7 @@ void RxConfigHandler::LoadJsonDb(const MessageDatabase::Ptr& pclMessageDb_)
     pclMyMsgDb = pclMessageDb_;
     clMyHeaderDecoder.LoadJsonDb(pclMessageDb_);
     clMyMessageDecoder.LoadJsonDb(pclMessageDb_);
-    clMyEncoder.LoadSharedJsonDb(pclMessageDb_);
+    clMyEncoder.LoadJsonDb(pclMessageDb_);
 
     vMyCommandDefinitions = pclMyMsgDb->GetEnumDefName("Commands");
     vMyPortAddressDefinitions = pclMyMsgDb->GetEnumDefName("PortAddress");


### PR DESCRIPTION
Previously I made it so that an `Encoder` could own only a weak reference to a `MessageDatabase` to allow a `PyMessageDatabase` to own an `Encoder`. This added some complexity to the ownership dynamics and the construction of `Encoder` objects.

The PR switches to a more straightforward approach wherein a `PyMessageDatabase` aggregates a `PyMessageDatabaseCore` subclass of `MessageDatabase`. The `Encoder` can then own the `PyMessageDatabaseCore` and the `PyMessageDatabase` can own the `Encoder` without creating a memory cycle. 

This change also makes it very easy to add other utility objects to the `PyMessageDatabase` such as an `RxConfigHandler`.


This PR introduces no interface changes to Python. It technically changes the C++ interface by removing the weak ref constructor for the `Encoder`, but this constructor was only added as a workaround and was not intended to be accessed in user code.