### PR TITLE
Restore consistency in Write method return types

### DIFF
--- a/examples/novatel/converter_components/converter_components.cpp
+++ b/examples/novatel/converter_components/converter_components.cpp
@@ -146,7 +146,8 @@ int main(int argc, char* argv[])
     {
         std::array<char, MAX_ASCII_MESSAGE_LENGTH> cData;
         ifs.read(cData.data(), cData.size());
-        if (clFramer.Write(reinterpret_cast<const unsigned char*>(cData.data()), ifs.gcount()) != ifs.gcount())
+        size_t ullBytesRead = ifs.gcount();
+        if (clFramer.Write(reinterpret_cast<const unsigned char*>(cData.data()), ullBytesRead) != ullBytesRead)
         {
             pclLogger->warn("Framer write failed.");
         }

--- a/examples/novatel/converter_components/converter_components.cpp
+++ b/examples/novatel/converter_components/converter_components.cpp
@@ -146,7 +146,10 @@ int main(int argc, char* argv[])
     {
         std::array<char, MAX_ASCII_MESSAGE_LENGTH> cData;
         ifs.read(cData.data(), cData.size());
-        if (!clFramer.Write(reinterpret_cast<const unsigned char*>(cData.data()), ifs.gcount())) { pclLogger->warn("Framer write failed."); }
+        if (clFramer.Write(reinterpret_cast<const unsigned char*>(cData.data()), ifs.gcount()) != ifs.gcount())
+        {
+            pclLogger->warn("Framer write failed.");
+        }
         // Clearing INCOMPLETE status when internal buffer needs more bytes.
         eFramerStatus = STATUS::INCOMPLETE_MORE_DATA;
 

--- a/examples/novatel/converter_parser/converter_parser.cpp
+++ b/examples/novatel/converter_parser/converter_parser.cpp
@@ -120,7 +120,8 @@ int main(int argc, char* argv[])
     {
         std::array<char, MAX_ASCII_MESSAGE_LENGTH> cData;
         ifs.read(cData.data(), cData.size());
-        if (clParser.Write(reinterpret_cast<unsigned char*>(cData.data()), ifs.gcount()) != ifs.gcount()) { pclLogger->warn("Parser write failed!"); }
+        size_t ullBytesRead = ifs.gcount();
+        if (clParser.Write(reinterpret_cast<unsigned char*>(cData.data()), ullBytesRead) != ullBytesRead) { pclLogger->warn("Parser write failed!"); }
 
         MetaDataStruct stMetaData;
         MessageDataStruct stMessageData;

--- a/examples/novatel/converter_parser/converter_parser.cpp
+++ b/examples/novatel/converter_parser/converter_parser.cpp
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
     {
         std::array<char, MAX_ASCII_MESSAGE_LENGTH> cData;
         ifs.read(cData.data(), cData.size());
-        clParser.Write(reinterpret_cast<unsigned char*>(cData.data()), ifs.gcount());
+        if (clParser.Write(reinterpret_cast<unsigned char*>(cData.data()), ifs.gcount()) != ifs.gcount()) { pclLogger->warn("Parser write failed!"); }
 
         MetaDataStruct stMetaData;
         MessageDataStruct stMessageData;

--- a/examples/novatel/json_parser/json_parser.cpp
+++ b/examples/novatel/json_parser/json_parser.cpp
@@ -131,8 +131,9 @@ int main(int argc, char* argv[])
         ifs.read(cData.data(), cData.size());
         size_t ullBytesRead = ifs.gcount();
         if (clParser.Write(reinterpret_cast<unsigned char*>(cData.data()), ullBytesRead) != ullBytesRead)
-        {  
-           throw std::runtime_error("Failed to write data to the parser. This should not be possible because data is always written in small chunks.");  
+        {
+            throw std::runtime_error(
+                "Failed to write data to the parser. This should not be possible because data is always written in small chunks.");
         }
         MetaDataStruct stMetaData;
         MessageDataStruct stMessageData;

--- a/examples/novatel/json_parser/json_parser.cpp
+++ b/examples/novatel/json_parser/json_parser.cpp
@@ -129,7 +129,9 @@ int main(int argc, char* argv[])
     {
         std::array<char, MAX_ASCII_MESSAGE_LENGTH> cData;
         ifs.read(cData.data(), cData.size());
-        if (clParser.Write(reinterpret_cast<unsigned char*>(cData.data()), ifs.gcount()) != ifs.gcount()) {  
+        size_t ullBytesRead = ifs.gcount();
+        if (clParser.Write(reinterpret_cast<unsigned char*>(cData.data()), ullBytesRead) != ullBytesRead)
+        {  
            throw std::runtime_error("Failed to write data to the parser. This should not be possible because data is always written in small chunks.");  
         }
         MetaDataStruct stMetaData;

--- a/examples/novatel/json_parser/json_parser.cpp
+++ b/examples/novatel/json_parser/json_parser.cpp
@@ -129,8 +129,9 @@ int main(int argc, char* argv[])
     {
         std::array<char, MAX_ASCII_MESSAGE_LENGTH> cData;
         ifs.read(cData.data(), cData.size());
-        clParser.Write(reinterpret_cast<unsigned char*>(cData.data()), ifs.gcount());
-
+        if (clParser.Write(reinterpret_cast<unsigned char*>(cData.data()), ifs.gcount()) != ifs.gcount()) {  
+           throw std::runtime_error("Failed to write data to the parser. This should not be possible because data is always written in small chunks.");  
+        }
         MetaDataStruct stMetaData;
         MessageDataStruct stMessageData;
 

--- a/examples/novatel/range_decompressor/range_decompressor.cpp
+++ b/examples/novatel/range_decompressor/range_decompressor.cpp
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
                 break;
             }
 
-            if (!clFramer.Write(reinterpret_cast<unsigned char*>(cData.data()), ifs.gcount())) { pclLogger->warn("Framer write failed."); }
+            if (clFramer.Write(reinterpret_cast<unsigned char*>(cData.data()), ifs.gcount()) != ifs.gcount()) { pclLogger->warn("Framer write failed."); }
         }
     }
 

--- a/examples/novatel/range_decompressor/range_decompressor.cpp
+++ b/examples/novatel/range_decompressor/range_decompressor.cpp
@@ -182,7 +182,11 @@ int main(int argc, char* argv[])
                 break;
             }
 
-            if (clFramer.Write(reinterpret_cast<unsigned char*>(cData.data()), ifs.gcount()) != ifs.gcount()) { pclLogger->warn("Framer write failed."); }
+            size_t ullBytesRead = ifs.gcount();
+            if (clFramer.Write(reinterpret_cast<unsigned char*>(cData.data()), ullBytesRead) != ullBytesRead)
+            {
+                pclLogger->warn("Framer write failed.");
+            }
         }
     }
 

--- a/include/novatel_edie/common/fixed_ring_buffer.hpp
+++ b/include/novatel_edie/common/fixed_ring_buffer.hpp
@@ -88,10 +88,10 @@ template <typename T, size_t N> class FixedRingBuffer
     //! \param[in] data_ptr Pointer to the source data buffer.
     //! \param[in] count The number of *elements* (of type T) to write.
     //! \return True if all elements were written (enough space), false otherwise.
-    [[nodiscard]] bool Write(const T* data_ptr, size_t count) noexcept
+    [[nodiscard]] size_t Write(const T* data_ptr, size_t count) noexcept
     {
-        if (data_ptr == nullptr || count > available_space()) { return false; }
-        if (count == 0) { return true; }
+        if (data_ptr == nullptr || count > available_space()) { return 0; }
+        if (count == 0) { return 0; }
 
         const size_t write_start_idx = (head + sz) & Mask;
         const size_t first_chunk_elements = std::min(count, N - write_start_idx);
@@ -108,7 +108,7 @@ template <typename T, size_t N> class FixedRingBuffer
         }
 
         sz += count;
-        return true;
+        return count;
     }
 
     //! \brief Returns the number of elements currently in the buffer.

--- a/include/novatel_edie/decoders/common/framer.hpp
+++ b/include/novatel_edie/decoders/common/framer.hpp
@@ -153,6 +153,13 @@ class FramerBase
         HandleUnknownBytes(pucBuffer_, uiBytesToFlush);
         return uiBytesToFlush;
     }
+
+    //----------------------------------------------------------------------------
+    //! \brief Get the number of bytes currently available in the internal buffer.
+    //! 
+    //! \return The number of bytes available in the internal circular buffer.
+    //------------------------------------------------------------------------------
+    [[nodiscard]] uint32_t GetAvailableSpace() const { return clMyBuffer.available_space(); }
 };
 
 #endif // FRAMER_HPP

--- a/include/novatel_edie/decoders/common/framer.hpp
+++ b/include/novatel_edie/decoders/common/framer.hpp
@@ -137,7 +137,7 @@ class FramerBase
     //
     //! \return The number of bytes written to the internal circular buffer.
     //----------------------------------------------------------------------------
-    [[nodiscard]] bool Write(const unsigned char* pucDataBuffer_, size_t uiDataBytes_) { return clMyBuffer.Write(pucDataBuffer_, uiDataBytes_); }
+    [[nodiscard]] size_t Write(const unsigned char* pucDataBuffer_, size_t uiDataBytes_) { return clMyBuffer.Write(pucDataBuffer_, uiDataBytes_); }
 
     //----------------------------------------------------------------------------
     //! \brief Flush bytes from the internal circular buffer.

--- a/include/novatel_edie/decoders/common/framer.hpp
+++ b/include/novatel_edie/decoders/common/framer.hpp
@@ -156,7 +156,7 @@ class FramerBase
 
     //----------------------------------------------------------------------------
     //! \brief Get the number of bytes currently available in the internal buffer.
-    //! 
+    //!
     //! \return The number of bytes available in the internal circular buffer.
     //------------------------------------------------------------------------------
     [[nodiscard]] uint32_t GetAvailableSpace() const { return clMyBuffer.available_space(); }

--- a/include/novatel_edie/decoders/common/framer.hpp
+++ b/include/novatel_edie/decoders/common/framer.hpp
@@ -159,7 +159,7 @@ class FramerBase
     //!
     //! \return The number of bytes available in the internal circular buffer.
     //------------------------------------------------------------------------------
-    [[nodiscard]] uint32_t GetAvailableSpace() const { return clMyBuffer.available_space(); }
+    [[nodiscard]] size_t GetAvailableSpace() const { return clMyBuffer.available_space(); }
 };
 
 #endif // FRAMER_HPP

--- a/include/novatel_edie/decoders/oem/parser.hpp
+++ b/include/novatel_edie/decoders/oem/parser.hpp
@@ -236,7 +236,7 @@ class Parser
     //!
     //! \return The number of bytes available in the Parser's internal buffer for writing new data.
     //---------------------------------------------------------------------------
-    [[nodiscard]] uint32_t GetAvailableSpace() const { return clMyFramer.GetAvailableSpace(); }
+    [[nodiscard]] size_t GetAvailableSpace() const { return clMyFramer.GetAvailableSpace(); }
 
     //----------------------------------------------------------------------------
     //! \brief Read a log from the Parser.

--- a/include/novatel_edie/decoders/oem/parser.hpp
+++ b/include/novatel_edie/decoders/oem/parser.hpp
@@ -229,7 +229,7 @@ class Parser
     //
     //! \return The number of bytes successfully written to the Parser.
     //----------------------------------------------------------------------------
-    [[nodiscard]] size_t Write(const unsigned char* pucData_, uint32_t uiDataSize_) { return clMyFramer.Write(pucData_, uiDataSize_); }
+    [[nodiscard]] size_t Write(const unsigned char* pucData_, size_t uiDataSize_) { return clMyFramer.Write(pucData_, uiDataSize_); }
 
     //----------------------------------------------------------------------------
     //! \brief Get the number of bytes available in the Parser's internal buffer.

--- a/include/novatel_edie/decoders/oem/parser.hpp
+++ b/include/novatel_edie/decoders/oem/parser.hpp
@@ -229,7 +229,7 @@ class Parser
     //
     //! \return The number of bytes successfully written to the Parser.
     //----------------------------------------------------------------------------
-    bool Write(const unsigned char* pucData_, uint32_t uiDataSize_) { return clMyFramer.Write(pucData_, uiDataSize_); }
+    [[nodiscard]] size_t Write(const unsigned char* pucData_, uint32_t uiDataSize_) { return clMyFramer.Write(pucData_, uiDataSize_); }
 
     //----------------------------------------------------------------------------
     //! \brief Get the number of bytes available in the Parser's internal buffer.

--- a/include/novatel_edie/decoders/oem/parser.hpp
+++ b/include/novatel_edie/decoders/oem/parser.hpp
@@ -233,7 +233,7 @@ class Parser
 
     //----------------------------------------------------------------------------
     //! \brief Get the number of bytes available in the Parser's internal buffer.
-    //! 
+    //!
     //! \return The number of bytes available in the Parser's internal buffer for writing new data.
     //---------------------------------------------------------------------------
     [[nodiscard]] uint32_t GetAvailableSpace() const { return clMyFramer.GetAvailableSpace(); }

--- a/include/novatel_edie/decoders/oem/parser.hpp
+++ b/include/novatel_edie/decoders/oem/parser.hpp
@@ -229,7 +229,14 @@ class Parser
     //
     //! \return The number of bytes successfully written to the Parser.
     //----------------------------------------------------------------------------
-    uint32_t Write(const unsigned char* pucData_, uint32_t uiDataSize_) { return clMyFramer.Write(pucData_, uiDataSize_); }
+    bool Write(const unsigned char* pucData_, uint32_t uiDataSize_) { return clMyFramer.Write(pucData_, uiDataSize_); }
+
+    //----------------------------------------------------------------------------
+    //! \brief Get the number of bytes available in the Parser's internal buffer.
+    //! 
+    //! \return The number of bytes available in the Parser's internal buffer for writing new data.
+    //---------------------------------------------------------------------------
+    [[nodiscard]] uint32_t GetAvailableSpace() const { return clMyFramer.GetAvailableSpace(); }
 
     //----------------------------------------------------------------------------
     //! \brief Read a log from the Parser.

--- a/include/novatel_edie/decoders/oem/rxconfig/rxconfig_handler.hpp
+++ b/include/novatel_edie/decoders/oem/rxconfig/rxconfig_handler.hpp
@@ -113,7 +113,7 @@ class RxConfigHandler
     //
     //! \return The number of bytes successfully written to the RxConfigHandler.
     //----------------------------------------------------------------------------
-    bool Write(const unsigned char* pucData_, uint32_t uiDataSize_);
+    size_t Write(const unsigned char* pucData_, uint32_t uiDataSize_);
 
     //----------------------------------------------------------------------------
     //! \brief Read and convert an RXCONFIG message from the handler.

--- a/python/bindings/exceptions.cpp
+++ b/python/bindings/exceptions.cpp
@@ -63,7 +63,7 @@ void init_novatel_exceptions(nb::module_& m)
         .value("NO_DEFINITION", STATUS::NO_DEFINITION, "No definition could be found in the database for the provided message.")
         .value("NO_DEFINITION_EMBEDDED", STATUS::NO_DEFINITION_EMBEDDED,
                "No definition could be found in the database for the embedded message in the RXCONFIG log.")
-        .value("BUFFER_FULL", STATUS::BUFFER_FULL, "The provided destination buffer is not big enough to contain the frame.")
+        .value("BUFFER_FULL", STATUS::BUFFER_FULL, "The destination buffer is not big enough to contain the provided data.")
         .value("BUFFER_EMPTY", STATUS::BUFFER_EMPTY, "The internal circular buffer does not contain any unread bytes")
         .value("STREAM_EMPTY", STATUS::STREAM_EMPTY, "The input stream is empty.")
         .value("UNSUPPORTED", STATUS::UNSUPPORTED, "An attempted operation is unsupported by this component.")

--- a/python/bindings/exceptions.hpp
+++ b/python/bindings/exceptions.hpp
@@ -73,7 +73,7 @@ class NoDefinitionEmbeddedException : public std::exception
 class BufferFullException : public std::exception
 {
   public:
-    const char* what() const noexcept override { return "The provided destination buffer is not big enough to contain the frame."; }
+    const char* what() const noexcept override { return "The destination buffer is not big enough to contain the provided data."; }
 };
 
 class BufferEmptyException : public std::exception

--- a/python/bindings/framer.cpp
+++ b/python/bindings/framer.cpp
@@ -54,7 +54,7 @@ void init_novatel_framer(nb::module_& m)
         .def_prop_rw("report_unknown_bytes", &oem::PyFramer::GetReportUnknownBytes, &oem::PyFramer::SetReportUnknownBytes,
                      "Whether to frame and return undecodable data.")
         .def_prop_ro("available_space", &oem::PyFramer::GetAvailableSpace,
-                     "The number of bytes in the Parser's internal buffer available for writing new data.")
+                     "The number of bytes in the Framer's internal buffer available for writing new data.")
         .def("get_frame", &oem::PyFramer::PyGetFrame, "buffer_size"_a = MESSAGE_SIZE_MAX,
              nb::sig("def get_frame(buffer_size = MAX_MESSAGE_LENGTH) -> tuple[bytes, MetaData]"),
              R"doc(
@@ -99,8 +99,14 @@ void init_novatel_framer(nb::module_& m)
             R"doc(
             Writes data to the Framer's buffer.
 
+            Use 'available_space' attribute to check how many bytes can be safely written.  
+
             Args:
                 data: The data to write to the buffer.
+
+            Returns:
+                The number of bytes written to the Framer's buffer. 
+                Can be less than the length of `data` if the buffer is full.
             )doc")
         .def(
             "flush",

--- a/python/bindings/framer.cpp
+++ b/python/bindings/framer.cpp
@@ -53,6 +53,8 @@ void init_novatel_framer(nb::module_& m)
                      "Whether to frame and return only the payload of detected messages.")
         .def_prop_rw("report_unknown_bytes", &oem::PyFramer::GetReportUnknownBytes, &oem::PyFramer::SetReportUnknownBytes,
                      "Whether to frame and return undecodable data.")
+        .def_prop_ro("available_space", &oem::PyFramer::GetAvailableSpace,
+                     "The number of bytes in the Parser's internal buffer available for writing new data.")
         .def("get_frame", &oem::PyFramer::PyGetFrame, "buffer_size"_a = MESSAGE_SIZE_MAX,
              nb::sig("def get_frame(buffer_size = MAX_MESSAGE_LENGTH) -> tuple[bytes, MetaData]"),
              R"doc(

--- a/python/bindings/parser.cpp
+++ b/python/bindings/parser.cpp
@@ -133,6 +133,9 @@ void init_novatel_parser(nb::module_& m)
              Args:
                  data: A set of bytes to append to the Parser's internal buffer.
 
+             Returns:
+                    The number of bytes written to the Parser's internal buffer.
+
              Raises:
                  BufferFullException: The Parser's internal buffer would be overrun by the data provided.
             )doc")

--- a/python/bindings/parser.cpp
+++ b/python/bindings/parser.cpp
@@ -119,8 +119,8 @@ void init_novatel_parser(nb::module_& m)
                 return std::static_pointer_cast<oem::PyFilter>(self.GetFilter());
             },
             [](oem::PyParser& self, oem::PyFilter::Ptr filter) { self.SetFilter(filter); }, "The filter which controls which data is skipped over.")
-        .def_prop_ro("availible_space", &oem::PyParser::GetAvailableSpace,
-                     "The number of bytes available in the Parser's internal buffer for writing new data.")
+        .def_prop_ro("available_space", &oem::PyParser::GetAvailableSpace,
+                     "The number of bytes in the Parser's internal buffer available for writing new data.")
         .def(
             "write",
             [](oem::PyParser& self, const nb::bytes& data) {
@@ -134,7 +134,7 @@ void init_novatel_parser(nb::module_& m)
                  data: A set of bytes to append to the Parser's internal buffer.
 
              Returns:
-                    The number of bytes written to the Parser's internal buffer.
+                    **depreciated** The number of bytes written to the Parser's internal buffer.
 
              Raises:
                  BufferFullException: The Parser's internal buffer would be overrun by the data provided.

--- a/python/bindings/parser.cpp
+++ b/python/bindings/parser.cpp
@@ -123,21 +123,18 @@ void init_novatel_parser(nb::module_& m)
                      "The number of bytes in the Parser's internal buffer available for writing new data.")
         .def(
             "write",
-            [](oem::PyParser& self, const nb::bytes& data) {
-                if (!self.Write(reinterpret_cast<const uint8_t*>(data.c_str()), data.size())) { throw_exception_from_status(STATUS::BUFFER_FULL); }
-                return nb::int_(data.size());
-            },
+            [](oem::PyParser& self, const nb::bytes& data) { return self.Write(reinterpret_cast<const uint8_t*>(data.c_str()), data.size()); },
             R"doc(
              Writes data to the Parser's internal buffer allowing it to later be parsed.
+
+             Use 'available_space' attribute to check how many bytes can be safely written.
 
              Args:
                  data: A set of bytes to append to the Parser's internal buffer.
 
              Returns:
-                    **depreciated** The number of bytes written to the Parser's internal buffer.
-
-             Raises:
-                 BufferFullException: The Parser's internal buffer would be overrun by the data provided.
+                    The number of bytes written to the Parser's internal buffer. 
+                    Can be less than the length of `data` if the buffer is full.
             )doc")
         .def("read", &oem::PyParser::PyRead, "decode_incomplete_abbreviated"_a = false,
              nb::sig("def read(self, decode_incomplete_abbreviated: bool = False) -> Message | Response | UnknownMessage | UnknownBytes"),

--- a/python/examples/converter_components.py
+++ b/python/examples/converter_components.py
@@ -68,7 +68,10 @@ def main():
 
     with open(input_file, "rb") as input_stream:
         while read_data := input_stream.read(framer.available_space):
-            framer.write(read_data)
+            written_bytes = framer.write(read_data)
+            if written_bytes != len(read_data):
+                raise ne.FailureException(
+                    f'Wrote {written_bytes} bytes, expected {len(read_data)} bytes.')
             for frame, meta in framer:
                 if meta.format == HEADER_FORMAT.UNKNOWN:
                     continue

--- a/python/examples/converter_components.py
+++ b/python/examples/converter_components.py
@@ -67,7 +67,7 @@ def main():
     my_filter = ne.Filter()
 
     with open(input_file, "rb") as input_stream:
-        while read_data := input_stream.read(MAX_MESSAGE_LENGTH):
+        while read_data := input_stream.read(framer.available_space):
             framer.write(read_data)
             for frame, meta in framer:
                 if meta.format == HEADER_FORMAT.UNKNOWN:

--- a/python/examples/converter_parser.py
+++ b/python/examples/converter_parser.py
@@ -54,7 +54,7 @@ def main():
     messages = 0
     start = timeit.default_timer()
     with open(input_file, "rb") as input_stream:
-        while read_data := input_stream.read(ne.MAX_MESSAGE_LENGTH):
+        while read_data := input_stream.read(parser.available_space):
             parser.write(read_data)
             for message in parser:
                 # Handle messages that can be fully decoded

--- a/python/examples/converter_parser.py
+++ b/python/examples/converter_parser.py
@@ -55,7 +55,10 @@ def main():
     start = timeit.default_timer()
     with open(input_file, "rb") as input_stream:
         while read_data := input_stream.read(parser.available_space):
-            parser.write(read_data)
+            written_bytes = parser.write(read_data)
+            if written_bytes != len(read_data):
+                raise ne.FailureException(
+                    f'Wrote {written_bytes} bytes, expected {len(read_data)} bytes.')
             for message in parser:
                 # Handle messages that can be fully decoded
                 if isinstance(message, ne.Message):

--- a/python/readme.md
+++ b/python/readme.md
@@ -92,6 +92,13 @@ parser = ne.Parser()
 parser.write(b'message_data')
 ```
 
+Writing too much data at once can lead to a failure, you may use the `availible_space` attribute to avoid this:
+
+```python
+parser = ne.Parser()
+parser.write(msg[:parser.available_space])
+```
+
 A `FileParser` accesses its data from a filepath provided at instantiation:
 
 ```python

--- a/python/readme.md
+++ b/python/readme.md
@@ -89,14 +89,16 @@ Data is written to a `Parser` as `bytes` via its `write()` method:
 
 ```python
 parser = ne.Parser()
-parser.write(b'message_data')
+bytes_written = parser.write(b'message_data')
 ```
 
-Writing too much data at once can lead to a failure, you may use the `availible_space` attribute to avoid this:
+The `bytes_written` return value indicates how many bytes were successfully written to the `Parser`.
+This number will be less than the size of the input if the `Parser` lacks space to store them.
+To guarentee that all bytes will be successfully, use the `Parser.available_space` property:
 
 ```python
 parser = ne.Parser()
-parser.write(msg[:parser.available_space])
+bytes_written = parser.write(msg[:parser.available_space])
 ```
 
 A `FileParser` accesses its data from a filepath provided at instantiation:

--- a/python/test/test_parser.py
+++ b/python/test/test_parser.py
@@ -110,3 +110,26 @@ def test_parse_abbrev_ascii_resp(response_str, context, ignore_responses, parser
         except AssertionError as e:
             raise AssertionError(
                 f"Failure at permutation {permutations[i]}: {e}") from e
+
+
+def test_write_max_num_bytes(parser: ne.Parser):
+    """Tests that data with length matching available space can be written."""
+    # Arrange
+    data = b'a' * parser.available_space
+    # Act
+    bytes_written = parser.write(data)
+    # Assert
+    assert bytes_written == len(data)
+
+
+def test_write_exceeding_max_num_bytes(parser: ne.Parser):
+    """Tests that data exceeding available space is not fully written.
+
+    Whether data is partially written is not defined in the spec.
+    """
+    # Arrange
+    data = b'a' * (parser.available_space + 1)
+    # Act
+    bytes_written = parser.write(data)
+    # Assert
+    assert bytes_written <= parser.available_space

--- a/src/decoders/oem/src/file_parser.cpp
+++ b/src/decoders/oem/src/file_parser.cpp
@@ -66,7 +66,7 @@ bool FileParser::ReadStream()
     std::array<char, MAX_ASCII_MESSAGE_LENGTH> cData{};
     pclMyInputStream->read(cData.data(), cData.size());
     size_t ullBytesRead = pclMyInputStream->gcount();
-    return pclMyInputStream->gcount() > 0 && clMyParser.Write(reinterpret_cast<unsigned char*>(cData.data()), ullBytesRead) == ullBytesRead;
+    return ullBytesRead > 0 && clMyParser.Write(reinterpret_cast<unsigned char*>(cData.data()), ullBytesRead) == ullBytesRead;
 }
 
 // -------------------------------------------------------------------------------------------------------

--- a/src/decoders/oem/src/file_parser.cpp
+++ b/src/decoders/oem/src/file_parser.cpp
@@ -65,7 +65,8 @@ bool FileParser::ReadStream()
 {
     std::array<char, MAX_ASCII_MESSAGE_LENGTH> cData{};
     pclMyInputStream->read(cData.data(), cData.size());
-    return pclMyInputStream->gcount() > 0 && clMyParser.Write(reinterpret_cast<unsigned char*>(cData.data()), pclMyInputStream->gcount());
+    return pclMyInputStream->gcount() > 0 &&
+           clMyParser.Write(reinterpret_cast<unsigned char*>(cData.data()), pclMyInputStream->gcount()) == pclMyInputStream->gcount();
 }
 
 // -------------------------------------------------------------------------------------------------------

--- a/src/decoders/oem/src/file_parser.cpp
+++ b/src/decoders/oem/src/file_parser.cpp
@@ -65,8 +65,8 @@ bool FileParser::ReadStream()
 {
     std::array<char, MAX_ASCII_MESSAGE_LENGTH> cData{};
     pclMyInputStream->read(cData.data(), cData.size());
-    return pclMyInputStream->gcount() > 0 &&
-           clMyParser.Write(reinterpret_cast<unsigned char*>(cData.data()), pclMyInputStream->gcount()) == pclMyInputStream->gcount();
+    size_t ullBytesRead = pclMyInputStream->gcount();
+    return pclMyInputStream->gcount() > 0 && clMyParser.Write(reinterpret_cast<unsigned char*>(cData.data()), ullBytesRead) == ullBytesRead;
 }
 
 // -------------------------------------------------------------------------------------------------------

--- a/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
+++ b/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
@@ -64,7 +64,7 @@ bool RxConfigHandler::IsRxConfigTypeMsg(uint16_t usMessageId_)
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool RxConfigHandler::Write(const unsigned char* pucData_, uint32_t uiDataSize_) { return clMyFramer.Write(pucData_, uiDataSize_); }
+size_t RxConfigHandler::Write(const unsigned char* pucData_, uint32_t uiDataSize_) { return clMyFramer.Write(pucData_, uiDataSize_); }
 
 // -------------------------------------------------------------------------------------------------------
 STATUS

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -2909,7 +2909,7 @@ TEST_F(ParserTest, PARSE_FILE_WITH_FILTER)
     while (clInputFileStream.read(buffer.data(), chunkSize) || clInputFileStream.gcount() > 0) {
         auto n = static_cast<uint32_t>(clInputFileStream.gcount());
         if (pclParser->Write(reinterpret_cast<const uint8_t*>(buffer.data()), n) != n) {
-            std::cerr << "Failed to write data to parser." << std::endl;
+            std::cerr << "Failed to write data to parser.";
             break;
         };
         while (true)

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -90,13 +90,17 @@ class FramerTest : public ::testing::Test
         while (!pclMyIFS->eof())
         {
             pclMyIFS->read(cData.data(), cData.size());
-            ASSERT_TRUE(pclMyFramer->Write(reinterpret_cast<unsigned char*>(cData.data()), pclMyIFS->gcount()) == pclMyIFS->gcount());
+            size_t ullBytesRead = pclMyIFS->gcount();
+            ASSERT_TRUE(pclMyFramer->Write(reinterpret_cast<unsigned char*>(cData.data()), ullBytesRead) == ullBytesRead);
         }
 
         pclMyIFS = nullptr;
     }
 
-    static void WriteBytesToFramer(const unsigned char* pucBytes_, uint32_t uiNumBytes_) { ASSERT_TRUE(pclMyFramer->Write(pucBytes_, uiNumBytes_) == uiNumBytes_); }
+    static void WriteBytesToFramer(const unsigned char* pucBytes_, uint32_t uiNumBytes_)
+    {
+        ASSERT_TRUE(pclMyFramer->Write(pucBytes_, uiNumBytes_) == uiNumBytes_);
+    }
 
     static void FlushFramer()
     {

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -90,13 +90,13 @@ class FramerTest : public ::testing::Test
         while (!pclMyIFS->eof())
         {
             pclMyIFS->read(cData.data(), cData.size());
-            ASSERT_TRUE(pclMyFramer->Write(reinterpret_cast<unsigned char*>(cData.data()), pclMyIFS->gcount()));
+            ASSERT_TRUE(pclMyFramer->Write(reinterpret_cast<unsigned char*>(cData.data()), pclMyIFS->gcount()) == pclMyIFS->gcount());
         }
 
         pclMyIFS = nullptr;
     }
 
-    static void WriteBytesToFramer(const unsigned char* pucBytes_, uint32_t uiNumBytes_) { ASSERT_TRUE(pclMyFramer->Write(pucBytes_, uiNumBytes_)); }
+    static void WriteBytesToFramer(const unsigned char* pucBytes_, uint32_t uiNumBytes_) { ASSERT_TRUE(pclMyFramer->Write(pucBytes_, uiNumBytes_) == uiNumBytes_); }
 
     static void FlushFramer()
     {
@@ -2904,7 +2904,10 @@ TEST_F(ParserTest, PARSE_FILE_WITH_FILTER)
     std::vector<char> buffer(chunkSize);
     while (clInputFileStream.read(buffer.data(), chunkSize) || clInputFileStream.gcount() > 0) {
         auto n = static_cast<uint32_t>(clInputFileStream.gcount());
-        pclParser->Write(reinterpret_cast<const uint8_t*>(buffer.data()), n);
+        if (pclParser->Write(reinterpret_cast<const uint8_t*>(buffer.data()), n) != n) {
+            std::cerr << "Failed to write data to parser." << std::endl;
+            break;
+        };
         while (true)
         {
             STATUS eStatus = pclParser->Read(stMessageData, stMetaData);

--- a/src/decoders/oem/test/proprietary_test.cpp
+++ b/src/decoders/oem/test/proprietary_test.cpp
@@ -68,11 +68,11 @@ class ProprietaryFramerTest : public ::testing::Test
         while (!pclMyIFS->eof())
         {
             pclMyIFS->read(cData.data(), cData.size());
-            ASSERT_TRUE(pclMyFramer->Write(reinterpret_cast<unsigned char*>(cData.data()), pclMyIFS->gcount()));
+            ASSERT_TRUE(pclMyFramer->Write(reinterpret_cast<unsigned char*>(cData.data()), pclMyIFS->gcount()) == pclMyIFS->gcount());
         }
     }
 
-    static void WriteBytesToFramer(unsigned char* pucBytes_, uint32_t uiNumBytes_) { ASSERT_TRUE(pclMyFramer->Write(pucBytes_, uiNumBytes_)); }
+    static void WriteBytesToFramer(unsigned char* pucBytes_, uint32_t uiNumBytes_) { ASSERT_TRUE(pclMyFramer->Write(pucBytes_, uiNumBytes_) == uiNumBytes_); }
 
     static void FlushFramer()
     {

--- a/src/decoders/oem/test/proprietary_test.cpp
+++ b/src/decoders/oem/test/proprietary_test.cpp
@@ -68,11 +68,15 @@ class ProprietaryFramerTest : public ::testing::Test
         while (!pclMyIFS->eof())
         {
             pclMyIFS->read(cData.data(), cData.size());
-            ASSERT_TRUE(pclMyFramer->Write(reinterpret_cast<unsigned char*>(cData.data()), pclMyIFS->gcount()) == pclMyIFS->gcount());
+            size_t ullBytesRead = pclMyIFS->gcount();
+            ASSERT_TRUE(pclMyFramer->Write(reinterpret_cast<unsigned char*>(cData.data()), ullBytesRead) == ullBytesRead);
         }
     }
 
-    static void WriteBytesToFramer(unsigned char* pucBytes_, uint32_t uiNumBytes_) { ASSERT_TRUE(pclMyFramer->Write(pucBytes_, uiNumBytes_) == uiNumBytes_); }
+    static void WriteBytesToFramer(unsigned char* pucBytes_, uint32_t uiNumBytes_)
+    {
+        ASSERT_TRUE(pclMyFramer->Write(pucBytes_, uiNumBytes_) == uiNumBytes_);
+    }
 
     static void FlushFramer()
     {


### PR DESCRIPTION
The interface for `FramerBase::Write`  was changed in #118 to return a bool indicating success, instead of an unsigned int indicating the number of successfully written bytes.
This change was not properly propagated to dependent functions such as `Parser::Write` which still returns an unsigned int.

To minimize interface changes and restore consistency, this PR changes the return value of `FramerBase::Write` back to an unsigned int representing the number of successfully written bytes. It also updates all dependent and example code to properly check the success of function calls under this paradigm.

#118 also made writes more likely to fail due to setting a fixed maximum on the size of the buffer. This PR adds `FramerBase::GetAvailableSpace` and `Parser::GetAvailableSpace` functions to help user code  proactively avoid this case. Likewise `Framer.available_space` and `Parser.available_space` functions are introduced on the Python side.