### PR TITLE
Update FieldContainer’s constructors to support more flexible and direct initialization and add virtual pointer alignment

### DIFF
--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -126,7 +126,7 @@ class MessageDecoderBase
     //! 4 and the field's length.
     //
     //! For binary formats that use packed structures and do not align fields
-    //! this function should be overridden in a derived decoder class to skip 
+    //! this function should be overridden in a derived decoder class to skip
     //! alignment.
     //
     //! \return None. The buffer pointer is updated in place.

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -56,10 +56,11 @@ struct FieldContainer
     FieldValueVariant fieldValue;
     BaseField::ConstPtr fieldDef;
 
-    template <class T>
-    FieldContainer(T tFieldValue_, BaseField::ConstPtr&& pstFieldDef_) : fieldValue(tFieldValue_), fieldDef(std::move(pstFieldDef_))
-    {
-    }
+    FieldContainer(const FieldValueVariant& value, BaseField::ConstPtr def) : fieldValue(value), fieldDef(std::move(def)) {}
+
+    FieldContainer(FieldValueVariant&& value, BaseField::ConstPtr def) : fieldValue(std::move(value)), fieldDef(std::move(def)) {}
+
+    template <typename T> FieldContainer(T&& value, BaseField::ConstPtr def) : fieldValue(std::forward<T>(value)), fieldDef(std::move(def)) {}
 };
 
 //============================================================================

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -214,6 +214,8 @@ class MessageDecoderBase
     //----------------------------------------------------------------------------
     MessageDecoderBase(MessageDatabase::Ptr pclMessageDb_ = nullptr);
 
+    virtual ~MessageDecoderBase() = default;
+
     //----------------------------------------------------------------------------
     //! \brief Load a MessageDatabase object.
     //

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -298,10 +298,7 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
 
     for (const auto& field : vMsgDefFields_)
     {
-        // Realign to type byte boundary if needed
-        uint8_t usTypeAlignment = std::min(static_cast<uint16_t>(4), field->dataType.length);
-        uint64_t usAlignmentOffset = static_cast<uint64_t>(*ppucLogBuf_ - pucTempStart) % usTypeAlignment;
-        if (usAlignmentOffset != 0) { *ppucLogBuf_ += usTypeAlignment - usAlignmentOffset; }
+        AlignBufferPointer(field, pucTempStart, ppucLogBuf_);
 
         switch (field->type)
         {
@@ -383,8 +380,7 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
             for (uint32_t i = 0; i < uiArraySize; ++i)
             {
                 // Realign to type byte boundary if needed
-                usAlignmentOffset = static_cast<uint64_t>(*ppucLogBuf_ - pucTempStart) % usTypeAlignment;
-                if (usAlignmentOffset != 0) { *ppucLogBuf_ += usTypeAlignment - usAlignmentOffset; }
+                AlignBufferPointer(field, pucTempStart, ppucLogBuf_);
                 pvFieldArrayContainer.emplace_back(std::vector<FieldContainer>(), field);
                 auto& pvFieldContainer = std::get<std::vector<FieldContainer>>(pvFieldArrayContainer.back().fieldValue);
                 pvFieldContainer.reserve(dynamic_cast<const FieldArrayField*>(field.get())->fields.size());


### PR DESCRIPTION
This change updates FieldContainer’s constructors to support more flexible and direct initialization of the fieldValue member, allowing both lvalue and rvalue inputs without ambiguous template deduction failures.

Specifically:
- Added two explicit overloads for FieldValueVariant:
  - FieldContainer(const FieldValueVariant& value, BaseField::ConstPtr def)
  - FieldContainer(FieldValueVariant&& value, BaseField::ConstPtr def)
- Updated the template constructor to take T&& and use std::forward<T> so it works correctly for all value categories.
- Removed the old template <class T> constructor that relied on type deduction rules that didn’t always work for conversions.

Also turn the the buffer alignment into a virtual function to support formats that have different alignment rules.