### PR TITLE
Add count attributes for field arrays and variable length arrays

### DIFF
--- a/python/bindings/py_message_objects.cpp
+++ b/python/bindings/py_message_objects.cpp
@@ -150,7 +150,7 @@ nb::dict& PyField::to_shallow_dict() const
     {
         for (const auto& field : fields)
         {
-            if (std::holds_alternative<std::vector<FieldContainer>>(field.fieldValue) && field.fieldDef->type == FIELD_TYPE::FIELD_ARRAY)
+            if (std::holds_alternative<std::vector<FieldContainer>>(field.fieldValue) && (field.fieldDef->type == FIELD_TYPE::FIELD_ARRAY || field.fieldDef->type == FIELD_TYPE::VARIABLE_LENGTH_ARRAY))
             {
                 std::vector<FieldContainer> field_array = std::get<std::vector<FieldContainer>>(field.fieldValue);
                 cached_values_[nb::cast(field.fieldDef->name + "_count")] = field_array.size();

--- a/python/bindings/py_message_objects.cpp
+++ b/python/bindings/py_message_objects.cpp
@@ -150,25 +150,21 @@ nb::dict& PyField::to_shallow_dict() const
     {
         for (const auto& field : fields)
         {
+            if (std::holds_alternative<std::vector<FieldContainer>>(field.fieldValue) && field.fieldDef->type == FIELD_TYPE::FIELD_ARRAY)
+            {
+                std::vector<FieldContainer> field_array = std::get<std::vector<FieldContainer>>(field.fieldValue);
+                cached_values_[nb::cast(field.fieldDef->name + "_count")] = field_array.size();
+            }
             cached_values_[nb::cast(field.fieldDef->name)] = convert_field(field, parent_db_, this->name, this->has_ptype);
         }
     }
     return cached_values_;
 }
 
-nb::dict& PyField::get_field_defs() const
-{
-    if (cached_fields_.size() == 0)
-    {
-        for (const auto& field : fields) { cached_fields_[nb::cast(field.fieldDef->name)] = field.fieldDef; }
-    }
-    return cached_fields_;
-}
-
 nb::list PyField::get_field_names() const
 {
     nb::list field_names = nb::list();
-    for (const auto& field : fields) { field_names.append(nb::cast(field.fieldDef->name)); }
+    for (const auto& [name, value] : to_shallow_dict()) { field_names.append(name); }
     return field_names;
 }
 
@@ -515,7 +511,7 @@ void init_message_objects(nb::module_& m)
                  nb::list base_list = nb::cast<nb::list>(super_obj.attr("__dir__")());
                  // add dynamic fields to the list
                  PyField* body = nb::inst_ptr<PyField>(self);
-                 for (const auto& [field_name, _] : body->get_field_defs()) { base_list.append(field_name); }
+                 for (const auto& field_name : body->get_field_names()) { base_list.append(field_name); }
 
                  return base_list;
              })
@@ -527,7 +523,7 @@ void init_message_objects(nb::module_& m)
                 The name of every top-level field within the message payload.      
             )doc")
         .def("get_field_values", &PyField::get_values,
-            R"doc(
+             R"doc(
             Retrieves the values of every top-level field within the payload of this message.
 
             Returns:

--- a/python/bindings/py_message_objects.cpp
+++ b/python/bindings/py_message_objects.cpp
@@ -153,7 +153,7 @@ nb::dict& PyField::to_shallow_dict() const
             if (std::holds_alternative<std::vector<FieldContainer>>(field.fieldValue) && (field.fieldDef->type == FIELD_TYPE::FIELD_ARRAY || field.fieldDef->type == FIELD_TYPE::VARIABLE_LENGTH_ARRAY))
             {
                 std::vector<FieldContainer> field_array = std::get<std::vector<FieldContainer>>(field.fieldValue);
-                cached_values_[nb::cast(field.fieldDef->name + "_count")] = field_array.size();
+                cached_values_[nb::cast(field.fieldDef->name + "_length")] = field_array.size();
             }
             cached_values_[nb::cast(field.fieldDef->name)] = convert_field(field, parent_db_, this->name, this->has_ptype);
         }

--- a/python/novatel_edie_files/stubgen.py
+++ b/python/novatel_edie_files/stubgen.py
@@ -198,15 +198,16 @@ class StubGenerator:
         if not fields:
             body_hint += '    pass\n\n'
         for field in fields:
+            if field['type'] in ('FIELD_ARRAY', 'VARIABLE_LENGTH_ARRAY'):
+                body_hint += f'    @property\n'
+                body_hint += f'    def {field["name"]}_count(self) -> int: ...\n\n'
+
             python_type = self._get_field_pytype(field, name)
             body_hint +=  '    @property\n'
             body_hint += f'    def {field["name"]}(self) -> {python_type}: ...\n\n'
 
             # Create hints for any subfields
             if field['type'] == 'FIELD_ARRAY':
-                body_hint += f'    @property\n'
-                body_hint += f'    def {field["name"]}_count(self) -> int: ...\n\n'
-
                 subfield_hints.append(self._convert_field_array_def(field, name))
 
 

--- a/python/novatel_edie_files/stubgen.py
+++ b/python/novatel_edie_files/stubgen.py
@@ -204,7 +204,12 @@ class StubGenerator:
 
             # Create hints for any subfields
             if field['type'] == 'FIELD_ARRAY':
+                body_hint += f'    @property\n'
+                body_hint += f'    def {field["name"]}_count(self) -> int: ...\n\n'
+
                 subfield_hints.append(self._convert_field_array_def(field, name))
+
+
 
         # Combine all hints
         hints = subfield_hints + [body_hint]

--- a/python/novatel_edie_files/stubgen.py
+++ b/python/novatel_edie_files/stubgen.py
@@ -200,7 +200,7 @@ class StubGenerator:
         for field in fields:
             if field['type'] in ('FIELD_ARRAY', 'VARIABLE_LENGTH_ARRAY'):
                 body_hint += f'    @property\n'
-                body_hint += f'    def {field["name"]}_count(self) -> int: ...\n\n'
+                body_hint += f'    def {field["name"]}_length(self) -> int: ...\n\n'
 
             python_type = self._get_field_pytype(field, name)
             body_hint +=  '    @property\n'

--- a/python/test/test_decode.py
+++ b/python/test/test_decode.py
@@ -37,6 +37,13 @@ def decoder():
     return ne.Decoder()
 
 def nest_values(message: ne.Field):
+    """Convert the values of field into a nested list structure.
+
+    Args:
+        message: A message or field to retrieve values from.
+    Returns:
+        list: A nested list of simple values.
+    """
     values = message.get_field_values()
     for i, value in enumerate(values):
         if isinstance(value, ne.Field):
@@ -52,7 +59,15 @@ def nest_values(message: ne.Field):
     return values
 
 def compare_with_floating_point(item1, item2) -> bool:
-    """Compare two lists for equality, including nested lists."""
+    """Compare items for equality, allowing for floating point tolerance within lists.
+
+    Args:
+        item1: The first item to compare.
+        item2: The second item to compare.
+
+    Returns:
+        bool: True if items are equal or within floating point tolerance, False otherwise.
+    """
     if isinstance(item1, list) and isinstance(item2, list):
         if len(item1) != len(item2):
             return False

--- a/python/test/test_decode.py
+++ b/python/test/test_decode.py
@@ -36,6 +36,35 @@ def decoder():
     """Fixture for creating a decoder instance."""
     return ne.Decoder()
 
+def nest_values(message: ne.Field):
+    values = message.get_field_values()
+    for i, value in enumerate(values):
+        if isinstance(value, ne.Field):
+            values[i] = nest_values(value)
+        elif isinstance(value, list):
+            list_values = []
+            for item in value:
+                if isinstance(item, ne.Field):
+                    list_values.append(nest_values(item))
+                else:
+                    list_values.append(item)
+            values[i] = list_values
+    return values
+
+def compare_with_floating_point(item1, item2) -> bool:
+    """Compare two lists for equality, including nested lists."""
+    if isinstance(item1, list) and isinstance(item2, list):
+        if len(item1) != len(item2):
+            return False
+        for item1, item2 in zip(item1, item2):
+            return compare_with_floating_point(item1, item2)
+    elif isinstance(item1, float) and isinstance(item2, float):
+        # Compare floating point numbers with a tolerance
+        ret_val = abs(item1 - item2) < 1e-6
+        return ret_val
+    return item1 == item2
+
+
 @pytest.mark.parametrize("data, exp_fields, exp_values", [
     pytest.param(
         b"#BESTPOSA,COM1,0,60.5,FINESTEERING,2166,327153.000,02000000,b1f6,16248;SOL_COMPUTED,WAAS,51.15043699323,-114.03067932462,1096.9772,-17.0000,WGS84,0.6074,0.5792,0.9564,\"131\",7.000,0.000,42,34,34,28,00,0b,1f,37*47bbdc4f\r\n",
@@ -70,14 +99,33 @@ def decoder():
             55
         ],
         id="BESTPOS"
+    ),
+    pytest.param(
+        b'#RANGECMP2A,USB1,0,66.5,FINESTEERING,2378,227093.000,03000020,1fe3,32768;5,ffffffffff*58bf791d',
+        ['range_data_count', 'range_data'],
+        [
+            5,
+            [0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
+        ],
+        id="RANGECMP2"
+    ),
+    pytest.param(
+        b'#RANGEA,USB1,0,66.0,FINESTEERING,2378,230219.000,03000020,5103,32768;1,27,0,24627698.557,0.246,-129419430.405069,0.014,3666.953,42.6,344.455,0810dc04*1d271f23',
+        ['obs_count', 'obs'],
+        [
+            1,
+            [[27, 0, 24627698.557, 0.246, -129419430.405069, 0.014, 3666.953, 42.6, 344.455, 135322628]]
+        ],
+        id="RANGEA"
     )
 ])
-def test_field_names_and_values(data, exp_fields, exp_values, decoder: ne.Decoder):
+def test_field_names_and_values(
+        data: bytes, exp_fields: list, exp_values: list, decoder: ne.Decoder):
     """Test that the field names are correct."""
     # Act
     msg = decoder.decode(data)
     fields = msg.get_field_names()
-    values = msg.get_field_values()
+    values = nest_values(msg)
     # Assert
     assert fields == exp_fields, f"Expected fields: {exp_fields}, but got: {fields}"
-    assert values == exp_values, f"Expected values: {exp_values}, but got: {values}"
+    assert compare_with_floating_point(values, exp_values), f"Expected values: {exp_values}, but got: {values}"

--- a/python/test/test_decode.py
+++ b/python/test/test_decode.py
@@ -102,7 +102,7 @@ def compare_with_floating_point(item1, item2) -> bool:
     ),
     pytest.param(
         b'#RANGECMP2A,USB1,0,66.5,FINESTEERING,2378,227093.000,03000020,1fe3,32768;5,ffffffffff*58bf791d',
-        ['range_data_count', 'range_data'],
+        ['range_data_length', 'range_data'],
         [
             5,
             [0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
@@ -111,7 +111,7 @@ def compare_with_floating_point(item1, item2) -> bool:
     ),
     pytest.param(
         b'#RANGEA,USB1,0,66.0,FINESTEERING,2378,230219.000,03000020,5103,32768;1,27,0,24627698.557,0.246,-129419430.405069,0.014,3666.953,42.6,344.455,0810dc04*1d271f23',
-        ['obs_count', 'obs'],
+        ['obs_length', 'obs'],
         [
             1,
             [[27, 0, 24627698.557, 0.246, -129419430.405069, 0.014, 3666.953, 42.6, 344.455, 135322628]]


### PR DESCRIPTION
Our public definitions indicate that logs with variables length arrays or field arrays should have a `#{field_name}` field preceding it.

https://docs.novatel.com/OEM7/Content/Logs/RANGECMP2.htm?Highlight=rangecmp2#:~:text=2-,%23%20bytes,-Number%20of%20bytes

As users expect such a field to exist I think its worth including one on the python side. I don't want to commit to duplicated data on the C++ side but the python property access is flexible enough I'm not worried about including it at that level.