### PR TITLE
Allow loggers in configuration file to override root logger.

### DIFF
--- a/include/novatel_edie/common/logger.hpp
+++ b/include/novatel_edie/common/logger.hpp
@@ -88,9 +88,13 @@ class CPPLoggerManager : public LoggerManager
     void InitRootLogger()
     {
         std::call_once(loggerFlag, [this]() {
-            rootLogger = spdlog::stdout_color_mt("root");
-            rootLogger->set_level(spdlog::level::info);
-            rootLogger->flush_on(spdlog::level::debug);
+            rootLogger = spdlog::get("root");
+            if (!rootLogger)
+            {
+                rootLogger = spdlog::stdout_color_mt("root");
+                rootLogger->set_level(spdlog::level::info);
+                rootLogger->flush_on(spdlog::level::debug);
+            }
             set_default_logger(rootLogger);
             rootLogger->info("Logger initialized.");
         });


### PR DESCRIPTION
* Check for existing 'root' logger before creating new one in logger.hpp
* Fixes crash when config file defines 'root' logger (e.g. docs/example_logger_config.toml)
* Can adjust the level of all internal loggers by overriding the 'root' logger (see include/novatel_edie/common/logger.hpp:148). In particular, logging can be silenced by setting the 'level' of 'root' to 'off' in the configuration file