### PR TITLE
Change fmt version from 11.0.2 to 11.1.3 in conanfile

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -52,7 +52,7 @@ class NovatelEdieConan(ConanFile):
         self.requires("spdlog/[>=1.13 <2]", transitive_headers=True, transitive_libs=True, force=True)
         self.requires("gegles-spdlog_setup/[>=1.1 <2]", transitive_headers=True)
         # fmt/11.1.1 is currently not compatible with spdlog https://github.com/gabime/spdlog/issues/3302
-        self.requires("fmt/11.0.2", force=True)
+        self.requires("fmt/11.1.3", force=True)
 
     def build_requirements(self):
         self.test_requires("gtest/[>=1.14 <1.15]")


### PR DESCRIPTION
- Fixes pipeline error caused by string overflow warning in GCC 14. See issue in fmt library [here](https://github.com/fmtlib/fmt/issues/4125)