### PR TITLE
Implement Chorba CRC32

### DIFF
--- a/include/novatel_edie/common/crc.hpp
+++ b/include/novatel_edie/common/crc.hpp
@@ -150,65 +150,59 @@ constexpr CrcT CalculateBlockCrc(const unsigned char* ucBuffer_, uint32_t uiCoun
     const size_t chunks = uiCount_ / 8;
     for (size_t k = 0; k < chunks; k++)
     {
-        uint8_t b0 = ucBuffer_[i + 0];
-        uint8_t b1 = ucBuffer_[i + 1];
-        uint8_t b2 = ucBuffer_[i + 2];
-        uint8_t b3 = ucBuffer_[i + 3];
-        uint8_t b4 = ucBuffer_[i + 4];
-        uint8_t b5 = ucBuffer_[i + 5];
-        uint8_t b6 = ucBuffer_[i + 6];
-        uint8_t b7 = ucBuffer_[i + 7];
+        uint8_t b[8]; // b0..b7
+        std::memcpy(b, ucBuffer_ + i, sizeof(b));
 
         if constexpr (Rev)
         {
             // LSB-first: inject running CRC bytes from right-to-left
-            b0 ^= static_cast<uint8_t>(crc & static_cast<CrcT>(0xFF));
-            if constexpr (sizeof(CrcT) > 1) { b1 ^= static_cast<uint8_t>((crc >> 8) & static_cast<CrcT>(0xFF)); }
+            b[0] ^= static_cast<uint8_t>(crc & static_cast<CrcT>(0xFF));
+            if constexpr (sizeof(CrcT) > 1) { b[1] ^= static_cast<uint8_t>((crc >> 8) & static_cast<CrcT>(0xFF)); }
             if constexpr (sizeof(CrcT) > 2)
             {
-                b2 ^= static_cast<uint8_t>((crc >> 16) & static_cast<CrcT>(0xFF));
-                b3 ^= static_cast<uint8_t>((crc >> 24) & static_cast<CrcT>(0xFF));
+                b[2] ^= static_cast<uint8_t>((crc >> 16) & static_cast<CrcT>(0xFF));
+                b[3] ^= static_cast<uint8_t>((crc >> 24) & static_cast<CrcT>(0xFF));
             }
             if constexpr (sizeof(CrcT) > 4)
             {
-                b4 ^= static_cast<uint8_t>((crc >> 32) & static_cast<CrcT>(0xFF));
-                b5 ^= static_cast<uint8_t>((crc >> 40) & static_cast<CrcT>(0xFF));
-                b6 ^= static_cast<uint8_t>((crc >> 48) & static_cast<CrcT>(0xFF));
-                b7 ^= static_cast<uint8_t>((crc >> 56) & static_cast<CrcT>(0xFF));
+                b[4] ^= static_cast<uint8_t>((crc >> 32) & static_cast<CrcT>(0xFF));
+                b[5] ^= static_cast<uint8_t>((crc >> 40) & static_cast<CrcT>(0xFF));
+                b[6] ^= static_cast<uint8_t>((crc >> 48) & static_cast<CrcT>(0xFF));
+                b[7] ^= static_cast<uint8_t>((crc >> 56) & static_cast<CrcT>(0xFF));
             }
         }
         else
         {
             // MSB-first: inject running CRC bytes from left-to-right
-            if constexpr (sizeof(CrcT) == 1) { b0 ^= static_cast<uint8_t>(crc); }
+            if constexpr (sizeof(CrcT) == 1) { b[0] ^= static_cast<uint8_t>(crc); }
             else if constexpr (sizeof(CrcT) == 2)
             {
-                b0 ^= static_cast<uint8_t>((crc >> 8) & static_cast<CrcT>(0xFF));
-                b1 ^= static_cast<uint8_t>(crc & static_cast<CrcT>(0xFF));
+                b[0] ^= static_cast<uint8_t>((crc >> 8) & static_cast<CrcT>(0xFF));
+                b[1] ^= static_cast<uint8_t>(crc & static_cast<CrcT>(0xFF));
             }
             else if constexpr (sizeof(CrcT) == 4)
             {
-                b0 ^= static_cast<uint8_t>((crc >> 24) & static_cast<CrcT>(0xFF));
-                b1 ^= static_cast<uint8_t>((crc >> 16) & static_cast<CrcT>(0xFF));
-                b2 ^= static_cast<uint8_t>((crc >> 8) & static_cast<CrcT>(0xFF));
-                b3 ^= static_cast<uint8_t>(crc & static_cast<CrcT>(0xFF));
+                b[0] ^= static_cast<uint8_t>((crc >> 24) & static_cast<CrcT>(0xFF));
+                b[1] ^= static_cast<uint8_t>((crc >> 16) & static_cast<CrcT>(0xFF));
+                b[2] ^= static_cast<uint8_t>((crc >> 8) & static_cast<CrcT>(0xFF));
+                b[3] ^= static_cast<uint8_t>(crc & static_cast<CrcT>(0xFF));
             }
             else
             {
-                b0 ^= static_cast<uint8_t>((crc >> 56) & static_cast<CrcT>(0xFF));
-                b1 ^= static_cast<uint8_t>((crc >> 48) & static_cast<CrcT>(0xFF));
-                b2 ^= static_cast<uint8_t>((crc >> 40) & static_cast<CrcT>(0xFF));
-                b3 ^= static_cast<uint8_t>((crc >> 32) & static_cast<CrcT>(0xFF));
-                b4 ^= static_cast<uint8_t>((crc >> 24) & static_cast<CrcT>(0xFF));
-                b5 ^= static_cast<uint8_t>((crc >> 16) & static_cast<CrcT>(0xFF));
-                b6 ^= static_cast<uint8_t>((crc >> 8) & static_cast<CrcT>(0xFF));
-                b7 ^= static_cast<uint8_t>(crc & static_cast<CrcT>(0xFF));
+                b[0] ^= static_cast<uint8_t>((crc >> 56) & static_cast<CrcT>(0xFF));
+                b[1] ^= static_cast<uint8_t>((crc >> 48) & static_cast<CrcT>(0xFF));
+                b[2] ^= static_cast<uint8_t>((crc >> 40) & static_cast<CrcT>(0xFF));
+                b[3] ^= static_cast<uint8_t>((crc >> 32) & static_cast<CrcT>(0xFF));
+                b[4] ^= static_cast<uint8_t>((crc >> 24) & static_cast<CrcT>(0xFF));
+                b[5] ^= static_cast<uint8_t>((crc >> 16) & static_cast<CrcT>(0xFF));
+                b[6] ^= static_cast<uint8_t>((crc >> 8) & static_cast<CrcT>(0xFF));
+                b[7] ^= static_cast<uint8_t>(crc & static_cast<CrcT>(0xFF));
             }
         }
 
-        crc = UI_CRC_TABLE<CrcT, Poly, Rev>[7][b0] ^ UI_CRC_TABLE<CrcT, Poly, Rev>[6][b1] ^ UI_CRC_TABLE<CrcT, Poly, Rev>[5][b2] ^
-              UI_CRC_TABLE<CrcT, Poly, Rev>[4][b3] ^ UI_CRC_TABLE<CrcT, Poly, Rev>[3][b4] ^ UI_CRC_TABLE<CrcT, Poly, Rev>[2][b5] ^
-              UI_CRC_TABLE<CrcT, Poly, Rev>[1][b6] ^ UI_CRC_TABLE<CrcT, Poly, Rev>[0][b7];
+        crc = UI_CRC_TABLE<CrcT, Poly, Rev>[7][b[0]] ^ UI_CRC_TABLE<CrcT, Poly, Rev>[6][b[1]] ^ UI_CRC_TABLE<CrcT, Poly, Rev>[5][b[2]] ^
+              UI_CRC_TABLE<CrcT, Poly, Rev>[4][b[3]] ^ UI_CRC_TABLE<CrcT, Poly, Rev>[3][b[4]] ^ UI_CRC_TABLE<CrcT, Poly, Rev>[2][b[5]] ^
+              UI_CRC_TABLE<CrcT, Poly, Rev>[1][b[6]] ^ UI_CRC_TABLE<CrcT, Poly, Rev>[0][b[7]];
 
         i += 8;
     }

--- a/include/novatel_edie/common/crc.hpp
+++ b/include/novatel_edie/common/crc.hpp
@@ -29,6 +29,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <string_view>
 #include <type_traits>
 
@@ -94,7 +95,7 @@ template <typename CrcT, CrcT Poly, bool Rev> constexpr auto make_crc_table()
 
 // Variable template: one table instance per CRC type/polynomial, computed entirely at compile time.
 template <typename CrcT, CrcT Poly, bool Rev> inline constexpr auto UI_CRC_TABLE = make_crc_table<CrcT, Poly, Rev>();
-} // namespace (anonymous)
+} // namespace
 
 namespace novatel::edie {
 // --------------------------------------------------------------------------
@@ -150,7 +151,7 @@ constexpr CrcT CalculateBlockCrc(const unsigned char* ucBuffer_, uint32_t uiCoun
     const size_t chunks = uiCount_ / 8;
     for (size_t k = 0; k < chunks; k++)
     {
-        uint8_t b[8]; // b0..b7
+        uint8_t b[8] = {0}; // b0..b7
         std::memcpy(b, ucBuffer_ + i, sizeof(b));
 
         if constexpr (Rev)

--- a/include/novatel_edie/common/crc.hpp
+++ b/include/novatel_edie/common/crc.hpp
@@ -32,6 +32,7 @@
 #include <string_view>
 #include <type_traits>
 
+namespace {
 // Build the slice-by-8 lookup tables for the given generator polynomial.
 // Rev=true expects a reflected polynomial and computes LSB-first tables.
 // Rev=false expects a normal polynomial and computes MSB-first tables.
@@ -93,7 +94,9 @@ template <typename CrcT, CrcT Poly, bool Rev> constexpr auto make_crc_table()
 
 // Variable template: one table instance per CRC type/polynomial, computed entirely at compile time.
 template <typename CrcT, CrcT Poly, bool Rev> inline constexpr auto UI_CRC_TABLE = make_crc_table<CrcT, Poly, Rev>();
+} // namespace (anonymous)
 
+namespace novatel::edie {
 // --------------------------------------------------------------------------
 // Accumulate a single character into the given CRC value
 // --------------------------------------------------------------------------
@@ -244,3 +247,4 @@ template <uint32_t Poly = 0xEDB88320UL, bool Rev = true> constexpr uint32_t Calc
 {
     return CalculateBlockCrc<uint32_t, Poly, Rev>(buffer_);
 }
+} // namespace novatel::edie

--- a/include/novatel_edie/common/fixed_buffer.hpp
+++ b/include/novatel_edie/common/fixed_buffer.hpp
@@ -34,7 +34,6 @@
 #include <numeric>
 #include <type_traits>
 
-#include "novatel_edie/common/crc.hpp"
 //!< Recommended frame buffer size. Should work for most formats and message sizes. If the buffer is too small, the framer will return BUFFER_FULL.
 constexpr uint32_t RECOMMENDED_FRAME_BUFFER_SIZE = 256 * 1024; // 256Kb
 

--- a/include/novatel_edie/decoders/oem/crc.hpp
+++ b/include/novatel_edie/decoders/oem/crc.hpp
@@ -100,7 +100,7 @@ inline uint32_t CalculateBlockCrc32Chorba(const unsigned char* ucBuffer_, uint32
 
     return novatel::edie::CalculateBlockCrc<uint32_t, 0xEDB88320UL, true>(reinterpret_cast<const unsigned char*>(final), uiCount_ - i, 0);
 }
-} // namespace (anonymous)
+} // namespace
 
 namespace novatel::edie::oem {
 constexpr void CalculateCharacterCrc32(uint32_t& uiCrc_, unsigned char ucChar_)
@@ -114,8 +114,5 @@ constexpr uint32_t CalculateBlockCrc32(const unsigned char* ucBuffer_, uint32_t 
                          : CalculateBlockCrc<uint32_t, 0xEDB88320UL, true>(ucBuffer_, uiCount_, uiInitialCrc_);
 }
 
-constexpr uint32_t CalculateBlockCrc32(std::string_view buffer_)
-{
-    return CalculateBlockCrc<uint32_t, 0xEDB88320UL, true>(buffer_);
-}
+constexpr uint32_t CalculateBlockCrc32(std::string_view buffer_) { return CalculateBlockCrc<uint32_t, 0xEDB88320UL, true>(buffer_); }
 } // namespace novatel::edie::oem

--- a/include/novatel_edie/decoders/oem/crc.hpp
+++ b/include/novatel_edie/decoders/oem/crc.hpp
@@ -29,6 +29,8 @@
 #include "novatel_edie/common/crc.hpp"
 
 namespace {
+constexpr size_t CHORBA_WINDOW = 48; // 6 words * 8 bytes/word
+
 //============================================================================
 //! \brief An implementation of the Chorba CRC32 algorithm from https://arxiv.org/abs/2412.16398.
 //!     Uses the reflected generator polynomial 0xEDB88320 and treats the input as LSB-first.
@@ -43,9 +45,10 @@ namespace {
 //============================================================================
 inline uint32_t CalculateBlockCrc32Chorba(const unsigned char* ucBuffer_, uint32_t uiCount_, uint32_t uiInitialCrc_ = 0)
 {
-    uint64_t final[6] = {0};
-    uint64_t next1 = uiInitialCrc_, next2 = 0, next3 = 0, next4 = 0, next5 = 0;
-    uint64_t in1, a1, a2, a3, a4;
+    uint64_t acc[5] = {0};
+    acc[0] = uiInitialCrc_;
+    uint64_t f[4] = {0};
+    uint64_t cur = 0;
 
     uint32_t i = 0;
 
@@ -53,52 +56,49 @@ inline uint32_t CalculateBlockCrc32Chorba(const unsigned char* ucBuffer_, uint32
     // The core idea of the Chorba algorithm is that adding any multiple of such a
     // zero polynomial does not change the CRC:
     // M(x) mod G(x) = (M(x) + k(x) * Z(x)) mod G(x).
-    // For each 64-bit word w from the input, the algorithm conceptually adds
-    // w * Z(x) (at the word's position) to the message, where
+    // For each 64-bit word m from the input, the algorithm conceptually adds
+    // m * Z(x) (at the word's position) to the message, where
     //
     //        Z(x) = x^300 + x^211 + x^183 + x^145 + 1.
     //
-    // (More precisely, we add w * x^k * Z(x), where k corresponds to the
-    // bit position of w in the stream.)
+    // (More precisely, we add m * x^k * Z(x), where k corresponds to the
+    // bit position of m in the stream.)
     //
     // This is a good choice of Z(x) because it has small degree (we only need to look
     // ceil(300 / 64) = 5 words ahead) and few terms (so we can implement the multiplication
     // with few shifts/XORs).
     //
-    // The algorithm maintains a 5-word window of pending modifications. "next1..next5"
+    // The algorithm maintains a 5-word window of pending modifications. "acc[0]..acc[4]"
     // are the terms to be XORed into the next five input words as the loop advances,
-    // and "a1..a4" are the newly generated downstream terms from the current "in1".
-    // This mapping may help visualize where each term lands:
+    // and "f[0]..f[3]" are the newly generated downstream terms from the current "cur".
+    // This diagram may help visualize where each term lands:
     //
-    // words:     w0       w1       w2       w3       w4       w5       w6       ...
-    // vars:      in1               a1       a2       a3       a4
-    //            next1    next2    next3    next4    next5
+    // input:     m0       m1       m2       m3       m4       m5       m6       ...
+    // vars:      cur               f[0]     f[1]     f[2]     f[3]
+    //            acc[0]   acc[1]   acc[2]   acc[3]   acc[4]
 
-    for (; (i + 40 + 8) < uiCount_; i += 8)
+    for (; i + CHORBA_WINDOW < uiCount_; i += 8)
     {
-        std::memcpy(&in1, ucBuffer_ + i, sizeof(in1));
-        in1 ^= next1;
+        std::memcpy(&cur, ucBuffer_ + i, sizeof(cur));
+        cur ^= acc[0];
 
-        a1 = (in1 << 17) /* represents x^145 (2*64 + 17 = 145) */ ^ (in1 << 55) /* represents x^183 (2*64 + 55 = 183) */;
-        a2 = (in1 >> 47) /* overflow from x^145 */ ^ (in1 >> 9) /* overflow from x^183 */ ^ (in1 << 19) /* represents x^211 (3*64 + 19 = 211) */;
-        a3 = (in1 >> 45) /* overflow from x^211 */ ^ (in1 << 44) /* represents x^300 (4*64 + 44 = 300) */;
-        a4 = (in1 >> 20) /* overflow from x^300 */;
+        f[0] = (cur << 17) /* represents x^145 (2*64 + 17 = 145) */ ^ (cur << 55) /* represents x^183 (2*64 + 55 = 183) */;
+        f[1] = (cur >> 47) /* overflow from x^145 */ ^ (cur >> 9) /* overflow from x^183 */ ^ (cur << 19) /* represents x^211 (3*64 + 19 = 211) */;
+        f[2] = (cur >> 45) /* overflow from x^211 */ ^ (cur << 44) /* represents x^300 (4*64 + 44 = 300) */;
+        f[3] = (cur >> 20) /* overflow from x^300 */;
 
-        next1 = next2;
-        next2 = next3 ^ a1;
-        next3 = next4 ^ a2;
-        next4 = next5 ^ a3;
-        next5 = a4;
+        acc[0] = acc[1];
+        acc[1] = acc[2] ^ f[0];
+        acc[2] = acc[3] ^ f[1];
+        acc[3] = acc[4] ^ f[2];
+        acc[4] = f[3];
     }
 
-    std::memcpy(final, ucBuffer_ + i, uiCount_ - i);
-    final[0] ^= next1;
-    final[1] ^= next2;
-    final[2] ^= next3;
-    final[3] ^= next4;
-    final[4] ^= next5;
+    uint64_t leftover[6] = {0};
+    std::memcpy(leftover, ucBuffer_ + i, uiCount_ - i);
+    for (size_t j = 0; j < 5; j++) { leftover[j] ^= acc[j]; }
 
-    return novatel::edie::CalculateBlockCrc<uint32_t, 0xEDB88320UL, true>(reinterpret_cast<const unsigned char*>(final), uiCount_ - i, 0);
+    return novatel::edie::CalculateBlockCrc<uint32_t, 0xEDB88320UL, true>(reinterpret_cast<const unsigned char*>(leftover), uiCount_ - i, 0);
 }
 } // namespace
 
@@ -110,8 +110,8 @@ constexpr void CalculateCharacterCrc32(uint32_t& uiCrc_, unsigned char ucChar_)
 
 constexpr uint32_t CalculateBlockCrc32(const unsigned char* ucBuffer_, uint32_t uiCount_, uint32_t uiInitialCrc_ = 0)
 {
-    return uiCount_ > 48 ? CalculateBlockCrc32Chorba(ucBuffer_, uiCount_, uiInitialCrc_)
-                         : CalculateBlockCrc<uint32_t, 0xEDB88320UL, true>(ucBuffer_, uiCount_, uiInitialCrc_);
+    return uiCount_ > CHORBA_WINDOW ? CalculateBlockCrc32Chorba(ucBuffer_, uiCount_, uiInitialCrc_)
+                                    : CalculateBlockCrc<uint32_t, 0xEDB88320UL, true>(ucBuffer_, uiCount_, uiInitialCrc_);
 }
 
 constexpr uint32_t CalculateBlockCrc32(std::string_view buffer_) { return CalculateBlockCrc<uint32_t, 0xEDB88320UL, true>(buffer_); }

--- a/include/novatel_edie/decoders/oem/crc.hpp
+++ b/include/novatel_edie/decoders/oem/crc.hpp
@@ -1,0 +1,121 @@
+// ===============================================================================
+// |                                                                             |
+// |  COPYRIGHT NovAtel Inc, 2022. All rights reserved.                          |
+// |                                                                             |
+// |  Permission is hereby granted, free of charge, to any person obtaining a    |
+// |  copy of this software and associated documentation files (the "Software"), |
+// |  to deal in the Software without restriction, including without limitation  |
+// |  the rights to use, copy, modify, merge, publish, distribute, sublicense,   |
+// |  and/or sell copies of the Software, and to permit persons to whom the      |
+// |  Software is furnished to do so, subject to the following conditions:       |
+// |                                                                             |
+// |  The above copyright notice and this permission notice shall be included    |
+// |  in all copies or substantial portions of the Software.                     |
+// |                                                                             |
+// |  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR |
+// |  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,   |
+// |  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL    |
+// |  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER |
+// |  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING    |
+// |  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER        |
+// |  DEALINGS IN THE SOFTWARE.                                                  |
+// |                                                                             |
+// ===============================================================================
+// ! \file crc.hpp
+// ===============================================================================
+
+#pragma once
+
+#include "novatel_edie/common/crc.hpp"
+
+namespace {
+//============================================================================
+//! \brief An implementation of the Chorba CRC32 algorithm from https://arxiv.org/abs/2412.16398.
+//!     Uses the reflected generator polynomial 0xEDB88320 and treats the input as LSB-first.
+//!
+//! This algorithm is more efficient than slice-by-8 for larger inputs (e.g. RANGE logs), while
+//! remaining at least as fast for smaller inputs.
+//!
+//! \param ucBuffer_ The buffer to calculate CRC for.
+//! \param uiCount_ The number of bytes in the buffer.
+//! \param uiInitialCrc_ The initial CRC value (default 0).
+//! \return The calculated CRC-32 value.
+//============================================================================
+inline uint32_t CalculateBlockCrc32Chorba(const unsigned char* ucBuffer_, uint32_t uiCount_, uint32_t uiInitialCrc_ = 0)
+{
+    uint64_t final[6] = {0};
+    uint64_t next1 = uiInitialCrc_, next2 = 0, next3 = 0, next4 = 0, next5 = 0;
+    uint64_t in1, a1, a2, a3, a4;
+
+    uint32_t i = 0;
+
+    // A zero polynomial Z(x) satisfies Z(x) mod G(x) = 0, where G(x) is the generator.
+    // The core idea of the Chorba algorithm is that adding any multiple of such a
+    // zero polynomial does not change the CRC:
+    // M(x) mod G(x) = (M(x) + k(x) * Z(x)) mod G(x).
+    // For each 64-bit word w from the input, the algorithm conceptually adds
+    // w * Z(x) (at the word's position) to the message, where
+    //
+    //        Z(x) = x^300 + x^211 + x^183 + x^145 + 1.
+    //
+    // (More precisely, we add w * x^k * Z(x), where k corresponds to the
+    // bit position of w in the stream.)
+    //
+    // This is a good choice of Z(x) because it has small degree (we only need to look
+    // ceil(300 / 64) = 5 words ahead) and few terms (so we can implement the multiplication
+    // with few shifts/XORs).
+    //
+    // The algorithm maintains a 5-word window of pending modifications. "next1..next5"
+    // are the terms to be XORed into the next five input words as the loop advances,
+    // and "a1..a4" are the newly generated downstream terms from the current "in1".
+    // This mapping may help visualize where each term lands:
+    //
+    // words:     w0       w1       w2       w3       w4       w5       w6       ...
+    // vars:      in1               a1       a2       a3       a4
+    //            next1    next2    next3    next4    next5
+
+    for (; (i + 40 + 8) < uiCount_; i += 8)
+    {
+        std::memcpy(&in1, ucBuffer_ + i, sizeof(in1));
+        in1 ^= next1;
+
+        a1 = (in1 << 17) /* represents x^145 (2*64 + 17 = 145) */ ^ (in1 << 55) /* represents x^183 (2*64 + 55 = 183) */;
+        a2 = (in1 >> 47) /* overflow from x^145 */ ^ (in1 >> 9) /* overflow from x^183 */ ^ (in1 << 19) /* represents x^211 (3*64 + 19 = 211) */;
+        a3 = (in1 >> 45) /* overflow from x^211 */ ^ (in1 << 44) /* represents x^300 (4*64 + 44 = 300) */;
+        a4 = (in1 >> 20) /* overflow from x^300 */;
+
+        next1 = next2;
+        next2 = next3 ^ a1;
+        next3 = next4 ^ a2;
+        next4 = next5 ^ a3;
+        next5 = a4;
+    }
+
+    std::memcpy(final, ucBuffer_ + i, uiCount_ - i);
+    final[0] ^= next1;
+    final[1] ^= next2;
+    final[2] ^= next3;
+    final[3] ^= next4;
+    final[4] ^= next5;
+
+    return novatel::edie::CalculateBlockCrc<uint32_t, 0xEDB88320UL, true>(reinterpret_cast<const unsigned char*>(final), uiCount_ - i, 0);
+}
+} // namespace (anonymous)
+
+namespace novatel::edie::oem {
+constexpr void CalculateCharacterCrc32(uint32_t& uiCrc_, unsigned char ucChar_)
+{
+    CalculateCharacterCrc<uint32_t, 0xEDB88320UL, true>(uiCrc_, ucChar_);
+}
+
+constexpr uint32_t CalculateBlockCrc32(const unsigned char* ucBuffer_, uint32_t uiCount_, uint32_t uiInitialCrc_ = 0)
+{
+    return uiCount_ > 48 ? CalculateBlockCrc32Chorba(ucBuffer_, uiCount_, uiInitialCrc_)
+                         : CalculateBlockCrc<uint32_t, 0xEDB88320UL, true>(ucBuffer_, uiCount_, uiInitialCrc_);
+}
+
+constexpr uint32_t CalculateBlockCrc32(std::string_view buffer_)
+{
+    return CalculateBlockCrc<uint32_t, 0xEDB88320UL, true>(buffer_);
+}
+} // namespace novatel::edie::oem

--- a/include/novatel_edie/decoders/oem/framer_ascii_base.hpp
+++ b/include/novatel_edie/decoders/oem/framer_ascii_base.hpp
@@ -30,6 +30,7 @@
 
 #include "novatel_edie/decoders/common/framer.hpp"
 #include "novatel_edie/decoders/oem/common.hpp"
+#include "novatel_edie/decoders/oem/crc.hpp"
 
 namespace novatel::edie::oem {
 

--- a/include/novatel_edie/decoders/oem/framer_binary_base.hpp
+++ b/include/novatel_edie/decoders/oem/framer_binary_base.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "novatel_edie/common/crc.hpp"
+#include "novatel_edie/decoders/oem/crc.hpp"
 #include "novatel_edie/decoders/common/framer.hpp"
 #include "novatel_edie/decoders/oem/common.hpp"
 

--- a/include/novatel_edie/decoders/oem/framer_binary_base.hpp
+++ b/include/novatel_edie/decoders/oem/framer_binary_base.hpp
@@ -26,9 +26,9 @@
 
 #pragma once
 
-#include "novatel_edie/decoders/oem/crc.hpp"
 #include "novatel_edie/decoders/common/framer.hpp"
 #include "novatel_edie/decoders/oem/common.hpp"
+#include "novatel_edie/decoders/oem/crc.hpp"
 
 namespace novatel::edie::oem {
 

--- a/src/common/test/crc_unit_test.cpp
+++ b/src/common/test/crc_unit_test.cpp
@@ -26,7 +26,9 @@
 
 #include <gtest/gtest.h>
 
-#include "novatel_edie/common/crc.hpp"
+#include "novatel_edie/decoders/oem/crc.hpp"
+
+using namespace novatel::edie::oem;
 
 // -------------------------------------------------------------------------------------------------------
 // CRC32 Unit Tests
@@ -75,14 +77,14 @@ TEST(CRC32Test, CalculateBlockCRC32_BESTPOS)
 TEST(CRC32Test, CalculateBlockCRC32_Koopman_forward)
 {
     constexpr unsigned char log[] = {0x33, 0x22, 0x55, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x3D, 0x34, 0x5A, 0xA6};
-    auto uiCalculatedCRC = CalculateBlockCrc32<0xF4ACFB13UL, false>(log, sizeof(log), 0xFFFFFFFFUL);
+    auto uiCalculatedCRC = novatel::edie::CalculateBlockCrc<uint32_t, 0xF4ACFB13UL, false>(log, sizeof(log), 0xFFFFFFFFUL);
     ASSERT_EQ(uiCalculatedCRC, 0x52DED2DCUL);
 }
 
 TEST(CRC32Test, CalculateBlockCRC32_Koopman_reflected)
 {
     constexpr unsigned char log[] = {0x33, 0x22, 0x55, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x3D, 0x34, 0x5A, 0xA6};
-    auto uiCalculatedCRC = CalculateBlockCrc32<0xC8DF352FUL>(log, sizeof(log), 0xFFFFFFFFUL);
+    auto uiCalculatedCRC = novatel::edie::CalculateBlockCrc<uint32_t, 0xC8DF352FUL, true>(log, sizeof(log), 0xFFFFFFFFUL);
     ASSERT_EQ(uiCalculatedCRC, 0x904CDDBFUL);
 }
 
@@ -93,7 +95,7 @@ TEST(CRC16Test, CalculateBlockCrc_CCITT_forward)
 {
     constexpr unsigned char log[] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C,
                                      0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C};
-    auto uiCalculatedCRC = CalculateBlockCrc<uint16_t, 0x1021UL, false>(log, sizeof(log));
+    auto uiCalculatedCRC = novatel::edie::CalculateBlockCrc<uint16_t, 0x1021UL, false>(log, sizeof(log));
     ASSERT_EQ(uiCalculatedCRC, 0x87D1UL);
 }
 
@@ -101,7 +103,7 @@ TEST(CRC16Test, CalculateBlockCrc_CCITT_reflected)
 {
     constexpr unsigned char log[] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C,
                                      0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C};
-    auto uiCalculatedCRC = CalculateBlockCrc<uint16_t, 0x8408UL, true>(log, sizeof(log));
+    auto uiCalculatedCRC = novatel::edie::CalculateBlockCrc<uint16_t, 0x8408UL, true>(log, sizeof(log));
     ASSERT_EQ(uiCalculatedCRC, 0x61C1UL);
 }
 
@@ -111,14 +113,14 @@ TEST(CRC16Test, CalculateBlockCrc_CCITT_reflected)
 TEST(CRC8Test, CalculateBlockCrc_AUTOSAR_forward)
 {
     constexpr unsigned char log[] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
-    auto uiCalculatedCRC = CalculateBlockCrc<uint8_t, 0x2FUL, false>(log, sizeof(log));
+    auto uiCalculatedCRC = novatel::edie::CalculateBlockCrc<uint8_t, 0x2FUL, false>(log, sizeof(log));
     ASSERT_EQ(uiCalculatedCRC, 0xABUL);
 }
 
 TEST(CRC8Test, CalculateBlockCrc_AUTOSAR_reflected)
 {
     constexpr unsigned char log[] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48};
-    auto uiCalculatedCRC = CalculateBlockCrc<uint8_t, 0xF4UL, true>(log, sizeof(log));
+    auto uiCalculatedCRC = novatel::edie::CalculateBlockCrc<uint8_t, 0xF4UL, true>(log, sizeof(log));
     ASSERT_EQ(uiCalculatedCRC, 0x34UL);
 }
 
@@ -128,13 +130,13 @@ TEST(CRC8Test, CalculateBlockCrc_AUTOSAR_reflected)
 TEST(CRC64Test, CalculateBlockCrc_ECMA182_forward)
 {
     constexpr unsigned char log[] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50};
-    auto uiCalculatedCRC = CalculateBlockCrc<uint64_t, 0x42F0E1EBA9EA3693UL, false>(log, sizeof(log));
+    auto uiCalculatedCRC = novatel::edie::CalculateBlockCrc<uint64_t, 0x42F0E1EBA9EA3693UL, false>(log, sizeof(log));
     ASSERT_EQ(uiCalculatedCRC, 0xEC07AF203BC7E0B5UL);
 }
 
 TEST(CRC64Test, CalculateBlockCrc_ECMA182_reflected)
 {
     constexpr unsigned char log[] = {0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50};
-    auto uiCalculatedCRC = CalculateBlockCrc<uint64_t, 0xC96C5795D7870F42UL, true>(log, sizeof(log));
+    auto uiCalculatedCRC = novatel::edie::CalculateBlockCrc<uint64_t, 0xC96C5795D7870F42UL, true>(log, sizeof(log));
     ASSERT_EQ(uiCalculatedCRC, 0x6B5F5863513AE525UL);
 }

--- a/src/decoders/oem/src/encoder.cpp
+++ b/src/decoders/oem/src/encoder.cpp
@@ -24,12 +24,13 @@
 // ! \file encoder.cpp
 // ===============================================================================
 
+#include "novatel_edie/decoders/oem/encoder.hpp"
+
 #include <algorithm>
 #include <charconv>
 #include <cstring>
 
 #include "novatel_edie/decoders/oem/crc.hpp"
-#include "novatel_edie/decoders/oem/encoder.hpp"
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;

--- a/src/decoders/oem/src/encoder.cpp
+++ b/src/decoders/oem/src/encoder.cpp
@@ -24,11 +24,12 @@
 // ! \file encoder.cpp
 // ===============================================================================
 
-#include "novatel_edie/decoders/oem/encoder.hpp"
-
 #include <algorithm>
 #include <charconv>
 #include <cstring>
+
+#include "novatel_edie/decoders/oem/crc.hpp"
+#include "novatel_edie/decoders/oem/encoder.hpp"
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;

--- a/src/decoders/oem/src/framer.cpp
+++ b/src/decoders/oem/src/framer.cpp
@@ -28,7 +28,7 @@
 
 #include <charconv>
 
-#include "novatel_edie/common/crc.hpp"
+#include "novatel_edie/decoders/oem/crc.hpp"
 #include "novatel_edie/decoders/common/framer_registration.hpp"
 
 using namespace novatel::edie;

--- a/src/decoders/oem/src/framer.cpp
+++ b/src/decoders/oem/src/framer.cpp
@@ -28,8 +28,8 @@
 
 #include <charconv>
 
-#include "novatel_edie/decoders/oem/crc.hpp"
 #include "novatel_edie/decoders/common/framer_registration.hpp"
+#include "novatel_edie/decoders/oem/crc.hpp"
 
 using namespace novatel::edie;
 using namespace novatel::edie::oem;

--- a/src/decoders/oem/src/framer_abb_ascii.cpp
+++ b/src/decoders/oem/src/framer_abb_ascii.cpp
@@ -28,7 +28,6 @@
 
 #include <charconv>
 
-#include "novatel_edie/common/crc.hpp"
 #include "novatel_edie/decoders/common/framer_registration.hpp"
 
 using namespace novatel::edie;

--- a/src/decoders/oem/src/message_decoder.cpp
+++ b/src/decoders/oem/src/message_decoder.cpp
@@ -24,8 +24,6 @@
 // ! \file message_decoder.cpp
 // ===============================================================================
 
-#include "novatel_edie/decoders/oem/message_decoder.hpp"
-
 #include <bitset>
 #include <charconv>
 #include <cmath>
@@ -33,6 +31,8 @@
 #include <simdjson.h>
 
 #include "novatel_edie/decoders/oem/common.hpp"
+#include "novatel_edie/decoders/oem/crc.hpp"
+#include "novatel_edie/decoders/oem/message_decoder.hpp"
 
 using namespace novatel::edie::oem;
 

--- a/src/decoders/oem/src/message_decoder.cpp
+++ b/src/decoders/oem/src/message_decoder.cpp
@@ -24,6 +24,8 @@
 // ! \file message_decoder.cpp
 // ===============================================================================
 
+#include "novatel_edie/decoders/oem/message_decoder.hpp"
+
 #include <bitset>
 #include <charconv>
 #include <cmath>
@@ -32,7 +34,6 @@
 
 #include "novatel_edie/decoders/oem/common.hpp"
 #include "novatel_edie/decoders/oem/crc.hpp"
-#include "novatel_edie/decoders/oem/message_decoder.hpp"
 
 using namespace novatel::edie::oem;
 


### PR DESCRIPTION
### Summary

- Implements a version of the "Chorba" algorithm from here: https://arxiv.org/abs/2412.16398
- Organizes CRC into two different headers/namespaces: one in common under `namespace novatel::edie`, and one in decoders/oem under `namespace novatel::edie::oem`
- Both namespaces contain `CalculateBlockCrc32` and `CalculateCharacterCrc32` for backwards-compatibility; the versions in the common header are templated (with the generator polynomial, CRC size, and direction), so calls to  `CalculateBlockCrc32(...)` resolve to the non-templated version in `novatel::edie::oem` by default
- An instantiation of Chorba is tied to a specific generator polynomial, so for now only the OEM CRC functions use the new Chorba algorithm

### Chorba algorithm

See the docs in the code for a brief explanation of the algorithm. Chorba is more performant than slice-by-8 because it does not use tables - all computation is done using only 10 persistent variables, which easily fit in the registers of a modern CPU. (Note that my implementation still calls the slice-by-8 function as a subroutine for the last 48 bytes of the input because it is way faster than the bitwise algorithm - but in principle you could avoid storing tables altogether using Chorba.)

In the current codebase, the `oem::CalculateBlockCrc32` function is used by the OEM Encoder and the standalone OEM Binary/ASCII framers. The performance benefits are most clear with larger logs like `RANGE` (note that our benchmarks currently only use BESTPOS logs). Here is an example framing/encoding a RANGE log:

Slice-by-8:
```
----------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------
FrameRangeAsciiFramerManager/min_time:2.000        4321 ns         4297 ns       640000 logs_per_second=232.727k/s
FrameRangeBinaryFramerManager/min_time:2.000       2397 ns         2393 ns      1194667 logs_per_second=417.807k/s
EncodeFlattenedBinaryRangeLog                      5055 ns         5022 ns       112000 logs_per_second=199.111k/s
EncodeAsciiRangeLog                               43576 ns        43945 ns        16000 logs_per_second=22.7556k/s
EncodeBinaryRangeLog                               2512 ns         2511 ns       298667 logs_per_second=398.223k/s
```

Chorba:

```
----------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------
FrameRangeAsciiFramerManager/min_time:2.000        1486 ns         1489 ns      1847423 logs_per_second=671.79k/s
FrameRangeBinaryFramerManager/min_time:2.000        717 ns          714 ns      3895652 logs_per_second=1.40068M/s
EncodeFlattenedBinaryRangeLog                      1428 ns         1413 ns       497778 logs_per_second=707.951k/s
EncodeAsciiRangeLog                               40221 ns        39899 ns        17231 logs_per_second=25.0633k/s
EncodeBinaryRangeLog                                707 ns          698 ns      1120000 logs_per_second=1.4336M/s
```