### PR TITLE
Fix array length field alignment

### DIFF
--- a/include/novatel_edie/decoders/common/encoder.hpp
+++ b/include/novatel_edie/decoders/common/encoder.hpp
@@ -317,12 +317,7 @@ template <typename Derived> class EncoderBase
                     const auto* arrayFieldDef = dynamic_cast<const ArrayField*>(field.fieldDef.get());
                     if (arrayFieldDef->arrayLengthRef.empty())
                     {
-                        // Not all Arrays use 4 bytes to store length data.
-                        // If arrayLengthFieldSize is specified, use that. Otherwise, if it's a FIELD_ARRAY, use the data type length.
-                        // For other array types, default to 4 bytes.
-                        const std::size_t lenBytes = (arrayFieldDef->arrayLengthFieldSize == 0
-                                                          ? (arrayFieldDef->type == FIELD_TYPE::FIELD_ARRAY ? arrayFieldDef->dataType.length : 4)
-                                                          : arrayFieldDef->arrayLengthFieldSize);
+                        const std::size_t lenBytes = arrayFieldDef->arrayLengthFieldSize;
 
                         if constexpr (Align)
                         {

--- a/include/novatel_edie/decoders/common/encoder.hpp
+++ b/include/novatel_edie/decoders/common/encoder.hpp
@@ -291,14 +291,21 @@ template <typename Derived> class EncoderBase
     {
         unsigned char* pucTempStart;
 
+        // TODO: MessageDecoderBase uses virtual functions to align the buffer pointer, which
+        // is probably a better approach because it allows each format to define its own
+        // alignment rules. In any case, should use the same approach for both encoder and
+        // decoder for consistency.
+        const auto alignBufferPtr = [&ppucOutBuf_, &uiBytesLeft_](uint8_t alignment) {
+            const auto uiAlign = std::min(static_cast<uint8_t>(4U), alignment);
+            const auto ullRem = reinterpret_cast<uint64_t>(*ppucOutBuf_) % uiAlign;
+            return (ullRem == 0) || SetInBuffer(ppucOutBuf_, uiBytesLeft_, 0, uiAlign - ullRem);
+        };
+
         for (const auto& field : stInterMessage_)
         {
             if constexpr (Align)
             {
-                // Realign to type byte boundary if needed
-                const uint32_t uiAlign = std::min(4U, static_cast<uint32_t>(field.fieldDef->dataType.length));
-                const auto ullRem = reinterpret_cast<uint64_t>(*ppucOutBuf_) % uiAlign;
-                if (ullRem && !SetInBuffer(ppucOutBuf_, uiBytesLeft_, 0, uiAlign - ullRem)) { return false; }
+                if (!alignBufferPtr(static_cast<uint8_t>(field.fieldDef->dataType.length))) { return false; }
             }
 
             if (std::holds_alternative<std::vector<FieldContainer>>(field.fieldValue))
@@ -316,6 +323,12 @@ template <typename Derived> class EncoderBase
                         const std::size_t lenBytes = (arrayFieldDef->arrayLengthFieldSize == 0
                                                           ? (arrayFieldDef->type == FIELD_TYPE::FIELD_ARRAY ? arrayFieldDef->dataType.length : 4)
                                                           : arrayFieldDef->arrayLengthFieldSize);
+
+                        if constexpr (Align)
+                        {
+                            if (!alignBufferPtr(static_cast<uint8_t>(lenBytes))) { return false; }
+                        }
+
                         switch (lenBytes)
                         {
                         case 4:

--- a/include/novatel_edie/decoders/common/encoder.hpp
+++ b/include/novatel_edie/decoders/common/encoder.hpp
@@ -310,12 +310,14 @@ template <typename Derived> class EncoderBase
                     const auto* arrayFieldDef = dynamic_cast<const ArrayField*>(field.fieldDef.get());
                     if (arrayFieldDef->arrayLengthRef.empty())
                     {
-                        const auto lenBytes = arrayFieldDef->arrayLengthFieldSize == 0 && arrayFieldDef->type == FIELD_TYPE::FIELD_ARRAY
-                                                  ? arrayFieldDef->dataType.length
-                                                  : arrayFieldDef->arrayLengthFieldSize;
+                        // Not all Arrays use 4 bytes to store length data.
+                        // If arrayLengthFieldSize is specified, use that. Otherwise, if it's a FIELD_ARRAY, use the data type length.
+                        // For other array types, default to 4 bytes.
+                        const std::size_t lenBytes = (arrayFieldDef->arrayLengthFieldSize == 0
+                                                          ? (arrayFieldDef->type == FIELD_TYPE::FIELD_ARRAY ? arrayFieldDef->dataType.length : 4)
+                                                          : arrayFieldDef->arrayLengthFieldSize);
                         switch (lenBytes)
                         {
-                        case 0: [[fallthrough]]; // By default, if arrayLengthFieldSize is not specified, encode array length using 4 bytes
                         case 4:
                             if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, static_cast<uint32_t>(vFcCurrentVectorField.size()))) { return false; }
                             break;

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -156,17 +156,16 @@ class MessageDecoderBase
     //----------------------------------------------------------------------------
     //! \brief Align the binary buffer pointer to the expected type boundary.
     //
-    //! \param[in] field_ A shared pointer to the field definition describing
-    //! the expected data type and length.
-    //! \param[in] pucStart_ The starting pointer of the binary buffer. Used to
+    //! \param[in] align The alignment requirement in bytes.
+    //! \param[in] start The starting pointer of the binary buffer. Used to
     //! calculate the current offset relative to the beginning of the payload.
-    //! \param[in, out] ppucBuf_ A pointer to the buffer pointer to be advanced
+    //! \param[in, out] ptr A pointer to the buffer pointer to be advanced
     //! to meet the alignment requirement.
     //
     //! \remark This default implementation assumes NovAtel binary log alignment,
     //! where fields are generally aligned to 4-byte boundaries, unless the
     //! field's type length is smaller. The alignment applied is the minimum of
-    //! 4 and the field's length.
+    //! 4 and the requested alignment.
     //
     //! For binary formats that use packed structures and do not align fields
     //! this function should be overridden in a derived decoder class to skip
@@ -174,9 +173,9 @@ class MessageDecoderBase
     //
     //! \return None. The buffer pointer is updated in place.
     //----------------------------------------------------------------------------
-    virtual void AlignBufferPointer(const BaseField::Ptr& field, const unsigned char* start, const unsigned char** ptr) const
+    virtual void AlignBufferPointer(const uint8_t align, const unsigned char* start, const unsigned char** ptr) const
     {
-        uint8_t alignment = std::min(static_cast<uint16_t>(4), field->dataType.length);
+        uint8_t alignment = std::min(static_cast<uint8_t>(4), align);
         uint64_t offset = static_cast<uintptr_t>(*ptr - start) % alignment;
         if (offset != 0) { *ptr += alignment - offset; }
     }
@@ -262,8 +261,8 @@ class MessageDecoderBase
     }
 
     // -------------------------------------------------------------------------------------------------------
-    static uint32_t GetArrayLength(const unsigned char** ppucLogBuf_, const ArrayField& arrayDef,
-                                   const std::vector<FieldContainer>& vIntermediateFormat_)
+    uint32_t GetArrayLength(const unsigned char* pucTempStart, const unsigned char** ppucLogBuf_, const ArrayField& arrayDef,
+                            const std::vector<FieldContainer>& vIntermediateFormat_) const
     {
         if (arrayDef.arrayLengthRef.empty())
         {
@@ -275,6 +274,8 @@ class MessageDecoderBase
                                                     : arrayDef.arrayLengthFieldSize);
             if (!(lenBytes == 1 || lenBytes == 2 || lenBytes == 4))
                 throw std::runtime_error("GetArrayLength: Unsupported length size; must be 1,2 or 4");
+
+            AlignBufferPointer(static_cast<uint8_t>(lenBytes), pucTempStart, ppucLogBuf_);
 
             uint32_t uiArrayLength = 0;
             for (std::size_t i = 0; i < lenBytes; ++i) { uiArrayLength |= static_cast<uint32_t>((*ppucLogBuf_)[i]) << (8 * i); }

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -266,12 +266,7 @@ class MessageDecoderBase
     {
         if (arrayDef.arrayLengthRef.empty())
         {
-            // Not all Arrays use 4 bytes to store length data.
-            // If arrayLengthFieldSize is specified, use that. Otherwise, if it's a FIELD_ARRAY, use the data type length.
-            // For other array types, default to 4 bytes.
-            const std::size_t lenBytes =
-                (arrayDef.arrayLengthFieldSize == 0 ? (arrayDef.type == FIELD_TYPE::FIELD_ARRAY ? arrayDef.dataType.length : 4)
-                                                    : arrayDef.arrayLengthFieldSize);
+            const std::size_t lenBytes = arrayDef.arrayLengthFieldSize;
             if (!(lenBytes == 1 || lenBytes == 2 || lenBytes == 4))
                 throw std::runtime_error("GetArrayLength: Unsupported length size; must be 1,2 or 4");
 

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -267,17 +267,19 @@ class MessageDecoderBase
     {
         if (arrayDef.arrayLengthRef.empty())
         {
-            // Use the dataType.length to determine number of bytes used to store the size data.
             // Not all Arrays use 4 bytes to store length data.
-
-            const std::size_t lenBytes = arrayDef.dataType.length;
+            // If arrayLengthFieldSize is specified, use that. Otherwise, if it's a FIELD_ARRAY, use the data type length.
+            // For other array types, default to 4 bytes.
+            const std::size_t lenBytes =
+                (arrayDef.arrayLengthFieldSize == 0 ? (arrayDef.type == FIELD_TYPE::FIELD_ARRAY ? arrayDef.dataType.length : 4)
+                                                    : arrayDef.arrayLengthFieldSize);
             if (!(lenBytes == 1 || lenBytes == 2 || lenBytes == 4))
                 throw std::runtime_error("GetArrayLength: Unsupported length size; must be 1,2 or 4");
 
             uint32_t uiArrayLength = 0;
-            for (std::size_t i = 0; i < arrayDef.dataType.length; ++i) { uiArrayLength |= static_cast<uint32_t>((*ppucLogBuf_)[i]) << (8 * i); }
+            for (std::size_t i = 0; i < lenBytes; ++i) { uiArrayLength |= static_cast<uint32_t>((*ppucLogBuf_)[i]) << (8 * i); }
 
-            *ppucLogBuf_ += arrayDef.dataType.length;
+            *ppucLogBuf_ += lenBytes;
             return uiArrayLength;
         }
 

--- a/src/decoders/common/src/json_db_reader.cpp
+++ b/src/decoders/common/src/json_db_reader.cpp
@@ -114,7 +114,7 @@ void from_json(const json& j_, ArrayField& fd_)
     from_json(j_, static_cast<BaseField&>(fd_));
 
     fd_.arrayLength = j_.at("arrayLength");
-    fd_.arrayLengthFieldSize = j_.value("arrayLengthFieldSize", 0);
+    fd_.arrayLengthFieldSize = j_.value("arrayLengthFieldSize", 4);
     fd_.dataType = j_.at("dataType");
     if (j_.find("arrayLengthRef") != j_.end()) { fd_.arrayLengthRef = j_.at("arrayLengthRef").is_null() ? "" : j_.at("arrayLengthRef"); }
 }
@@ -125,7 +125,7 @@ void from_json(const json& j_, FieldArrayField& fd_)
     from_json(j_, static_cast<BaseField&>(fd_));
 
     fd_.arrayLength = j_.at("arrayLength").is_null() ? 0 : static_cast<uint32_t>(j_.at("arrayLength"));
-    fd_.arrayLengthFieldSize = j_.value("arrayLengthFieldSize", 0);
+    fd_.arrayLengthFieldSize = j_.value("arrayLengthFieldSize", 4);
     fd_.fieldSize = fd_.arrayLength * ParseFields(j_.at("fields"), fd_.fields);
     if (j_.find("arrayLengthRef") != j_.end()) { fd_.arrayLengthRef = j_.at("arrayLengthRef").is_null() ? "" : j_.at("arrayLengthRef"); }
 }

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -454,7 +454,8 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
 
     for (const auto& field : vMsgDefFields_)
     {
-        AlignBufferPointer(field, pucTempStart, ppucLogBuf_);
+        auto fieldTypeLength = static_cast<uint8_t>(field->dataType.length);
+        AlignBufferPointer(fieldTypeLength, pucTempStart, ppucLogBuf_);
 
         switch (field->type)
         {
@@ -491,7 +492,7 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
             break;
         }
         case FIELD_TYPE::VARIABLE_LENGTH_ARRAY: {
-            const uint32_t uiArraySize = GetArrayLength(ppucLogBuf_, dynamic_cast<ArrayField&>(*field), vIntermediateFormat_);
+            const uint32_t uiArraySize = GetArrayLength(pucTempStart, ppucLogBuf_, dynamic_cast<ArrayField&>(*field), vIntermediateFormat_);
 
             vIntermediateFormat_.emplace_back(std::vector<FieldContainer>(), field);
             auto& pvFieldContainer = std::get<std::vector<FieldContainer>>(vIntermediateFormat_.back().fieldValue);
@@ -510,7 +511,7 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
         }
         case FIELD_TYPE::FIELD_ARRAY: {
             auto* subFieldDefinitions = dynamic_cast<FieldArrayField*>(field.get());
-            const uint32_t uiArraySize = GetArrayLength(ppucLogBuf_, *subFieldDefinitions, vIntermediateFormat_);
+            const uint32_t uiArraySize = GetArrayLength(pucTempStart, ppucLogBuf_, *subFieldDefinitions, vIntermediateFormat_);
 
             vIntermediateFormat_.emplace_back(std::vector<FieldContainer>(), field);
             auto& pvFieldArrayContainer = std::get<std::vector<FieldContainer>>(vIntermediateFormat_.back().fieldValue);
@@ -519,7 +520,7 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
             for (uint32_t i = 0; i < uiArraySize; ++i)
             {
                 // Realign to type byte boundary if needed
-                AlignBufferPointer(field, pucTempStart, ppucLogBuf_);
+                AlignBufferPointer(fieldTypeLength, pucTempStart, ppucLogBuf_);
                 pvFieldArrayContainer.emplace_back(std::vector<FieldContainer>(), field);
                 auto& pvFieldContainer = std::get<std::vector<FieldContainer>>(pvFieldArrayContainer.back().fieldValue);
                 pvFieldContainer.reserve(dynamic_cast<const FieldArrayField*>(field.get())->fields.size());


### PR DESCRIPTION
- Align the array length field for variable length and field arrays in both the decoder and encoder (only relevant for BINARY decoding/encoding)
- Set `arrayLengthFieldSize` in JSON DB reader. Use `arrayLengthFieldSize` in both decoder and encoder