### PR TITLE
Refactor Python Database Ownership Model

### DIFF
--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -571,6 +571,15 @@ class MessageDatabase
     //----------------------------------------------------------------------------
     [[nodiscard]] DbMetadata::ConstPtr GetDbMetadata() const { return pDbMetadata; }
 
+    //----------------------------------------------------------------------------
+    //! \brief Sets the message family on the DB metadata, creating it if absent.
+    //----------------------------------------------------------------------------
+    void SetMessageFamily(const std::string& messageFamily_)
+    {
+        if (!pDbMetadata) { pDbMetadata = std::make_shared<DbMetadata>(); }
+        pDbMetadata->messageFamily = messageFamily_;
+    }
+
   protected:
     virtual void GenerateEnumMappings()
     {

--- a/python/include/py_common/field_objects.hpp
+++ b/python/include/py_common/field_objects.hpp
@@ -26,7 +26,7 @@ using ssize_t = std::make_signed_t<size_t>;
 struct PyField
 {
     explicit PyField(std::vector<FieldContainer> message_, const ::novatel::edie::BaseField* fieldDef_,
-                     py_common::PyMessageDatabaseCore::ConstPtr parentDb_)
+                     py_common::PyMessageDatabase::ConstPtr parentDb_)
         : fields(std::move(message_)), fieldDef(fieldDef_), parentDb(std::move(parentDb_))
     {
         fieldsPtr = fields.data();
@@ -36,7 +36,7 @@ struct PyField
     };
 
     explicit PyField(std::vector<FieldContainer> message_, const ::novatel::edie::MessageDefinition* msgDef_, uint32_t crc_,
-                     py_common::PyMessageDatabaseCore::ConstPtr parentDb_)
+                     py_common::PyMessageDatabase::ConstPtr parentDb_)
         : fields(std::move(message_)), parentDb(std::move(parentDb_))
     {
         fieldsPtr = fields.data();
@@ -46,7 +46,7 @@ struct PyField
     };
 
     explicit PyField(std::vector<FieldContainer>& message_, const ::novatel::edie::BaseField* fieldDef_,
-                     py_common::PyMessageDatabaseCore::ConstPtr parentDb_, nb::object parentField_)
+                     py_common::PyMessageDatabase::ConstPtr parentDb_, nb::object parentField_)
         : fieldDef(fieldDef_), parentDb(std::move(parentDb_)), parent(std::move(parentField_))
     {
         fieldsPtr = message_.data();
@@ -117,7 +117,7 @@ struct PyField
     mutable nb::dict cached_values_;
     mutable std::vector<std::optional<nb::weakref>> cachedArrays_;
 
-    py_common::PyMessageDatabaseCore::ConstPtr parentDb;
+    py_common::PyMessageDatabase::ConstPtr parentDb;
 };
 
 template <typename Fn> void PyField::for_each_entry(Fn&& visitor) const
@@ -141,7 +141,7 @@ template <typename Fn> void PyField::for_each_entry(Fn&& visitor) const
 struct PyFieldArray
 {
     explicit PyFieldArray(std::vector<FieldContainer>& data_, const ::novatel::edie::BaseField* fieldDef_,
-                          py_common::PyMessageDatabaseCore::ConstPtr parentDb_, nb::object parent_)
+                          py_common::PyMessageDatabase::ConstPtr parentDb_, nb::object parent_)
         : data(&data_), fieldDef(fieldDef_), parentDb(std::move(parentDb_)), parent(std::move(parent_)), cache(data_.size()) {};
 
     nb::object getitem(ssize_t index) const;
@@ -149,7 +149,7 @@ struct PyFieldArray
 
     std::vector<FieldContainer>* data;
     const BaseField* fieldDef{nullptr};
-    py_common::PyMessageDatabaseCore::ConstPtr parentDb;
+    py_common::PyMessageDatabase::ConstPtr parentDb;
     nb::object parent;
     mutable std::vector<std::optional<nb::weakref>> cache;
 };

--- a/python/include/py_common/message_database.hpp
+++ b/python/include/py_common/message_database.hpp
@@ -38,10 +38,11 @@ const MessageFamilyRegistration* GetMessageFamilyRegistration(const std::string&
 class PyMessageDatabaseCore : public MessageDatabase
 {
   public:
+    // All python message databases are to be managed via a shared pointer
     static std::shared_ptr<PyMessageDatabaseCore> Create(MessageDatabase message_db = MessageDatabase());
-
     ~PyMessageDatabaseCore();
 
+    // Only allow construction via static Create method
     PyMessageDatabaseCore(const PyMessageDatabaseCore&) = delete;
     PyMessageDatabaseCore& operator=(const PyMessageDatabaseCore&) = delete;
     PyMessageDatabaseCore(PyMessageDatabaseCore&&) = delete;
@@ -107,12 +108,7 @@ class PyMessageDatabaseCore : public MessageDatabase
     void SetMessageFamily(const std::string& messageFamily);
 
     [[nodiscard]] void* GetMessageFamilyExtras() const { return message_family_extras_; }
-    [[nodiscard]] std::shared_ptr<PyMessageDatabaseCore> GetSharedPtr() const
-    {
-        auto self = self_weak_.lock();
-        if (!self) { throw FailureException("PyMessageDatabaseCore is not owned by a shared pointer."); }
-        return self;
-    }
+    [[nodiscard]] std::shared_ptr<PyMessageDatabaseCore> GetSharedPtr() const { return self_weak_.lock(); }
 
     // MessageDatabase overloads
     void Merge(const std::shared_ptr<PyMessageDatabaseCore> other_);
@@ -171,7 +167,7 @@ class PyMessageDatabaseCore : public MessageDatabase
   private:
     explicit PyMessageDatabaseCore(MessageDatabase&& message_db);
 
-    void InitializeAfterConstruction();
+    void Initialize();
     void ResetMessageFamilyExtras();
 
     //-----------------------------------------------------------------------

--- a/python/include/py_common/message_database.hpp
+++ b/python/include/py_common/message_database.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include <unordered_map>
 
 #include "novatel_edie/decoders/common/message_database.hpp"
@@ -19,15 +20,32 @@ struct FieldLookupEntry
 
 using FieldNameMap = std::unordered_map<std::string, FieldLookupEntry>;
 
-std::unordered_map<std::string, nb::handle>& GetMessageFamilyTypes();
-nb::handle GetMessageFamilyType(const std::string& message_family);
+class PyMessageDatabaseCore;
+
+using MessageFamilyExtrasAllocFn = void* (*)(PyMessageDatabaseCore* database);
+using MessageFamilyExtrasFreeFn = void (*)(void* extras);
+
+struct MessageFamilyRegistration
+{
+    nb::handle messageType;
+    MessageFamilyExtrasAllocFn allocateExtras;
+    MessageFamilyExtrasFreeFn freeExtras;
+};
+
+std::unordered_map<std::string, MessageFamilyRegistration>& GetMessageFamilyRegistrations();
+const MessageFamilyRegistration* GetMessageFamilyRegistration(const std::string& message_family);
 
 class PyMessageDatabaseCore : public MessageDatabase
 {
   public:
-    PyMessageDatabaseCore();
-    explicit PyMessageDatabaseCore(const MessageDatabase& message_db) noexcept;
-    explicit PyMessageDatabaseCore(const MessageDatabase&& message_db) noexcept;
+    static std::shared_ptr<PyMessageDatabaseCore> Create(MessageDatabase message_db = MessageDatabase());
+
+    ~PyMessageDatabaseCore();
+
+    PyMessageDatabaseCore(const PyMessageDatabaseCore&) = delete;
+    PyMessageDatabaseCore& operator=(const PyMessageDatabaseCore&) = delete;
+    PyMessageDatabaseCore(PyMessageDatabaseCore&&) = delete;
+    PyMessageDatabaseCore& operator=(PyMessageDatabaseCore&&) = delete;
 
     [[nodiscard]] nb::object GetFieldType(const BaseField* field) const
     {
@@ -88,6 +106,14 @@ class PyMessageDatabaseCore : public MessageDatabase
     [[nodiscard]] std::string GetMessageFamily() const;
     void SetMessageFamily(const std::string& messageFamily);
 
+    [[nodiscard]] void* GetMessageFamilyExtras() const { return message_family_extras_; }
+    [[nodiscard]] std::shared_ptr<PyMessageDatabaseCore> GetSharedPtr() const
+    {
+        auto self = self_weak_.lock();
+        if (!self) { throw FailureException("PyMessageDatabaseCore is not owned by a shared pointer."); }
+        return self;
+    }
+
     // MessageDatabase overloads
     void Merge(const std::shared_ptr<PyMessageDatabaseCore> other_);
     void AppendMessages(const std::vector<MessageDefinition::ConstPtr>& vMessageDefinitions_);
@@ -143,6 +169,11 @@ class PyMessageDatabaseCore : public MessageDatabase
     }
 
   private:
+    explicit PyMessageDatabaseCore(MessageDatabase&& message_db);
+
+    void InitializeAfterConstruction();
+    void ResetMessageFamilyExtras();
+
     //-----------------------------------------------------------------------
     //! \brief Creates Python Enums for multiple enum definitions.
     //!
@@ -194,7 +225,9 @@ class PyMessageDatabaseCore : public MessageDatabase
 
     void ResolveBaseType();
 
-    nb::handle base_message_type;
+    const MessageFamilyRegistration* message_family_registration_ = nullptr;
+    void* message_family_extras_ = nullptr;
+    std::weak_ptr<PyMessageDatabaseCore> self_weak_;
     std::unordered_map<const MessageDefinition*, std::map<uint32_t, nb::object>> messages_types{};
     std::unordered_map<const BaseField*, nb::object> field_types{};
     std::unordered_map<const EnumDefinition*, nb::object> enum_types{};

--- a/python/include/py_common/message_database.hpp
+++ b/python/include/py_common/message_database.hpp
@@ -22,14 +22,18 @@ using FieldNameMap = std::unordered_map<std::string, FieldLookupEntry>;
 
 class PyMessageDatabaseCore;
 
-using MessageFamilyExtrasAllocFn = void* (*)(PyMessageDatabaseCore* database);
-using MessageFamilyExtrasFreeFn = void (*)(void* extras);
+class MessageDBExtrasBase
+{
+  public:
+    virtual ~MessageDBExtrasBase() = default;
+};
+
+using MessageFamilyExtrasAllocFn = std::unique_ptr<MessageDBExtrasBase> (*)(PyMessageDatabaseCore* database);
 
 struct MessageFamilyRegistration
 {
     nb::handle messageType;
     MessageFamilyExtrasAllocFn allocateExtras;
-    MessageFamilyExtrasFreeFn freeExtras;
 };
 
 std::unordered_map<std::string, MessageFamilyRegistration>& GetMessageFamilyRegistrations();
@@ -40,7 +44,6 @@ class PyMessageDatabaseCore : public MessageDatabase
   public:
     // All python message databases are to be managed via a shared pointer
     static std::shared_ptr<PyMessageDatabaseCore> Create(MessageDatabase message_db = MessageDatabase());
-    ~PyMessageDatabaseCore();
 
     // Only allow construction via static Create method
     PyMessageDatabaseCore(const PyMessageDatabaseCore&) = delete;
@@ -107,7 +110,7 @@ class PyMessageDatabaseCore : public MessageDatabase
     [[nodiscard]] std::string GetMessageFamily() const;
     void SetMessageFamily(const std::string& messageFamily);
 
-    [[nodiscard]] void* GetMessageFamilyExtras() const { return message_family_extras_; }
+    [[nodiscard]] MessageDBExtrasBase* GetMessageFamilyExtras() const { return message_family_extras_.get(); }
     [[nodiscard]] std::shared_ptr<PyMessageDatabaseCore> GetSharedPtr() const { return self_weak_.lock(); }
 
     // MessageDatabase overloads
@@ -168,7 +171,6 @@ class PyMessageDatabaseCore : public MessageDatabase
     explicit PyMessageDatabaseCore(MessageDatabase&& message_db);
 
     void Initialize();
-    void ResetMessageFamilyExtras();
 
     //-----------------------------------------------------------------------
     //! \brief Creates Python Enums for multiple enum definitions.
@@ -222,7 +224,7 @@ class PyMessageDatabaseCore : public MessageDatabase
     void ResolveBaseType();
 
     const MessageFamilyRegistration* message_family_registration_ = nullptr;
-    void* message_family_extras_ = nullptr;
+    std::unique_ptr<MessageDBExtrasBase> message_family_extras_;
     std::weak_ptr<PyMessageDatabaseCore> self_weak_;
     std::unordered_map<const MessageDefinition*, std::map<uint32_t, nb::object>> messages_types{};
     std::unordered_map<const BaseField*, nb::object> field_types{};

--- a/python/include/py_common/message_database.hpp
+++ b/python/include/py_common/message_database.hpp
@@ -20,15 +20,13 @@ struct FieldLookupEntry
 
 using FieldNameMap = std::unordered_map<std::string, FieldLookupEntry>;
 
-class PyMessageDatabaseCore;
-
 class MessageDBExtrasBase
 {
   public:
     virtual ~MessageDBExtrasBase() = default;
 };
 
-using MessageFamilyExtrasAllocFn = std::unique_ptr<MessageDBExtrasBase> (*)(std::shared_ptr<PyMessageDatabaseCore> database);
+using MessageFamilyExtrasAllocFn = std::unique_ptr<MessageDBExtrasBase> (*)(std::shared_ptr<MessageDatabase> database);
 
 struct MessageFamilyRegistration
 {
@@ -39,16 +37,43 @@ struct MessageFamilyRegistration
 std::unordered_map<std::string, MessageFamilyRegistration>& GetMessageFamilyRegistrations();
 const MessageFamilyRegistration* GetMessageFamilyRegistration(const std::string& message_family);
 
-class PyMessageDatabaseCore : public MessageDatabase
+//============================================================================
+//! \class PyMessageDatabase
+//! \brief A Python-facing message database that owns a MessageDatabase, the
+//!        Python type caches built from it, and any registered message-family
+//!        extras (e.g. OEM Encoder, RxConfigHandler).
+//============================================================================
+class PyMessageDatabase
 {
   public:
-    explicit PyMessageDatabaseCore(MessageDatabase&& message_db = MessageDatabase());
+    using Ptr = std::shared_ptr<PyMessageDatabase>;
+    using ConstPtr = std::shared_ptr<const PyMessageDatabase>;
 
-    PyMessageDatabaseCore(const PyMessageDatabaseCore&) = delete;
-    PyMessageDatabaseCore& operator=(const PyMessageDatabaseCore&) = delete;
-    PyMessageDatabaseCore(PyMessageDatabaseCore&&) = delete;
-    PyMessageDatabaseCore& operator=(PyMessageDatabaseCore&&) = delete;
+    explicit PyMessageDatabase(MessageDatabase&& message_db = MessageDatabase());
 
+    PyMessageDatabase(const PyMessageDatabase&) = delete;
+    PyMessageDatabase& operator=(const PyMessageDatabase&) = delete;
+    PyMessageDatabase(PyMessageDatabase&&) = delete;
+    PyMessageDatabase& operator=(PyMessageDatabase&&) = delete;
+
+    [[nodiscard]] const MessageDatabase::Ptr& core() const { return core_; }
+    [[nodiscard]] const MessageDBExtrasBase* GetMessageFamilyExtras() const { return extras_.get(); }
+
+    // Mutators — wrap MessageDatabase mutations so the Python caches stay in sync.
+    void Merge(const Ptr& other);
+    void AppendMessages(const std::vector<MessageDefinition::ConstPtr>& vMessageDefinitions_);
+    void AppendEnumerations(const std::vector<EnumDefinition::ConstPtr>& vEnumDefinitions_);
+    void RemoveMessage(uint32_t iMsgId_);
+    void RemoveEnumeration(std::string strEnumeration_);
+
+    // Definition lookups — forward to the underlying MessageDatabase.
+    [[nodiscard]] MessageDefinition::ConstPtr GetMsgDef(std::string_view name) const { return core_->GetMsgDef(name); }
+    [[nodiscard]] MessageDefinition::ConstPtr GetMsgDef(int32_t id) const { return core_->GetMsgDef(id); }
+    [[nodiscard]] EnumDefinition::ConstPtr GetEnumDefId(const std::string& id) const { return core_->GetEnumDefId(id); }
+    [[nodiscard]] EnumDefinition::ConstPtr GetEnumDefName(const std::string& name) const { return core_->GetEnumDefName(name); }
+    [[nodiscard]] std::string MsgIdToMsgName(uint32_t id) const { return core_->MsgIdToMsgName(id); }
+
+    // Python type-cache lookups.
     [[nodiscard]] nb::object GetFieldType(const BaseField* field) const
     {
         auto it = field_types.find(field);
@@ -69,13 +94,11 @@ class PyMessageDatabaseCore : public MessageDatabase
         if (message == nullptr) { return nb::none(); }
         return GetMessageType(message, message->latestMessageCrc);
     }
-
     [[nodiscard]] nb::object GetMessageType(std::string_view messageName, uint32_t crc) const
     {
         return GetMessageType(GetMsgDef(messageName).get(), crc);
     }
     [[nodiscard]] nb::object GetMessageType(std::string_view messageName) const { return GetMessageType(GetMsgDef(messageName).get()); }
-
     [[nodiscard]] nb::object GetMessageType(int32_t id, uint32_t crc) const { return GetMessageType(GetMsgDef(id).get(), crc); }
     [[nodiscard]] nb::object GetMessageType(int32_t id) const { return GetMessageType(GetMsgDef(id).get()); }
 
@@ -109,14 +132,6 @@ class PyMessageDatabaseCore : public MessageDatabase
     void SetMessageFamily(const std::string& messageFamily);
 
     [[nodiscard]] const MessageFamilyRegistration* GetMessageFamilyRegistration() const { return message_family_registration_; }
-
-    // MessageDatabase overloads
-    void Merge(const std::shared_ptr<PyMessageDatabaseCore> other_);
-    void AppendMessages(const std::vector<MessageDefinition::ConstPtr>& vMessageDefinitions_);
-    void AppendEnumerations(const std::vector<EnumDefinition::ConstPtr>& vEnumDefinitions_);
-    void RemoveMessage(uint32_t iMsgId_);
-    void RemoveFieldTypes(const std::vector<BaseField::Ptr>& fieldDefs);
-    void RemoveEnumeration(std::string strEnumeration_);
 
     void bindFieldsToModule(nanobind::module_& m_, const std::vector<BaseField::Ptr>& fields_)
     {
@@ -164,59 +179,29 @@ class PyMessageDatabaseCore : public MessageDatabase
         for (const auto& [enum_def, enum_type] : enum_types) { enumsMod_.attr(enum_def->name.c_str()) = enum_type; }
     }
 
+    [[nodiscard]] Ptr clone() const;
+
   private:
     void Initialize();
+    void ResolveBaseType();
+    void allocateExtras();
 
     //-----------------------------------------------------------------------
     //! \brief Creates Python Enums for multiple enum definitions.
-    //!
-    //! These classes are stored by EnumDefinition pointer in the enum_types map.
     //-----------------------------------------------------------------------
     void AppendEnumTypes(const std::vector<EnumDefinition::ConstPtr>& enum_defs);
-    //-----------------------------------------------------------------------
-    //! \brief Removes an enum type from the Python type map.
-    //-----------------------------------------------------------------------
     void RemoveEnumType(const std::string& enum_name);
     //-----------------------------------------------------------------------
     //! \brief Creates Python types for multiple message definitions and their fields.
-    //!
-    //! A message named "MESSAGE" will be mapped to a Python class named "MESSAGE".
-    //! A field of that payload named "FIELD" will be mapped to a class named "MESSAGE_FIELD_Field".
-    //! A subfield of that field named "SUBFIELD" will be mapped to a class named "MESSAGE_FIELD_Field_SUBFIELD_Field".
-    //!
-    //! These classes are stored by name in the messages_by_name and fields_by_message maps.
     //-----------------------------------------------------------------------
     void AppendMessageTypes(const std::vector<MessageDefinition::ConstPtr>& message_defs);
-    //-----------------------------------------------------------------------
-    //! \brief Removes a message type and its associated field types from the Python type maps.
-    //!
-    //! Removes the message from messages_by_name and all its associated fields from
-    //! fields_by_name and fields_by_message.
-    //-----------------------------------------------------------------------
     void RemoveMessageType(uint32_t message_id);
+    void RemoveFieldTypes(const std::vector<BaseField::Ptr>& fieldDefs);
 
-    void GenerateMessageMappings() override;
-    void GenerateEnumMappings() override;
-    //-----------------------------------------------------------------------
-    //! \brief Creates Python Enums for each enum definition in the database.
-    //!
-    //! These classes are stored by EnumDefinition pointer in the enum_types map.
-    //-----------------------------------------------------------------------
     void UpdatePythonEnums();
-    //-----------------------------------------------------------------------
-    //! \brief Creates Python types for each component of all message definitions in the database.
-    //!
-    //! A message named "MESSAGE" will be mapped to a Python class named "MESSAGE".
-    //! A field of that payload named "FIELD" will be mapped to a class named "MESSAGE_FIELD_Field".
-    //! A subfield of that field named "SUBFIELD" will be mapped to a class named "MESSAGE_FIELD_Field_SUBFIELD_Field".
-    //!
-    //! These classes are stored by name in the messages_by_name map.
-    //-----------------------------------------------------------------------
     void UpdatePythonMessageTypes();
     void AddFieldType(std::vector<std::shared_ptr<BaseField>> fields, std::string base_name, std::string parent_message, nb::handle type_cons,
                       nb::handle type_tuple, nb::handle type_dict);
-
-    void ResolveBaseType();
 
     const MessageFamilyRegistration* message_family_registration_ = nullptr;
     std::unordered_map<const MessageDefinition*, std::map<uint32_t, nb::object>> messages_types{};
@@ -225,77 +210,8 @@ class PyMessageDatabaseCore : public MessageDatabase
     std::unordered_map<const BaseField*, FieldNameMap> field_name_maps_{};
     std::unordered_map<const MessageDefinition*, std::map<uint32_t, FieldNameMap>> message_field_name_maps_{};
 
-  public:
-    using Ptr = std::shared_ptr<PyMessageDatabaseCore>;
-    using ConstPtr = std::shared_ptr<const PyMessageDatabaseCore>;
-};
-
-//============================================================================
-//! \class PyMessageDatabase
-//! \brief A Python-facing wrapper that owns a PyMessageDatabaseCore alongside
-//!        any registered message-family extras (e.g. OEM Encoder, RxConfigHandler).
-//!
-//! Owning the extras here — rather than inside the core — breaks any
-//! shared_ptr cycles.
-//============================================================================
-class PyMessageDatabase
-{
-  public:
-    using Ptr = std::shared_ptr<PyMessageDatabase>;
-    using ConstPtr = std::shared_ptr<const PyMessageDatabase>;
-
-    explicit PyMessageDatabase(MessageDatabase&& message_db = MessageDatabase());
-
-    PyMessageDatabase(const PyMessageDatabase&) = delete;
-    PyMessageDatabase& operator=(const PyMessageDatabase&) = delete;
-    PyMessageDatabase(PyMessageDatabase&&) = delete;
-    PyMessageDatabase& operator=(PyMessageDatabase&&) = delete;
-
-    [[nodiscard]] const PyMessageDatabaseCore::Ptr& core() const { return core_; }
-    [[nodiscard]] const MessageDBExtrasBase* GetMessageFamilyExtras() const { return extras_.get(); }
-
-    // Delegated MessageDatabase / PyMessageDatabaseCore interface.
-    void Merge(const Ptr& other) { core_->Merge(other->core_); }
-    void AppendMessages(const std::vector<MessageDefinition::ConstPtr>& msgs) { core_->AppendMessages(msgs); }
-    void AppendEnumerations(const std::vector<EnumDefinition::ConstPtr>& enums) { core_->AppendEnumerations(enums); }
-    void RemoveMessage(uint32_t msgId) { core_->RemoveMessage(msgId); }
-    void RemoveEnumeration(std::string enumeration) { core_->RemoveEnumeration(std::move(enumeration)); }
-
-    [[nodiscard]] MessageDefinition::ConstPtr GetMsgDef(std::string_view name) const { return core_->GetMsgDef(name); }
-    [[nodiscard]] MessageDefinition::ConstPtr GetMsgDef(int32_t id) const { return core_->GetMsgDef(id); }
-    [[nodiscard]] EnumDefinition::ConstPtr GetEnumDefId(const std::string& id) const { return core_->GetEnumDefId(id); }
-    [[nodiscard]] EnumDefinition::ConstPtr GetEnumDefName(const std::string& name) const { return core_->GetEnumDefName(name); }
-    [[nodiscard]] std::string MsgIdToMsgName(uint32_t id) const { return core_->MsgIdToMsgName(id); }
-
-    [[nodiscard]] nb::object GetFieldType(const BaseField* field) const { return core_->GetFieldType(field); }
-    [[nodiscard]] nb::object GetMessageType(const MessageDefinition* msg, uint32_t crc) const { return core_->GetMessageType(msg, crc); }
-    [[nodiscard]] nb::object GetMessageType(const MessageDefinition* msg) const { return core_->GetMessageType(msg); }
-    [[nodiscard]] nb::object GetMessageType(std::string_view name, uint32_t crc) const { return core_->GetMessageType(name, crc); }
-    [[nodiscard]] nb::object GetMessageType(std::string_view name) const { return core_->GetMessageType(name); }
-    [[nodiscard]] nb::object GetMessageType(int32_t id, uint32_t crc) const { return core_->GetMessageType(id, crc); }
-    [[nodiscard]] nb::object GetMessageType(int32_t id) const { return core_->GetMessageType(id); }
-    [[nodiscard]] nb::object GetEnumType(const EnumDefinition* def) const { return core_->GetEnumType(def); }
-    [[nodiscard]] nb::object GetEnumTypeByName(const std::string& name) const { return core_->GetEnumTypeByName(name); }
-    [[nodiscard]] nb::object GetEnumTypeById(const std::string& id) const { return core_->GetEnumTypeById(id); }
-
-    [[nodiscard]] const FieldNameMap* GetFieldNameMap(const BaseField* field) const { return core_->GetFieldNameMap(field); }
-    [[nodiscard]] const FieldNameMap* GetMessageFieldNameMap(const MessageDefinition* def, uint32_t crc) const
-    {
-        return core_->GetMessageFieldNameMap(def, crc);
-    }
-
-    [[nodiscard]] std::string GetMessageFamily() const { return core_->GetMessageFamily(); }
-    void SetMessageFamily(const std::string& messageFamily);
-
-    void bindToModule(nanobind::module_& messageMod, nanobind::module_& enumsMod) { core_->bindToModule(messageMod, enumsMod); }
-
-    [[nodiscard]] Ptr clone() const;
-
-  private:
-    void allocateExtras();
-
     std::unique_ptr<MessageDBExtrasBase> extras_;
-    PyMessageDatabaseCore::Ptr core_;
+    MessageDatabase::Ptr core_;
 };
 
 } // namespace novatel::edie::py_common

--- a/python/include/py_common/message_database.hpp
+++ b/python/include/py_common/message_database.hpp
@@ -28,7 +28,7 @@ class MessageDBExtrasBase
     virtual ~MessageDBExtrasBase() = default;
 };
 
-using MessageFamilyExtrasAllocFn = std::unique_ptr<MessageDBExtrasBase> (*)(PyMessageDatabaseCore* database);
+using MessageFamilyExtrasAllocFn = std::unique_ptr<MessageDBExtrasBase> (*)(std::shared_ptr<PyMessageDatabaseCore> database);
 
 struct MessageFamilyRegistration
 {
@@ -42,10 +42,8 @@ const MessageFamilyRegistration* GetMessageFamilyRegistration(const std::string&
 class PyMessageDatabaseCore : public MessageDatabase
 {
   public:
-    // All python message databases are to be managed via a shared pointer
-    static std::shared_ptr<PyMessageDatabaseCore> Create(MessageDatabase message_db = MessageDatabase());
+    explicit PyMessageDatabaseCore(MessageDatabase&& message_db = MessageDatabase());
 
-    // Only allow construction via static Create method
     PyMessageDatabaseCore(const PyMessageDatabaseCore&) = delete;
     PyMessageDatabaseCore& operator=(const PyMessageDatabaseCore&) = delete;
     PyMessageDatabaseCore(PyMessageDatabaseCore&&) = delete;
@@ -110,8 +108,7 @@ class PyMessageDatabaseCore : public MessageDatabase
     [[nodiscard]] std::string GetMessageFamily() const;
     void SetMessageFamily(const std::string& messageFamily);
 
-    [[nodiscard]] MessageDBExtrasBase* GetMessageFamilyExtras() const { return message_family_extras_.get(); }
-    [[nodiscard]] std::shared_ptr<PyMessageDatabaseCore> GetSharedPtr() const { return self_weak_.lock(); }
+    [[nodiscard]] const MessageFamilyRegistration* GetMessageFamilyRegistration() const { return message_family_registration_; }
 
     // MessageDatabase overloads
     void Merge(const std::shared_ptr<PyMessageDatabaseCore> other_);
@@ -168,8 +165,6 @@ class PyMessageDatabaseCore : public MessageDatabase
     }
 
   private:
-    explicit PyMessageDatabaseCore(MessageDatabase&& message_db);
-
     void Initialize();
 
     //-----------------------------------------------------------------------
@@ -224,8 +219,6 @@ class PyMessageDatabaseCore : public MessageDatabase
     void ResolveBaseType();
 
     const MessageFamilyRegistration* message_family_registration_ = nullptr;
-    std::unique_ptr<MessageDBExtrasBase> message_family_extras_;
-    std::weak_ptr<PyMessageDatabaseCore> self_weak_;
     std::unordered_map<const MessageDefinition*, std::map<uint32_t, nb::object>> messages_types{};
     std::unordered_map<const BaseField*, nb::object> field_types{};
     std::unordered_map<const EnumDefinition*, nb::object> enum_types{};
@@ -235,6 +228,74 @@ class PyMessageDatabaseCore : public MessageDatabase
   public:
     using Ptr = std::shared_ptr<PyMessageDatabaseCore>;
     using ConstPtr = std::shared_ptr<const PyMessageDatabaseCore>;
+};
+
+//============================================================================
+//! \class PyMessageDatabase
+//! \brief A Python-facing wrapper that owns a PyMessageDatabaseCore alongside
+//!        any registered message-family extras (e.g. OEM Encoder, RxConfigHandler).
+//!
+//! Owning the extras here — rather than inside the core — breaks any
+//! shared_ptr cycles.
+//============================================================================
+class PyMessageDatabase
+{
+  public:
+    using Ptr = std::shared_ptr<PyMessageDatabase>;
+    using ConstPtr = std::shared_ptr<const PyMessageDatabase>;
+
+    explicit PyMessageDatabase(MessageDatabase&& message_db = MessageDatabase());
+
+    PyMessageDatabase(const PyMessageDatabase&) = delete;
+    PyMessageDatabase& operator=(const PyMessageDatabase&) = delete;
+    PyMessageDatabase(PyMessageDatabase&&) = delete;
+    PyMessageDatabase& operator=(PyMessageDatabase&&) = delete;
+
+    [[nodiscard]] const PyMessageDatabaseCore::Ptr& core() const { return core_; }
+    [[nodiscard]] const MessageDBExtrasBase* GetMessageFamilyExtras() const { return extras_.get(); }
+
+    // Delegated MessageDatabase / PyMessageDatabaseCore interface.
+    void Merge(const Ptr& other) { core_->Merge(other->core_); }
+    void AppendMessages(const std::vector<MessageDefinition::ConstPtr>& msgs) { core_->AppendMessages(msgs); }
+    void AppendEnumerations(const std::vector<EnumDefinition::ConstPtr>& enums) { core_->AppendEnumerations(enums); }
+    void RemoveMessage(uint32_t msgId) { core_->RemoveMessage(msgId); }
+    void RemoveEnumeration(std::string enumeration) { core_->RemoveEnumeration(std::move(enumeration)); }
+
+    [[nodiscard]] MessageDefinition::ConstPtr GetMsgDef(std::string_view name) const { return core_->GetMsgDef(name); }
+    [[nodiscard]] MessageDefinition::ConstPtr GetMsgDef(int32_t id) const { return core_->GetMsgDef(id); }
+    [[nodiscard]] EnumDefinition::ConstPtr GetEnumDefId(const std::string& id) const { return core_->GetEnumDefId(id); }
+    [[nodiscard]] EnumDefinition::ConstPtr GetEnumDefName(const std::string& name) const { return core_->GetEnumDefName(name); }
+    [[nodiscard]] std::string MsgIdToMsgName(uint32_t id) const { return core_->MsgIdToMsgName(id); }
+
+    [[nodiscard]] nb::object GetFieldType(const BaseField* field) const { return core_->GetFieldType(field); }
+    [[nodiscard]] nb::object GetMessageType(const MessageDefinition* msg, uint32_t crc) const { return core_->GetMessageType(msg, crc); }
+    [[nodiscard]] nb::object GetMessageType(const MessageDefinition* msg) const { return core_->GetMessageType(msg); }
+    [[nodiscard]] nb::object GetMessageType(std::string_view name, uint32_t crc) const { return core_->GetMessageType(name, crc); }
+    [[nodiscard]] nb::object GetMessageType(std::string_view name) const { return core_->GetMessageType(name); }
+    [[nodiscard]] nb::object GetMessageType(int32_t id, uint32_t crc) const { return core_->GetMessageType(id, crc); }
+    [[nodiscard]] nb::object GetMessageType(int32_t id) const { return core_->GetMessageType(id); }
+    [[nodiscard]] nb::object GetEnumType(const EnumDefinition* def) const { return core_->GetEnumType(def); }
+    [[nodiscard]] nb::object GetEnumTypeByName(const std::string& name) const { return core_->GetEnumTypeByName(name); }
+    [[nodiscard]] nb::object GetEnumTypeById(const std::string& id) const { return core_->GetEnumTypeById(id); }
+
+    [[nodiscard]] const FieldNameMap* GetFieldNameMap(const BaseField* field) const { return core_->GetFieldNameMap(field); }
+    [[nodiscard]] const FieldNameMap* GetMessageFieldNameMap(const MessageDefinition* def, uint32_t crc) const
+    {
+        return core_->GetMessageFieldNameMap(def, crc);
+    }
+
+    [[nodiscard]] std::string GetMessageFamily() const { return core_->GetMessageFamily(); }
+    void SetMessageFamily(const std::string& messageFamily);
+
+    void bindToModule(nanobind::module_& messageMod, nanobind::module_& enumsMod) { core_->bindToModule(messageMod, enumsMod); }
+
+    [[nodiscard]] Ptr clone() const;
+
+  private:
+    void allocateExtras();
+
+    std::unique_ptr<MessageDBExtrasBase> extras_;
+    PyMessageDatabaseCore::Ptr core_;
 };
 
 } // namespace novatel::edie::py_common

--- a/python/include/py_oem/decoder.hpp
+++ b/python/include/py_oem/decoder.hpp
@@ -4,8 +4,8 @@
 #include "novatel_edie/decoders/oem/message_decoder.hpp"
 #include "novatel_edie/decoders/oem/rxconfig/rxconfig_handler.hpp"
 #include "py_common/bindings_core.hpp"
-#include "py_oem/message_db_singleton.hpp"
 #include "py_oem/message_database.hpp"
+#include "py_oem/message_db_singleton.hpp"
 #include "py_oem/py_message_objects.hpp"
 
 namespace nb = nanobind;
@@ -15,14 +15,13 @@ namespace novatel::edie::py_oem {
 class PyDecoder
 {
   public:
-    PyMessageDatabase::Ptr database;
+    py_common::PyMessageDatabaseCore::Ptr database;
     oem::HeaderDecoder header_decoder;
     oem::MessageDecoder message_decoder;
     oem::RxConfigHandler rx_config_handler;
 
     PyDecoder(py_common::PyMessageDatabaseCore::Ptr pclMessageDb_)
-        : database(std::make_shared<PyMessageDatabase>(pclMessageDb_)), header_decoder(pclMessageDb_), message_decoder(pclMessageDb_),
-          rx_config_handler(pclMessageDb_)
+        : database(std::move(pclMessageDb_)), header_decoder(database), message_decoder(database), rx_config_handler(database)
     {
     }
 

--- a/python/include/py_oem/decoder.hpp
+++ b/python/include/py_oem/decoder.hpp
@@ -15,13 +15,13 @@ namespace novatel::edie::py_oem {
 class PyDecoder
 {
   public:
-    py_common::PyMessageDatabaseCore::Ptr database;
+    py_common::PyMessageDatabase::Ptr database;
     oem::HeaderDecoder header_decoder;
     oem::MessageDecoder message_decoder;
     oem::RxConfigHandler rx_config_handler;
 
-    PyDecoder(py_common::PyMessageDatabaseCore::Ptr pclMessageDb_)
-        : database(std::move(pclMessageDb_)), header_decoder(database), message_decoder(database), rx_config_handler(database)
+    PyDecoder(py_common::PyMessageDatabase::Ptr pclMessageDb_)
+        : database(std::move(pclMessageDb_)), header_decoder(database->core()), message_decoder(database->core()), rx_config_handler(database->core())
     {
     }
 

--- a/python/include/py_oem/file_parser.hpp
+++ b/python/include/py_oem/file_parser.hpp
@@ -6,8 +6,8 @@
 #include "novatel_edie/decoders/oem/file_parser.hpp"
 #include "py_common/bindings_core.hpp"
 #include "py_common/exceptions.hpp"
-#include "py_oem/message_db_singleton.hpp"
 #include "py_common/py_message_data.hpp"
+#include "py_oem/message_db_singleton.hpp"
 #include "py_oem/py_message_objects.hpp"
 
 namespace nb = nanobind;
@@ -17,7 +17,7 @@ namespace novatel::edie::py_oem {
 class PyFileParser : public oem::FileParser
 {
   private:
-    py_oem::PyMessageDatabase::Ptr pclPyMessageDb;
+    py_common::PyMessageDatabaseCore::Ptr pclPyMessageDb;
     void SetStreamByPath(const std::filesystem::path& filepath_)
     {
         auto ifs = std::make_shared<std::ifstream>(filepath_, std::ios::binary);
@@ -29,7 +29,7 @@ class PyFileParser : public oem::FileParser
     PyFileParser(const std::filesystem::path& filepath_) : PyFileParser(filepath_, py_oem::MessageDbSingleton::get()) {};
 
     PyFileParser(const std::filesystem::path& filepath_, const py_common::PyMessageDatabaseCore::Ptr& message_db_pointer)
-        : FileParser(message_db_pointer), pclPyMessageDb(std::make_shared<py_oem::PyMessageDatabase>(message_db_pointer))
+        : FileParser(message_db_pointer), pclPyMessageDb(message_db_pointer)
     {
         SetStreamByPath(filepath_);
     }

--- a/python/include/py_oem/file_parser.hpp
+++ b/python/include/py_oem/file_parser.hpp
@@ -17,7 +17,7 @@ namespace novatel::edie::py_oem {
 class PyFileParser : public oem::FileParser
 {
   private:
-    py_common::PyMessageDatabaseCore::Ptr pclPyMessageDb;
+    py_common::PyMessageDatabase::Ptr pclPyMessageDb;
     void SetStreamByPath(const std::filesystem::path& filepath_)
     {
         auto ifs = std::make_shared<std::ifstream>(filepath_, std::ios::binary);
@@ -28,8 +28,8 @@ class PyFileParser : public oem::FileParser
   public:
     PyFileParser(const std::filesystem::path& filepath_) : PyFileParser(filepath_, py_oem::MessageDbSingleton::get()) {};
 
-    PyFileParser(const std::filesystem::path& filepath_, const py_common::PyMessageDatabaseCore::Ptr& message_db_pointer)
-        : FileParser(message_db_pointer), pclPyMessageDb(message_db_pointer)
+    PyFileParser(const std::filesystem::path& filepath_, const py_common::PyMessageDatabase::Ptr& message_db_pointer)
+        : FileParser(message_db_pointer->core()), pclPyMessageDb(message_db_pointer)
     {
         SetStreamByPath(filepath_);
     }

--- a/python/include/py_oem/message_database.hpp
+++ b/python/include/py_oem/message_database.hpp
@@ -20,7 +20,6 @@ struct DatabaseExtras
 void* AllocateDatabaseExtras(py_common::PyMessageDatabaseCore* database);
 void FreeDatabaseExtras(void* extras);
 
-DatabaseExtras& GetDatabaseExtras(py_common::PyMessageDatabaseCore& database);
 const DatabaseExtras& GetDatabaseExtras(const py_common::PyMessageDatabaseCore& database);
 
 void ThrowRXConfigConstructionError();

--- a/python/include/py_oem/message_database.hpp
+++ b/python/include/py_oem/message_database.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "novatel_edie/decoders/oem/encoder.hpp"
 #include "novatel_edie/decoders/oem/rxconfig/rxconfig_handler.hpp"
 #include "py_common/message_database.hpp"
@@ -8,41 +10,19 @@ namespace nb = nanobind;
 
 namespace novatel::edie::py_oem {
 
-class PyMessageDatabase
+struct DatabaseExtras
 {
-  private:
-    void Initialize();
-
-  public:
-    explicit PyMessageDatabase(py_common::PyMessageDatabaseCore::Ptr pclMessageDb_);
-
-    [[nodiscard]] std::string MsgIdToMsgName(uint32_t uiMessageId_) const { return pclMessageDb->MsgIdToMsgName(uiMessageId_); };
-
-    // MessageDatabase wrappers
-    [[nodiscard]] MessageDefinition::ConstPtr GetMsgDef(std::string_view strMsgName_) const { return pclMessageDb->GetMsgDef(strMsgName_); }
-    [[nodiscard]] MessageDefinition::ConstPtr GetMsgDef(int32_t iMsgId_) const { return pclMessageDb->GetMsgDef(iMsgId_); }
-
-    [[nodiscard]] EnumDefinition::ConstPtr GetEnumDefId(std::string& strEnumId_) const { return pclMessageDb->GetEnumDefId(strEnumId_); }
-    [[nodiscard]] EnumDefinition::ConstPtr GetEnumDefName(std::string& strEnumName_) const { return pclMessageDb->GetEnumDefName(strEnumName_); }
-
-    [[nodiscard]] nb::object GetEnumType(const EnumDefinition* enum_def) const { return pclMessageDb->GetEnumType(enum_def); }
-    [[nodiscard]] nb::object GetEnumTypeByName(const std::string& name) const { return pclMessageDb->GetEnumTypeByName(name); }
-    [[nodiscard]] nb::object GetEnumTypeById(const std::string& id) const { return pclMessageDb->GetEnumTypeById(id); }
-
-  private:
-    py_common::PyMessageDatabaseCore::Ptr pclMessageDb; // This is the MessageDatabase that this class wraps
-    std::unique_ptr<oem::Encoder> pclEncoder;
-    std::unique_ptr<oem::RxConfigHandler> pclRxConfigHandler;
-
-    void ThrowRXConfigConstructionError() const { throw py_common::FailureException("RXConfig definition in database cannot be handled."); }
-
-  public:
-    using Ptr = std::shared_ptr<PyMessageDatabase>;
-    using ConstPtr = std::shared_ptr<const PyMessageDatabase>;
-
-    py_common::PyMessageDatabaseCore::Ptr GetCoreDatabase() const { return pclMessageDb; }
-    const oem::Encoder* GetEncoder() const { return pclEncoder.get(); }
-    oem::RxConfigHandler* GetRxConfigHandler() const { return pclRxConfigHandler.get(); }
+    const py_common::PyMessageDatabaseCore* database;
+    std::unique_ptr<oem::Encoder> encoder;
+    std::unique_ptr<oem::RxConfigHandler> rxConfigHandler;
 };
+
+void* AllocateDatabaseExtras(py_common::PyMessageDatabaseCore* database);
+void FreeDatabaseExtras(void* extras);
+
+DatabaseExtras& GetDatabaseExtras(py_common::PyMessageDatabaseCore& database);
+const DatabaseExtras& GetDatabaseExtras(const py_common::PyMessageDatabaseCore& database);
+
+void ThrowRXConfigConstructionError();
 
 } // namespace novatel::edie::py_oem

--- a/python/include/py_oem/message_database.hpp
+++ b/python/include/py_oem/message_database.hpp
@@ -10,15 +10,14 @@ namespace nb = nanobind;
 
 namespace novatel::edie::py_oem {
 
-struct DatabaseExtras
+struct DatabaseExtras : public py_common::MessageDBExtrasBase
 {
     const py_common::PyMessageDatabaseCore* database;
     std::unique_ptr<oem::Encoder> encoder;
     std::unique_ptr<oem::RxConfigHandler> rxConfigHandler;
 };
 
-void* AllocateDatabaseExtras(py_common::PyMessageDatabaseCore* database);
-void FreeDatabaseExtras(void* extras);
+std::unique_ptr<py_common::MessageDBExtrasBase> AllocateDatabaseExtras(py_common::PyMessageDatabaseCore* database);
 
 const DatabaseExtras& GetDatabaseExtras(const py_common::PyMessageDatabaseCore& database);
 

--- a/python/include/py_oem/message_database.hpp
+++ b/python/include/py_oem/message_database.hpp
@@ -16,7 +16,7 @@ struct DatabaseExtras : public py_common::MessageDBExtrasBase
     std::unique_ptr<oem::RxConfigHandler> rxConfigHandler;
 };
 
-std::unique_ptr<py_common::MessageDBExtrasBase> AllocateDatabaseExtras(py_common::PyMessageDatabaseCore::Ptr database);
+std::unique_ptr<py_common::MessageDBExtrasBase> AllocateDatabaseExtras(MessageDatabase::Ptr database);
 
 const DatabaseExtras& GetDatabaseExtras(const py_common::PyMessageDatabase& database);
 

--- a/python/include/py_oem/message_database.hpp
+++ b/python/include/py_oem/message_database.hpp
@@ -12,14 +12,13 @@ namespace novatel::edie::py_oem {
 
 struct DatabaseExtras : public py_common::MessageDBExtrasBase
 {
-    const py_common::PyMessageDatabaseCore* database;
     std::unique_ptr<oem::Encoder> encoder;
     std::unique_ptr<oem::RxConfigHandler> rxConfigHandler;
 };
 
-std::unique_ptr<py_common::MessageDBExtrasBase> AllocateDatabaseExtras(py_common::PyMessageDatabaseCore* database);
+std::unique_ptr<py_common::MessageDBExtrasBase> AllocateDatabaseExtras(py_common::PyMessageDatabaseCore::Ptr database);
 
-const DatabaseExtras& GetDatabaseExtras(const py_common::PyMessageDatabaseCore& database);
+const DatabaseExtras& GetDatabaseExtras(const py_common::PyMessageDatabase& database);
 
 void ThrowRXConfigConstructionError();
 

--- a/python/include/py_oem/message_db_singleton.hpp
+++ b/python/include/py_oem/message_db_singleton.hpp
@@ -24,7 +24,7 @@ class MessageDbSingleton
     //!
     //! If the instance does not yet exist, it will be created and returned.
     //----------------------------------------------------------------------------
-    [[nodiscard]] static py_common::PyMessageDatabaseCore::Ptr& get();
+    [[nodiscard]] static py_common::PyMessageDatabase::Ptr& get();
 };
 
 } // namespace novatel::edie::py_oem

--- a/python/include/py_oem/parser.hpp
+++ b/python/include/py_oem/parser.hpp
@@ -3,9 +3,9 @@
 #include "novatel_edie/decoders/oem/parser.hpp"
 #include "py_common/bindings_core.hpp"
 #include "py_common/message_database.hpp"
-#include "py_oem/message_db_singleton.hpp"
 #include "py_common/py_message_data.hpp"
 #include "py_oem/message_database.hpp"
+#include "py_oem/message_db_singleton.hpp"
 #include "py_oem/py_message_objects.hpp"
 
 namespace nb = nanobind;
@@ -14,19 +14,16 @@ namespace novatel::edie::py_oem {
 
 nb::object HandlePythonReadStatus(STATUS status_, MessageDataStruct& message_data_, py_oem::PyHeader& header_,
                                   std::vector<FieldContainer>&& message_fields_, oem::MetaDataStruct& metadata_,
-                                  py_oem::PyMessageDatabase::ConstPtr database_);
+                                  py_common::PyMessageDatabaseCore::ConstPtr database_);
 
 class PyParser : public oem::Parser
 {
   private:
-    py_oem::PyMessageDatabase::Ptr pclPyMessageDb;
+    py_common::PyMessageDatabaseCore::Ptr pclPyMessageDb;
 
   public:
     // inherit constructors
-    PyParser(py_common::PyMessageDatabaseCore::Ptr& pclMessageDb_)
-        : Parser(pclMessageDb_), pclPyMessageDb(std::make_shared<PyMessageDatabase>(pclMessageDb_))
-    {
-    }
+    PyParser(py_common::PyMessageDatabaseCore::Ptr& pclMessageDb_) : Parser(pclMessageDb_), pclPyMessageDb(pclMessageDb_) {}
 
     nb::object PyRead(bool decode_incomplete);
     nb::object PyIterRead();

--- a/python/include/py_oem/parser.hpp
+++ b/python/include/py_oem/parser.hpp
@@ -14,16 +14,16 @@ namespace novatel::edie::py_oem {
 
 nb::object HandlePythonReadStatus(STATUS status_, MessageDataStruct& message_data_, py_oem::PyHeader& header_,
                                   std::vector<FieldContainer>&& message_fields_, oem::MetaDataStruct& metadata_,
-                                  py_common::PyMessageDatabaseCore::ConstPtr database_);
+                                  py_common::PyMessageDatabase::ConstPtr database_);
 
 class PyParser : public oem::Parser
 {
   private:
-    py_common::PyMessageDatabaseCore::Ptr pclPyMessageDb;
+    py_common::PyMessageDatabase::Ptr pclPyMessageDb;
 
   public:
     // inherit constructors
-    PyParser(py_common::PyMessageDatabaseCore::Ptr& pclMessageDb_) : Parser(pclMessageDb_), pclPyMessageDb(pclMessageDb_) {}
+    PyParser(py_common::PyMessageDatabase::Ptr& pclMessageDb_) : Parser(pclMessageDb_->core()), pclPyMessageDb(pclMessageDb_) {}
 
     nb::object PyRead(bool decode_incomplete);
     nb::object PyIterRead();

--- a/python/include/py_oem/py_message_objects.hpp
+++ b/python/include/py_oem/py_message_objects.hpp
@@ -112,7 +112,6 @@ struct PyEncodableField : public py_common::PyField
 
   public:
     PyHeader header;
-    PyMessageDatabase::ConstPtr encoderDb;
     const MessageDefinition* messageDef;
     uint32_t messageCrc;
 
@@ -124,10 +123,10 @@ struct PyEncodableField : public py_common::PyField
         return messageDef->name;
     }
 
-    explicit PyEncodableField(std::vector<FieldContainer> fields_, PyMessageDatabase::ConstPtr encoderDb_, PyHeader header_,
+    explicit PyEncodableField(std::vector<FieldContainer> fields_, py_common::PyMessageDatabaseCore::ConstPtr database_, PyHeader header_,
                               const MessageDefinition* messageDef_, uint32_t messageCrc_)
-        : PyField(std::move(fields_), messageDef_, messageCrc_, std::move(encoderDb_->GetCoreDatabase())), header(std::move(header_)),
-          encoderDb(std::move(encoderDb_)), messageDef(messageDef_), messageCrc(messageCrc_) {};
+        : PyField(std::move(fields_), messageDef_, messageCrc_, std::move(database_)), header(std::move(header_)), messageDef(messageDef_),
+          messageCrc(messageCrc_) {};
 
     py_common::PyMessageData encode(ENCODE_FORMAT fmt);
     py_common::PyMessageData to_ascii();
@@ -143,7 +142,7 @@ struct PyEncodableField : public py_common::PyField
 //============================================================================
 struct PyMessage : public PyEncodableField
 {
-    explicit PyMessage(std::vector<FieldContainer> fields_, PyMessageDatabase::ConstPtr parent_db_, PyHeader header_,
+    explicit PyMessage(std::vector<FieldContainer> fields_, py_common::PyMessageDatabaseCore::ConstPtr parent_db_, PyHeader header_,
                        const MessageDefinition* messageDef_, uint32_t messageCrc_)
         : PyEncodableField(std::move(fields_), std::move(parent_db_), std::move(header_), messageDef_, messageCrc_) {};
 };
@@ -151,7 +150,7 @@ struct PyMessage : public PyEncodableField
 nb::object create_unknown_message_instance(nb::bytes data, PyHeader& header);
 
 nb::object create_message_instance(PyHeader& header, std::vector<FieldContainer>&& message_fields, oem::MetaDataStruct& metadata,
-                                   PyMessageDatabase::ConstPtr database);
+                                   py_common::PyMessageDatabaseCore::ConstPtr database);
 
 //============================================================================
 //! \class PyResponse
@@ -163,7 +162,7 @@ nb::object create_message_instance(PyHeader& header, std::vector<FieldContainer>
 struct PyResponse : public PyEncodableField
 {
     bool complete;
-    explicit PyResponse(std::vector<FieldContainer> fields_, PyMessageDatabase::ConstPtr parent_db_, PyHeader header_, bool complete_,
+    explicit PyResponse(std::vector<FieldContainer> fields_, py_common::PyMessageDatabaseCore::ConstPtr parent_db_, PyHeader header_, bool complete_,
                         const MessageDefinition* messageDef_, uint32_t messageCrc_)
         : PyEncodableField(std::move(fields_), std::move(parent_db_), std::move(header_), messageDef_, messageCrc_), complete(complete_) {};
 
@@ -175,7 +174,7 @@ struct PyResponse : public PyEncodableField
 
     nb::object GetEnumValue()
     {
-        nb::object response_enum = encoderDb->GetEnumTypeByName("Responses");
+        nb::object response_enum = parentDb->GetEnumTypeByName("Responses");
         if (response_enum.is_none()) { return nb::none(); }
         int32_t value = GetResponseId();
         nb::object enum_val = response_enum(value);

--- a/python/include/py_oem/py_message_objects.hpp
+++ b/python/include/py_oem/py_message_objects.hpp
@@ -123,7 +123,7 @@ struct PyEncodableField : public py_common::PyField
         return messageDef->name;
     }
 
-    explicit PyEncodableField(std::vector<FieldContainer> fields_, py_common::PyMessageDatabaseCore::ConstPtr database_, PyHeader header_,
+    explicit PyEncodableField(std::vector<FieldContainer> fields_, py_common::PyMessageDatabase::ConstPtr database_, PyHeader header_,
                               const MessageDefinition* messageDef_, uint32_t messageCrc_)
         : PyField(std::move(fields_), messageDef_, messageCrc_, std::move(database_)), header(std::move(header_)), messageDef(messageDef_),
           messageCrc(messageCrc_) {};
@@ -142,7 +142,7 @@ struct PyEncodableField : public py_common::PyField
 //============================================================================
 struct PyMessage : public PyEncodableField
 {
-    explicit PyMessage(std::vector<FieldContainer> fields_, py_common::PyMessageDatabaseCore::ConstPtr parent_db_, PyHeader header_,
+    explicit PyMessage(std::vector<FieldContainer> fields_, py_common::PyMessageDatabase::ConstPtr parent_db_, PyHeader header_,
                        const MessageDefinition* messageDef_, uint32_t messageCrc_)
         : PyEncodableField(std::move(fields_), std::move(parent_db_), std::move(header_), messageDef_, messageCrc_) {};
 };
@@ -150,7 +150,7 @@ struct PyMessage : public PyEncodableField
 nb::object create_unknown_message_instance(nb::bytes data, PyHeader& header);
 
 nb::object create_message_instance(PyHeader& header, std::vector<FieldContainer>&& message_fields, oem::MetaDataStruct& metadata,
-                                   py_common::PyMessageDatabaseCore::ConstPtr database);
+                                   py_common::PyMessageDatabase::ConstPtr database);
 
 //============================================================================
 //! \class PyResponse
@@ -162,7 +162,7 @@ nb::object create_message_instance(PyHeader& header, std::vector<FieldContainer>
 struct PyResponse : public PyEncodableField
 {
     bool complete;
-    explicit PyResponse(std::vector<FieldContainer> fields_, py_common::PyMessageDatabaseCore::ConstPtr parent_db_, PyHeader header_, bool complete_,
+    explicit PyResponse(std::vector<FieldContainer> fields_, py_common::PyMessageDatabase::ConstPtr parent_db_, PyHeader header_, bool complete_,
                         const MessageDefinition* messageDef_, uint32_t messageCrc_)
         : PyEncodableField(std::move(fields_), std::move(parent_db_), std::move(header_), messageDef_, messageCrc_), complete(complete_) {};
 

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -167,14 +167,12 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<py_common::PyMessageDatabaseCore>(m, "MessageDatabase")
-        .def(nb::new_([]() { return std::make_shared<py_common::PyMessageDatabaseCore>(); }))
-        .def(nb::new_([](std::filesystem::path& file_path) {
-                 return std::make_shared<py_common::PyMessageDatabaseCore>(std::move(*LoadJsonDbFile(file_path)));
-             }),
+        .def(nb::new_([]() { return py_common::PyMessageDatabaseCore::Create(); }))
+        .def(nb::new_(
+                 [](std::filesystem::path& file_path) { return py_common::PyMessageDatabaseCore::Create(std::move(*LoadJsonDbFile(file_path))); }),
              "file_path"_a)
         .def_static(
-            "from_string",
-            [](std::string_view json_data) { return std::make_shared<py_common::PyMessageDatabaseCore>(std::move(*ParseJsonDb(json_data))); },
+            "from_string", [](std::string_view json_data) { return py_common::PyMessageDatabaseCore::Create(std::move(*ParseJsonDb(json_data))); },
             "json_data"_a)
         .def("merge", &py_common::PyMessageDatabaseCore::Merge, "other_db"_a)
         .def("append_messages", &py_common::PyMessageDatabaseCore::AppendMessages, "messages"_a)
@@ -196,7 +194,7 @@ void py_common::init_common_message_database(nb::module_& m)
         .def(
             "clone",
             [](const py_common::PyMessageDatabaseCore& self) {
-                return std::make_shared<py_common::PyMessageDatabaseCore>(static_cast<const MessageDatabase&>(self));
+                return py_common::PyMessageDatabaseCore::Create(static_cast<const MessageDatabase&>(self));
             },
             "Create an copy of this database.");
 }

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -166,35 +166,33 @@ void py_common::init_common_message_database(nb::module_& m)
                 .format(msg_def.name, msg_def._id, msg_def.logID, msg_def.description, self.attr("fields"), msg_def.latestMessageCrc);
         });
 
-    nb::class_<py_common::PyMessageDatabaseCore>(m, "MessageDatabase")
-        .def(nb::new_([]() { return py_common::PyMessageDatabaseCore::Create(); }))
+    nb::class_<py_common::PyMessageDatabase>(m, "MessageDatabase", nb::is_weak_referenceable())
+        .def(nb::new_([]() { return std::make_shared<py_common::PyMessageDatabase>(); }))
         .def(nb::new_(
-                 [](std::filesystem::path& file_path) { return py_common::PyMessageDatabaseCore::Create(std::move(*LoadJsonDbFile(file_path))); }),
+                 [](std::filesystem::path& file_path) {
+                     return std::make_shared<py_common::PyMessageDatabase>(std::move(*LoadJsonDbFile(file_path)));
+                 }),
              "file_path"_a)
         .def_static(
-            "from_string", [](std::string_view json_data) { return py_common::PyMessageDatabaseCore::Create(std::move(*ParseJsonDb(json_data))); },
+            "from_string",
+            [](std::string_view json_data) { return std::make_shared<py_common::PyMessageDatabase>(std::move(*ParseJsonDb(json_data))); },
             "json_data"_a)
-        .def("merge", &py_common::PyMessageDatabaseCore::Merge, "other_db"_a)
-        .def("append_messages", &py_common::PyMessageDatabaseCore::AppendMessages, "messages"_a)
-        .def("append_enumerations", &py_common::PyMessageDatabaseCore::AppendEnumerations, "enums"_a)
-        .def("remove_message", &py_common::PyMessageDatabaseCore::RemoveMessage, "msg_id"_a)
-        .def("remove_enumeration", &py_common::PyMessageDatabaseCore::RemoveEnumeration, "enumeration"_a)
-        .def("get_msg_def", nb::overload_cast<std::string_view>(&py_common::PyMessageDatabaseCore::GetMsgDef, nb::const_), "msg_name"_a)
-        .def("get_msg_def", nb::overload_cast<int32_t>(&py_common::PyMessageDatabaseCore::GetMsgDef, nb::const_), "msg_id"_a)
-        .def("get_enum_def", &py_common::PyMessageDatabaseCore::GetEnumDefId, "enum_id"_a)
-        .def("get_enum_def_by_id", &py_common::PyMessageDatabaseCore::GetEnumDefId, "enum_id"_a)
-        .def("get_enum_def_by_name", &py_common::PyMessageDatabaseCore::GetEnumDefName, "enum_name"_a)
+        .def("merge", &py_common::PyMessageDatabase::Merge, "other_db"_a)
+        .def("append_messages", &py_common::PyMessageDatabase::AppendMessages, "messages"_a)
+        .def("append_enumerations", &py_common::PyMessageDatabase::AppendEnumerations, "enums"_a)
+        .def("remove_message", &py_common::PyMessageDatabase::RemoveMessage, "msg_id"_a)
+        .def("remove_enumeration", &py_common::PyMessageDatabase::RemoveEnumeration, "enumeration"_a)
+        .def("get_msg_def", nb::overload_cast<std::string_view>(&py_common::PyMessageDatabase::GetMsgDef, nb::const_), "msg_name"_a)
+        .def("get_msg_def", nb::overload_cast<int32_t>(&py_common::PyMessageDatabase::GetMsgDef, nb::const_), "msg_id"_a)
+        .def("get_enum_def", &py_common::PyMessageDatabase::GetEnumDefId, "enum_id"_a)
+        .def("get_enum_def_by_id", &py_common::PyMessageDatabase::GetEnumDefId, "enum_id"_a)
+        .def("get_enum_def_by_name", &py_common::PyMessageDatabase::GetEnumDefName, "enum_name"_a)
         .def(
-            "get_msg_type", [](py_common::PyMessageDatabaseCore& self, std::string name) { return self.GetMessageType(name); }, "name"_a)
+            "get_msg_type", [](py_common::PyMessageDatabase& self, std::string name) { return self.GetMessageType(name); }, "name"_a)
         .def(
-            "get_enum_type_by_name", [](py_common::PyMessageDatabaseCore& self, std::string name) { return self.GetEnumTypeByName(name); }, "name"_a)
+            "get_enum_type_by_name", [](py_common::PyMessageDatabase& self, std::string name) { return self.GetEnumTypeByName(name); }, "name"_a)
         .def(
-            "get_enum_type_by_id", [](py_common::PyMessageDatabaseCore& self, std::string id) { return self.GetEnumTypeById(id); }, "id"_a)
-        .def_prop_rw("message_family", &py_common::PyMessageDatabaseCore::GetMessageFamily, &py_common::PyMessageDatabaseCore::SetMessageFamily)
-        .def(
-            "clone",
-            [](const py_common::PyMessageDatabaseCore& self) {
-                return py_common::PyMessageDatabaseCore::Create(static_cast<const MessageDatabase&>(self));
-            },
-            "Create an copy of this database.");
+            "get_enum_type_by_id", [](py_common::PyMessageDatabase& self, std::string id) { return self.GetEnumTypeById(id); }, "id"_a)
+        .def_prop_rw("message_family", &py_common::PyMessageDatabase::GetMessageFamily, &py_common::PyMessageDatabase::SetMessageFamily)
+        .def("clone", &py_common::PyMessageDatabase::clone, "Create a copy of this database.");
 }

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -166,7 +166,7 @@ void py_common::init_common_message_database(nb::module_& m)
                 .format(msg_def.name, msg_def._id, msg_def.logID, msg_def.description, self.attr("fields"), msg_def.latestMessageCrc);
         });
 
-    nb::class_<py_common::PyMessageDatabase>(m, "MessageDatabase", nb::is_weak_referenceable())
+    nb::class_<py_common::PyMessageDatabase>(m, "MessageDatabase")
         .def(nb::new_([]() { return std::make_shared<py_common::PyMessageDatabase>(); }))
         .def(nb::new_(
                  [](std::filesystem::path& file_path) {

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -14,26 +14,24 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace novatel::edie;
 
-PYCOMMON_EXPORT py_common::PyMessageDatabaseCore::PyMessageDatabaseCore() : MessageDatabase()
+PYCOMMON_EXPORT py_common::PyMessageDatabaseCore::PyMessageDatabaseCore(MessageDatabase&& message_db) : MessageDatabase(std::move(message_db)) {}
+
+PYCOMMON_EXPORT std::shared_ptr<py_common::PyMessageDatabaseCore> py_common::PyMessageDatabaseCore::Create(MessageDatabase message_db)
+{
+    auto db = std::shared_ptr<PyMessageDatabaseCore>(new PyMessageDatabaseCore(std::move(message_db)));
+    db->self_weak_ = db;
+    db->InitializeAfterConstruction();
+    return db;
+}
+
+void py_common::PyMessageDatabaseCore::InitializeAfterConstruction()
 {
     ResolveBaseType();
     UpdatePythonEnums();
     UpdatePythonMessageTypes();
 }
 
-PYCOMMON_EXPORT py_common::PyMessageDatabaseCore::PyMessageDatabaseCore(const MessageDatabase& message_db) noexcept : MessageDatabase(message_db)
-{
-    ResolveBaseType();
-    UpdatePythonEnums();
-    UpdatePythonMessageTypes();
-}
-
-PYCOMMON_EXPORT py_common::PyMessageDatabaseCore::PyMessageDatabaseCore(const MessageDatabase&& message_db) noexcept : MessageDatabase(message_db)
-{
-    ResolveBaseType();
-    UpdatePythonEnums();
-    UpdatePythonMessageTypes();
-}
+PYCOMMON_EXPORT py_common::PyMessageDatabaseCore::~PyMessageDatabaseCore() { ResetMessageFamilyExtras(); }
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::GenerateMessageMappings()
 {
@@ -54,6 +52,16 @@ void py_common::PyMessageDatabaseCore::SetMessageFamily(const std::string& messa
     pDbMetadata->messageFamily = messageFamily;
     ResolveBaseType();
     UpdatePythonMessageTypes();
+}
+
+void py_common::PyMessageDatabaseCore::ResetMessageFamilyExtras()
+{
+    if (message_family_extras_ && message_family_registration_ && message_family_registration_->freeExtras)
+    {
+        message_family_registration_->freeExtras(message_family_extras_);
+        message_family_extras_ = nullptr;
+    }
+    else { message_family_extras_ = nullptr; }
 }
 
 void py_common::PyMessageDatabaseCore::Merge(const std::shared_ptr<PyMessageDatabaseCore> other_)
@@ -143,8 +151,16 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::ResolveBaseType()
         dbMetadata->messageFamily = "";
         pDbMetadata = dbMetadata;
     }
-    base_message_type = GetMessageFamilyType(pDbMetadata->messageFamily);
-    if (!base_message_type.is_valid()) { throw FailureException(pDbMetadata->messageFamily + " is not a recognized message type."); }
+
+    ResetMessageFamilyExtras();
+
+    message_family_registration_ = GetMessageFamilyRegistration(pDbMetadata->messageFamily);
+    if (!message_family_registration_ || !message_family_registration_->messageType.is_valid())
+    {
+        throw FailureException(pDbMetadata->messageFamily + " is not a recognized message type.");
+    }
+
+    if (message_family_registration_->allocateExtras) { message_family_extras_ = message_family_registration_->allocateExtras(this); }
 }
 
 static py_common::FieldNameMap BuildFieldNameMapFromDefs(const std::vector<BaseField::Ptr>& fields)
@@ -191,13 +207,18 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::AddFieldType(std::vector<
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::AppendMessageTypes(const std::vector<MessageDefinition::ConstPtr>& message_defs)
 {
+    if (!message_family_registration_ || !message_family_registration_->messageType.is_valid())
+    {
+        throw FailureException("Message family type is not initialized.");
+    }
+
     // get type constructor
     nb::object type_constructor = nb::module_::import_("builtins").attr("type");
     // specify the python superclass for the message body types
     nb::tuple field_type_tuple = nb::make_tuple(nb::type<py_common::PyField>());
     // provide no additional attributes via `__dict__`
     nb::dict type_dict = nb::dict();
-    nb::tuple message_type_tuple = nb::make_tuple(base_message_type);
+    nb::tuple message_type_tuple = nb::make_tuple(message_family_registration_->messageType);
     type_dict[nb::str("__slots__")] = nb::make_tuple();
 
     // add message and message body types for each message definition
@@ -252,16 +273,16 @@ void py_common::PyMessageDatabaseCore::RemoveFieldTypes(const std::vector<BaseFi
     }
 }
 
-PYCOMMON_EXPORT std::unordered_map<std::string, nb::handle>& py_common::GetMessageFamilyTypes()
+PYCOMMON_EXPORT std::unordered_map<std::string, py_common::MessageFamilyRegistration>& py_common::GetMessageFamilyRegistrations()
 {
-    static std::unordered_map<std::string, nb::handle> nameToType;
-    return nameToType;
+    static std::unordered_map<std::string, py_common::MessageFamilyRegistration> registrations;
+    return registrations;
 }
 
-PYCOMMON_EXPORT nb::handle py_common::GetMessageFamilyType(const std::string& message_family)
+PYCOMMON_EXPORT const py_common::MessageFamilyRegistration* py_common::GetMessageFamilyRegistration(const std::string& message_family)
 {
-    std::unordered_map<std::string, nb::handle>& typeGetters = GetMessageFamilyTypes();
-    auto typeGetterIt = typeGetters.find(message_family);
-    if (typeGetterIt == typeGetters.end()) { return nb::handle(); }
-    else { return typeGetterIt->second; }
+    auto& registrations = GetMessageFamilyRegistrations();
+    auto registrationIt = registrations.find(message_family);
+    if (registrationIt == registrations.end()) { return nullptr; }
+    return &registrationIt->second;
 }

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -20,11 +20,11 @@ PYCOMMON_EXPORT std::shared_ptr<py_common::PyMessageDatabaseCore> py_common::PyM
 {
     auto db = std::shared_ptr<PyMessageDatabaseCore>(new PyMessageDatabaseCore(std::move(message_db)));
     db->self_weak_ = db;
-    db->InitializeAfterConstruction();
+    db->Initialize();
     return db;
 }
 
-void py_common::PyMessageDatabaseCore::InitializeAfterConstruction()
+void py_common::PyMessageDatabaseCore::Initialize()
 {
     ResolveBaseType();
     UpdatePythonEnums();
@@ -59,9 +59,8 @@ void py_common::PyMessageDatabaseCore::ResetMessageFamilyExtras()
     if (message_family_extras_ && message_family_registration_ && message_family_registration_->freeExtras)
     {
         message_family_registration_->freeExtras(message_family_extras_);
-        message_family_extras_ = nullptr;
     }
-    else { message_family_extras_ = nullptr; }
+    message_family_extras_ = nullptr;
 }
 
 void py_common::PyMessageDatabaseCore::Merge(const std::shared_ptr<PyMessageDatabaseCore> other_)

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -31,8 +31,6 @@ void py_common::PyMessageDatabaseCore::Initialize()
     UpdatePythonMessageTypes();
 }
 
-PYCOMMON_EXPORT py_common::PyMessageDatabaseCore::~PyMessageDatabaseCore() { ResetMessageFamilyExtras(); }
-
 PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::GenerateMessageMappings()
 {
     MessageDatabase::GenerateMessageMappings();
@@ -52,15 +50,6 @@ void py_common::PyMessageDatabaseCore::SetMessageFamily(const std::string& messa
     pDbMetadata->messageFamily = messageFamily;
     ResolveBaseType();
     UpdatePythonMessageTypes();
-}
-
-void py_common::PyMessageDatabaseCore::ResetMessageFamilyExtras()
-{
-    if (message_family_extras_ && message_family_registration_ && message_family_registration_->freeExtras)
-    {
-        message_family_registration_->freeExtras(message_family_extras_);
-    }
-    message_family_extras_ = nullptr;
 }
 
 void py_common::PyMessageDatabaseCore::Merge(const std::shared_ptr<PyMessageDatabaseCore> other_)
@@ -151,7 +140,7 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::ResolveBaseType()
         pDbMetadata = dbMetadata;
     }
 
-    ResetMessageFamilyExtras();
+    message_family_extras_.reset();
 
     message_family_registration_ = GetMessageFamilyRegistration(pDbMetadata->messageFamily);
     if (!message_family_registration_ || !message_family_registration_->messageType.is_valid())

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -14,69 +14,107 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace novatel::edie;
 
-PYCOMMON_EXPORT py_common::PyMessageDatabaseCore::PyMessageDatabaseCore(MessageDatabase&& message_db) : MessageDatabase(std::move(message_db)) { Initialize(); }
+PYCOMMON_EXPORT std::unordered_map<std::string, py_common::MessageFamilyRegistration>& py_common::GetMessageFamilyRegistrations()
+{
+    static std::unordered_map<std::string, py_common::MessageFamilyRegistration> registrations;
+    return registrations;
+}
 
-void py_common::PyMessageDatabaseCore::Initialize()
+PYCOMMON_EXPORT const py_common::MessageFamilyRegistration* py_common::GetMessageFamilyRegistration(const std::string& message_family)
+{
+    auto& registrations = GetMessageFamilyRegistrations();
+    auto registrationIt = registrations.find(message_family);
+    if (registrationIt == registrations.end()) { return nullptr; }
+    return &registrationIt->second;
+}
+
+PYCOMMON_EXPORT py_common::PyMessageDatabase::PyMessageDatabase(MessageDatabase&& message_db)
+    : core_(std::make_shared<MessageDatabase>(std::move(message_db)))
+{
+    Initialize();
+    allocateExtras();
+}
+
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::Initialize()
 {
     ResolveBaseType();
     UpdatePythonEnums();
     UpdatePythonMessageTypes();
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::GenerateMessageMappings()
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::ResolveBaseType()
 {
-    MessageDatabase::GenerateMessageMappings();
-    UpdatePythonMessageTypes();
+    if (!core_->GetDbMetadata()) { core_->SetMessageFamily(""); }
+
+    const std::string family = GetMessageFamily();
+    message_family_registration_ = py_common::GetMessageFamilyRegistration(family);
+    if (!message_family_registration_ || !message_family_registration_->messageType.is_valid())
+    {
+        throw FailureException(family + " is not a recognized message type.");
+    }
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::GenerateEnumMappings()
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::allocateExtras()
 {
-    MessageDatabase::GenerateEnumMappings();
-    UpdatePythonEnums();
+    if (message_family_registration_ && message_family_registration_->allocateExtras)
+    {
+        extras_ = message_family_registration_->allocateExtras(core_);
+    }
+    else { extras_.reset(); }
 }
 
-std::string py_common::PyMessageDatabaseCore::GetMessageFamily() const { return pDbMetadata ? pDbMetadata->messageFamily : ""; }
-
-void py_common::PyMessageDatabaseCore::SetMessageFamily(const std::string& messageFamily)
+PYCOMMON_EXPORT std::string py_common::PyMessageDatabase::GetMessageFamily() const
 {
-    pDbMetadata->messageFamily = messageFamily;
+    auto metadata = core_->GetDbMetadata();
+    return metadata ? metadata->messageFamily : "";
+}
+
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::SetMessageFamily(const std::string& messageFamily)
+{
+    core_->SetMessageFamily(messageFamily);
     ResolveBaseType();
     UpdatePythonMessageTypes();
+    allocateExtras();
 }
 
-void py_common::PyMessageDatabaseCore::Merge(const std::shared_ptr<PyMessageDatabaseCore> other_)
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::Merge(const Ptr& other_)
 {
-    MessageDatabase::AppendEnumerations(other_->vEnumDefinitions);
-    AppendEnumTypes(other_->vEnumDefinitions);
-    MessageDatabase::AppendMessages(other_->vMessageDefinitions);
-    AppendMessageTypes(other_->vMessageDefinitions);
+    core_->AppendEnumerations(other_->core_->EnumDefinitions());
+    AppendEnumTypes(other_->core_->EnumDefinitions());
+    core_->AppendMessages(other_->core_->MessageDefinitions());
+    AppendMessageTypes(other_->core_->MessageDefinitions());
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::AppendMessages(const std::vector<MessageDefinition::ConstPtr>& vMessageDefinitions_)
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendMessages(const std::vector<MessageDefinition::ConstPtr>& vMessageDefinitions_)
 {
-    MessageDatabase::AppendMessages(vMessageDefinitions_);
+    core_->AppendMessages(vMessageDefinitions_);
     AppendMessageTypes(vMessageDefinitions_);
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::AppendEnumerations(const std::vector<EnumDefinition::ConstPtr>& vEnumDefinitions_)
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendEnumerations(const std::vector<EnumDefinition::ConstPtr>& vEnumDefinitions_)
 {
-    MessageDatabase::AppendEnumerations(vEnumDefinitions_);
+    core_->AppendEnumerations(vEnumDefinitions_);
     AppendEnumTypes(vEnumDefinitions_);
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::RemoveMessage(uint32_t iMsgId_)
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveMessage(uint32_t iMsgId_)
 {
     RemoveMessageType(iMsgId_);
-    MessageDatabase::RemoveMessage(iMsgId_);
+    core_->RemoveMessage(iMsgId_);
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::RemoveEnumeration(std::string strEnumeration_)
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveEnumeration(std::string strEnumeration_)
 {
     RemoveEnumType(strEnumeration_);
-    MessageDatabase::RemoveEnumeration(strEnumeration_);
+    core_->RemoveEnumeration(strEnumeration_);
 }
 
-void cleanString(std::string& str)
+PYCOMMON_EXPORT py_common::PyMessageDatabase::Ptr py_common::PyMessageDatabase::clone() const
+{
+    return std::make_shared<PyMessageDatabase>(MessageDatabase(*core_));
+}
+
+static void cleanString(std::string& str)
 {
     // Remove special characters from the string to make it a valid python attribute name
     for (char& c : str)
@@ -86,13 +124,13 @@ void cleanString(std::string& str)
     if (isdigit(str[0])) { str = "_" + str; }
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::UpdatePythonEnums()
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::UpdatePythonEnums()
 {
     enum_types.clear();
-    AppendEnumTypes(EnumDefinitions());
+    AppendEnumTypes(core_->EnumDefinitions());
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::AppendEnumTypes(const std::vector<EnumDefinition::ConstPtr>& enum_defs)
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendEnumTypes(const std::vector<EnumDefinition::ConstPtr>& enum_defs)
 {
     nb::object IntEnum = nb::module_::import_("enum").attr("IntEnum");
     for (const auto& enum_def : enum_defs)
@@ -116,27 +154,11 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::AppendEnumTypes(const std
     }
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::RemoveEnumType(const std::string& enum_name)
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveEnumType(const std::string& enum_name)
 {
     // get the enum definition to retrieve the pointer
-    EnumDefinition::ConstPtr enum_def = GetEnumDefName(enum_name);
+    EnumDefinition::ConstPtr enum_def = core_->GetEnumDefName(enum_name);
     if (enum_def) { enum_types.erase(enum_def.get()); }
-}
-
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::ResolveBaseType()
-{
-    if (!pDbMetadata)
-    {
-        auto dbMetadata = std::make_shared<DbMetadata>();
-        dbMetadata->messageFamily = "";
-        pDbMetadata = dbMetadata;
-    }
-
-    message_family_registration_ = py_common::GetMessageFamilyRegistration(pDbMetadata->messageFamily);
-    if (!message_family_registration_ || !message_family_registration_->messageType.is_valid())
-    {
-        throw FailureException(pDbMetadata->messageFamily + " is not a recognized message type.");
-    }
 }
 
 static py_common::FieldNameMap BuildFieldNameMapFromDefs(const std::vector<BaseField::Ptr>& fields)
@@ -151,7 +173,7 @@ static py_common::FieldNameMap BuildFieldNameMapFromDefs(const std::vector<BaseF
     return map;
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::UpdatePythonMessageTypes()
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::UpdatePythonMessageTypes()
 {
     // clear existing definitions
     messages_types.clear();
@@ -159,12 +181,12 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::UpdatePythonMessageTypes(
     message_field_name_maps_.clear();
 
     // add message and message body types for each message definition
-    AppendMessageTypes(MessageDefinitions());
+    AppendMessageTypes(core_->MessageDefinitions());
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::AddFieldType(std::vector<std::shared_ptr<BaseField>> fields, std::string base_name,
-                                                                    std::string parent_message, nb::handle type_constructor, nb::handle type_tuple,
-                                                                    nb::handle type_dict)
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::AddFieldType(std::vector<std::shared_ptr<BaseField>> fields, std::string base_name,
+                                                                std::string parent_message, nb::handle type_constructor, nb::handle type_tuple,
+                                                                nb::handle type_dict)
 {
     // rescursively add field types for each field array element within the provided vector
     for (const auto& field : fields)
@@ -181,7 +203,7 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::AddFieldType(std::vector<
     }
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::AppendMessageTypes(const std::vector<MessageDefinition::ConstPtr>& message_defs)
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendMessageTypes(const std::vector<MessageDefinition::ConstPtr>& message_defs)
 {
     if (!message_family_registration_ || !message_family_registration_->messageType.is_valid())
     {
@@ -221,10 +243,10 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::AppendMessageTypes(const 
     }
 }
 
-PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::RemoveMessageType(uint32_t message_id)
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveMessageType(uint32_t message_id)
 {
     // get the message definition to retrieve the name
-    MessageDefinition::ConstPtr message_def = GetMsgDef(message_id);
+    MessageDefinition::ConstPtr message_def = core_->GetMsgDef(message_id);
     if (!message_def) { return; }
 
     // remove the message type
@@ -235,7 +257,7 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::RemoveMessageType(uint32_
     for (const auto& [crc, fields] : message_def->fields) { RemoveFieldTypes(fields); }
 }
 
-void py_common::PyMessageDatabaseCore::RemoveFieldTypes(const std::vector<BaseField::Ptr>& fieldDefs)
+void py_common::PyMessageDatabase::RemoveFieldTypes(const std::vector<BaseField::Ptr>& fieldDefs)
 {
     for (const auto& fieldDef : fieldDefs)
     {
@@ -247,42 +269,4 @@ void py_common::PyMessageDatabaseCore::RemoveFieldTypes(const std::vector<BaseFi
             RemoveFieldTypes(fieldArrayFieldDef->fields);
         }
     }
-}
-
-PYCOMMON_EXPORT std::unordered_map<std::string, py_common::MessageFamilyRegistration>& py_common::GetMessageFamilyRegistrations()
-{
-    static std::unordered_map<std::string, py_common::MessageFamilyRegistration> registrations;
-    return registrations;
-}
-
-PYCOMMON_EXPORT const py_common::MessageFamilyRegistration* py_common::GetMessageFamilyRegistration(const std::string& message_family)
-{
-    auto& registrations = GetMessageFamilyRegistrations();
-    auto registrationIt = registrations.find(message_family);
-    if (registrationIt == registrations.end()) { return nullptr; }
-    return &registrationIt->second;
-}
-
-PYCOMMON_EXPORT py_common::PyMessageDatabase::PyMessageDatabase(MessageDatabase&& message_db)
-    : core_(std::make_shared<PyMessageDatabaseCore>(std::move(message_db)))
-{
-    allocateExtras();
-}
-
-PYCOMMON_EXPORT void py_common::PyMessageDatabase::allocateExtras()
-{
-    const MessageFamilyRegistration* registration = core_->GetMessageFamilyRegistration();
-    if (registration && registration->allocateExtras) { extras_ = registration->allocateExtras(core_); }
-    else { extras_.reset(); }
-}
-
-PYCOMMON_EXPORT void py_common::PyMessageDatabase::SetMessageFamily(const std::string& messageFamily)
-{
-    core_->SetMessageFamily(messageFamily);
-    allocateExtras();
-}
-
-PYCOMMON_EXPORT py_common::PyMessageDatabase::Ptr py_common::PyMessageDatabase::clone() const
-{
-    return std::make_shared<PyMessageDatabase>(MessageDatabase(static_cast<const MessageDatabase&>(*core_)));
 }

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -14,15 +14,7 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace novatel::edie;
 
-PYCOMMON_EXPORT py_common::PyMessageDatabaseCore::PyMessageDatabaseCore(MessageDatabase&& message_db) : MessageDatabase(std::move(message_db)) {}
-
-PYCOMMON_EXPORT std::shared_ptr<py_common::PyMessageDatabaseCore> py_common::PyMessageDatabaseCore::Create(MessageDatabase message_db)
-{
-    auto db = std::shared_ptr<PyMessageDatabaseCore>(new PyMessageDatabaseCore(std::move(message_db)));
-    db->self_weak_ = db;
-    db->Initialize();
-    return db;
-}
+PYCOMMON_EXPORT py_common::PyMessageDatabaseCore::PyMessageDatabaseCore(MessageDatabase&& message_db) : MessageDatabase(std::move(message_db)) { Initialize(); }
 
 void py_common::PyMessageDatabaseCore::Initialize()
 {
@@ -140,15 +132,11 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabaseCore::ResolveBaseType()
         pDbMetadata = dbMetadata;
     }
 
-    message_family_extras_.reset();
-
-    message_family_registration_ = GetMessageFamilyRegistration(pDbMetadata->messageFamily);
+    message_family_registration_ = py_common::GetMessageFamilyRegistration(pDbMetadata->messageFamily);
     if (!message_family_registration_ || !message_family_registration_->messageType.is_valid())
     {
         throw FailureException(pDbMetadata->messageFamily + " is not a recognized message type.");
     }
-
-    if (message_family_registration_->allocateExtras) { message_family_extras_ = message_family_registration_->allocateExtras(this); }
 }
 
 static py_common::FieldNameMap BuildFieldNameMapFromDefs(const std::vector<BaseField::Ptr>& fields)
@@ -273,4 +261,28 @@ PYCOMMON_EXPORT const py_common::MessageFamilyRegistration* py_common::GetMessag
     auto registrationIt = registrations.find(message_family);
     if (registrationIt == registrations.end()) { return nullptr; }
     return &registrationIt->second;
+}
+
+PYCOMMON_EXPORT py_common::PyMessageDatabase::PyMessageDatabase(MessageDatabase&& message_db)
+    : core_(std::make_shared<PyMessageDatabaseCore>(std::move(message_db)))
+{
+    allocateExtras();
+}
+
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::allocateExtras()
+{
+    const MessageFamilyRegistration* registration = core_->GetMessageFamilyRegistration();
+    if (registration && registration->allocateExtras) { extras_ = registration->allocateExtras(core_); }
+    else { extras_.reset(); }
+}
+
+PYCOMMON_EXPORT void py_common::PyMessageDatabase::SetMessageFamily(const std::string& messageFamily)
+{
+    core_->SetMessageFamily(messageFamily);
+    allocateExtras();
+}
+
+PYCOMMON_EXPORT py_common::PyMessageDatabase::Ptr py_common::PyMessageDatabase::clone() const
+{
+    return std::make_shared<PyMessageDatabase>(MessageDatabase(static_cast<const MessageDatabase&>(*core_)));
 }

--- a/python/src/py_oem/bindings/commander.cpp
+++ b/python/src/py_oem/bindings/commander.cpp
@@ -16,9 +16,9 @@ void py_oem::init_novatel_commander(nb::module_& m)
     nb::class_<oem::Commander>(m, "Commander")
         .def(
             "__init__",
-            [](oem::Commander* t, py_common::PyMessageDatabaseCore::Ptr message_db) {
+            [](oem::Commander* t, py_common::PyMessageDatabase::Ptr message_db) {
                 if (!message_db) { message_db = py_oem::MessageDbSingleton::get(); };
-                new (t) oem::Commander(message_db);
+                new (t) oem::Commander(message_db->core());
             },
             nb::arg("message_db") = nb::none()) // NOLINT(*.NewDeleteLeaks)
         .def(

--- a/python/src/py_oem/bindings/decoder.cpp
+++ b/python/src/py_oem/bindings/decoder.cpp
@@ -38,7 +38,7 @@ void py_oem::init_novatel_decoder(nb::module_& m)
     nb::class_<py_oem::PyDecoder>(m, "Decoder")
         .def(
             "__init__",
-            [](py_oem::PyDecoder* self, py_common::PyMessageDatabaseCore::Ptr message_db) {
+            [](py_oem::PyDecoder* self, py_common::PyMessageDatabase::Ptr message_db) {
                 if (!message_db) { message_db = py_oem::MessageDbSingleton::get(); }
                 new (self) py_oem::PyDecoder(message_db);
             },

--- a/python/src/py_oem/bindings/file_parser.cpp
+++ b/python/src/py_oem/bindings/file_parser.cpp
@@ -81,7 +81,7 @@ void py_oem::init_novatel_file_parser(nb::module_& m)
     nb::class_<py_oem::PyFileParser>(m, "FileParser")
         .def(
             "__init__",
-            [](py_oem::PyFileParser* self, const std::filesystem::path& file_path, py_common::PyMessageDatabaseCore::Ptr message_db) {
+            [](py_oem::PyFileParser* self, const std::filesystem::path& file_path, py_common::PyMessageDatabase::Ptr message_db) {
                 if (!message_db) { message_db = py_oem::MessageDbSingleton::get(); }
                 new (self) py_oem::PyFileParser(file_path, message_db);
             },

--- a/python/src/py_oem/bindings/parser.cpp
+++ b/python/src/py_oem/bindings/parser.cpp
@@ -19,7 +19,7 @@ using namespace novatel::edie::py_common;
 
 nb::object py_oem::HandlePythonReadStatus(STATUS status_, MessageDataStruct& message_data_, py_oem::PyHeader& header_,
                                           std::vector<FieldContainer>&& message_fields_, oem::MetaDataStruct& metadata_,
-                                          py_oem::PyMessageDatabase::ConstPtr database_)
+                                          py_common::PyMessageDatabaseCore::ConstPtr database_)
 {
     header_.format = metadata_.eFormat;
     switch (status_)

--- a/python/src/py_oem/bindings/parser.cpp
+++ b/python/src/py_oem/bindings/parser.cpp
@@ -19,7 +19,7 @@ using namespace novatel::edie::py_common;
 
 nb::object py_oem::HandlePythonReadStatus(STATUS status_, MessageDataStruct& message_data_, py_oem::PyHeader& header_,
                                           std::vector<FieldContainer>&& message_fields_, oem::MetaDataStruct& metadata_,
-                                          py_common::PyMessageDatabaseCore::ConstPtr database_)
+                                          py_common::PyMessageDatabase::ConstPtr database_)
 {
     header_.format = metadata_.eFormat;
     switch (status_)
@@ -96,7 +96,7 @@ void py_oem::init_novatel_parser(nb::module_& m)
     nb::class_<py_oem::PyParser>(m, "Parser")
         .def(
             "__init__",
-            [](py_oem::PyParser* self, py_common::PyMessageDatabaseCore::Ptr message_db) {
+            [](py_oem::PyParser* self, py_common::PyMessageDatabase::Ptr message_db) {
                 if (!message_db) { message_db = py_oem::MessageDbSingleton::get(); }
                 new (self) py_oem::PyParser(message_db);
             },

--- a/python/src/py_oem/bindings/py_message_objects.cpp
+++ b/python/src/py_oem/bindings/py_message_objects.cpp
@@ -53,7 +53,8 @@ py_common::PyMessageData py_oem::PyEncodableField::PyEncode(ENCODE_FORMAT format
 {
     STATUS status;
     MessageDataStruct message_data = MessageDataStruct();
-    RxConfigHandler* pclRxConfigHandler = this->encoderDb->GetRxConfigHandler();
+    const py_oem::DatabaseExtras& extras = py_oem::GetDatabaseExtras(*parentDb);
+    RxConfigHandler* pclRxConfigHandler = extras.rxConfigHandler.get();
 
     // Allocate more space for JSON messages.
     // A TRACKSTAT message can use about 47k bytes when encoded as JSON.
@@ -63,12 +64,9 @@ py_common::PyMessageData py_oem::PyEncodableField::PyEncode(ENCODE_FORMAT format
     uint32_t buf_size = MESSAGE_SIZE_MAX * 3;
     if (pclRxConfigHandler->IsRxConfigTypeMsg(this->header.usMessageId))
     {
-        status = this->encoderDb->GetRxConfigHandler()->Encode(&buf_ptr, buf_size, this->header, this->fields, message_data, format);
+        status = extras.rxConfigHandler->Encode(&buf_ptr, buf_size, this->header, this->fields, message_data, format);
     }
-    else
-    {
-        status = this->encoderDb->GetEncoder()->Encode(&buf_ptr, buf_size, this->header, this->fields, message_data, this->header.format, format);
-    }
+    else { status = extras.encoder->Encode(&buf_ptr, buf_size, this->header, this->fields, message_data, this->header.format, format); }
     throw_exception_from_status(status);
     return py_common::PyMessageData(message_data);
 }
@@ -100,7 +98,7 @@ nb::object py_oem::create_unknown_message_instance(nb::bytes data, py_oem::PyHea
 }
 
 nb::object py_oem::create_message_instance(py_oem::PyHeader& header, std::vector<FieldContainer>&& message_fields, MetaDataStruct& metadata,
-                                           py_oem::PyMessageDatabase::ConstPtr database)
+                                           py_common::PyMessageDatabaseCore::ConstPtr database)
 {
 
     const MessageDefinition* msgDef = database->GetMsgDef(metadata.usMessageId).get();
@@ -117,7 +115,7 @@ nb::object py_oem::create_message_instance(py_oem::PyHeader& header, std::vector
         return response_pyinst;
     }
 
-    PyMessageDatabaseCore* coreDatabase = database->GetCoreDatabase().get();
+    const PyMessageDatabaseCore* coreDatabase = database.get();
     uint32_t crc = metadata.uiMessageCrc;
 
     nb::handle message_pytype = coreDatabase->GetMessageType(metadata.usMessageId, crc);
@@ -125,7 +123,7 @@ nb::object py_oem::create_message_instance(py_oem::PyHeader& header, std::vector
     {
         // Fallback to latest CRC
         crc = msgDef->latestMessageCrc;
-        message_pytype = database->GetCoreDatabase()->GetMessageType(msgDef, msgDef->latestMessageCrc);
+        message_pytype = database->GetMessageType(msgDef, msgDef->latestMessageCrc);
     }
     nb::object message_pyinst = nb::inst_alloc(message_pytype);
     PyMessage* message_cinst = nb::inst_ptr<PyMessage>(message_pyinst);
@@ -306,9 +304,10 @@ void py_oem::init_message_objects(nb::module_& m)
         .def_ro("header", &py_oem::PyMessage::header, "The header of the message.")
         .def_prop_ro("name", &py_oem::PyEncodableField::name, "The type of message it is.");
 
-    auto& familyTypes = py_common::GetMessageFamilyTypes();
-    familyTypes["OEM"] = nb::type<py_oem::PyMessage>();
-    familyTypes[""] = nb::type<py_oem::PyMessage>(); // Use as the default
+    auto& familyRegistrations = py_common::GetMessageFamilyRegistrations();
+    familyRegistrations["OEM"] =
+        py_common::MessageFamilyRegistration{nb::type<py_oem::PyMessage>(), &py_oem::AllocateDatabaseExtras, &py_oem::FreeDatabaseExtras};
+    familyRegistrations[""] = py_common::MessageFamilyRegistration{nb::type<py_oem::PyMessage>(), nullptr, nullptr};
 
     nb::class_<py_oem::PyResponse>(m, "Response")
         .def("encode", &py_oem::PyResponse::encode)

--- a/python/src/py_oem/bindings/py_message_objects.cpp
+++ b/python/src/py_oem/bindings/py_message_objects.cpp
@@ -307,7 +307,8 @@ void py_oem::init_message_objects(nb::module_& m)
     auto& familyRegistrations = py_common::GetMessageFamilyRegistrations();
     familyRegistrations["OEM"] =
         py_common::MessageFamilyRegistration{nb::type<py_oem::PyMessage>(), &py_oem::AllocateDatabaseExtras, &py_oem::FreeDatabaseExtras};
-    familyRegistrations[""] = py_common::MessageFamilyRegistration{nb::type<py_oem::PyMessage>(), nullptr, nullptr};
+    familyRegistrations[""] =
+        py_common::MessageFamilyRegistration{nb::type<py_oem::PyMessage>(), &py_oem::AllocateDatabaseExtras, &py_oem::FreeDatabaseExtras};
 
     nb::class_<py_oem::PyResponse>(m, "Response")
         .def("encode", &py_oem::PyResponse::encode)

--- a/python/src/py_oem/bindings/py_message_objects.cpp
+++ b/python/src/py_oem/bindings/py_message_objects.cpp
@@ -305,10 +305,8 @@ void py_oem::init_message_objects(nb::module_& m)
         .def_prop_ro("name", &py_oem::PyEncodableField::name, "The type of message it is.");
 
     auto& familyRegistrations = py_common::GetMessageFamilyRegistrations();
-    familyRegistrations["OEM"] =
-        py_common::MessageFamilyRegistration{nb::type<py_oem::PyMessage>(), &py_oem::AllocateDatabaseExtras, &py_oem::FreeDatabaseExtras};
-    familyRegistrations[""] =
-        py_common::MessageFamilyRegistration{nb::type<py_oem::PyMessage>(), &py_oem::AllocateDatabaseExtras, &py_oem::FreeDatabaseExtras};
+    familyRegistrations["OEM"] = py_common::MessageFamilyRegistration{nb::type<py_oem::PyMessage>(), &py_oem::AllocateDatabaseExtras};
+    familyRegistrations[""] = py_common::MessageFamilyRegistration{nb::type<py_oem::PyMessage>(), &py_oem::AllocateDatabaseExtras};
 
     nb::class_<py_oem::PyResponse>(m, "Response")
         .def("encode", &py_oem::PyResponse::encode)

--- a/python/src/py_oem/bindings/py_message_objects.cpp
+++ b/python/src/py_oem/bindings/py_message_objects.cpp
@@ -98,7 +98,7 @@ nb::object py_oem::create_unknown_message_instance(nb::bytes data, py_oem::PyHea
 }
 
 nb::object py_oem::create_message_instance(py_oem::PyHeader& header, std::vector<FieldContainer>&& message_fields, MetaDataStruct& metadata,
-                                           py_common::PyMessageDatabaseCore::ConstPtr database)
+                                           py_common::PyMessageDatabase::ConstPtr database)
 {
 
     const MessageDefinition* msgDef = database->GetMsgDef(metadata.usMessageId).get();
@@ -115,10 +115,9 @@ nb::object py_oem::create_message_instance(py_oem::PyHeader& header, std::vector
         return response_pyinst;
     }
 
-    const PyMessageDatabaseCore* coreDatabase = database.get();
     uint32_t crc = metadata.uiMessageCrc;
 
-    nb::handle message_pytype = coreDatabase->GetMessageType(metadata.usMessageId, crc);
+    nb::handle message_pytype = database->GetMessageType(metadata.usMessageId, crc);
     if (message_pytype.is_none())
     {
         // Fallback to latest CRC

--- a/python/src/py_oem/bindings/py_message_objects.cpp
+++ b/python/src/py_oem/bindings/py_message_objects.cpp
@@ -54,7 +54,6 @@ py_common::PyMessageData py_oem::PyEncodableField::PyEncode(ENCODE_FORMAT format
     STATUS status;
     MessageDataStruct message_data = MessageDataStruct();
     const py_oem::DatabaseExtras& extras = py_oem::GetDatabaseExtras(*parentDb);
-    RxConfigHandler* pclRxConfigHandler = extras.rxConfigHandler.get();
 
     // Allocate more space for JSON messages.
     // A TRACKSTAT message can use about 47k bytes when encoded as JSON.
@@ -62,7 +61,7 @@ py_common::PyMessageData py_oem::PyEncodableField::PyEncode(ENCODE_FORMAT format
     uint8_t buffer[MESSAGE_SIZE_MAX * 3];
     auto buf_ptr = reinterpret_cast<uint8_t*>(&buffer);
     uint32_t buf_size = MESSAGE_SIZE_MAX * 3;
-    if (pclRxConfigHandler->IsRxConfigTypeMsg(this->header.usMessageId))
+    if (extras.rxConfigHandler->IsRxConfigTypeMsg(this->header.usMessageId))
     {
         status = extras.rxConfigHandler->Encode(&buf_ptr, buf_size, this->header, this->fields, message_data, format);
     }

--- a/python/src/py_oem/bindings/range_decompressor.cpp
+++ b/python/src/py_oem/bindings/range_decompressor.cpp
@@ -18,9 +18,9 @@ void py_oem::init_novatel_range_decompressor(nb::module_& m)
     nb::class_<oem::RangeDecompressor>(m, "RangeDecompressor")
         .def(
             "__init__",
-            [](oem::RangeDecompressor* t, py_common::PyMessageDatabaseCore::Ptr message_db) {
+            [](oem::RangeDecompressor* t, py_common::PyMessageDatabase::Ptr message_db) {
                 if (!message_db) { message_db = py_oem::MessageDbSingleton::get(); };
-                new (t) oem::RangeDecompressor(message_db);
+                new (t) oem::RangeDecompressor(message_db->core());
                 t->GetLogger()->warn(
                     "The RangeDecompressor interface is currently unstable! It may undergo breaking changes between minor version increments.");
             },

--- a/python/src/py_oem/bindings/rxconfig_handler.cpp
+++ b/python/src/py_oem/bindings/rxconfig_handler.cpp
@@ -16,9 +16,9 @@ void py_oem::init_novatel_rxconfig_handler(nb::module_& m)
     nb::class_<oem::RxConfigHandler>(m, "RxConfigHandler")
         .def(
             "__init__",
-            [](oem::RxConfigHandler* t, py_common::PyMessageDatabaseCore::Ptr message_db) {
+            [](oem::RxConfigHandler* t, py_common::PyMessageDatabase::Ptr message_db) {
                 if (!message_db) { message_db = py_oem::MessageDbSingleton::get(); };
-                new (t) oem::RxConfigHandler(message_db);
+                new (t) oem::RxConfigHandler(message_db->core());
                 t->GetLogger()->warn(
                     "The RXConfigHandler interface is currently unstable! It may undergo breaking changes between minor version increments.");
             },

--- a/python/src/py_oem/implementations/message_database.cpp
+++ b/python/src/py_oem/implementations/message_database.cpp
@@ -10,7 +10,8 @@ void py_oem::ThrowRXConfigConstructionError() { throw py_common::FailureExceptio
 
 void* py_oem::AllocateDatabaseExtras(py_common::PyMessageDatabaseCore* database)
 {
-    auto* extras = new DatabaseExtras();
+    // Use unique pointer for cleanup if method throws
+    auto extras = std::make_unique<DatabaseExtras>();
     extras->database = database;
 
     auto ownedDb = database->GetSharedPtr();
@@ -22,11 +23,10 @@ void* py_oem::AllocateDatabaseExtras(py_common::PyMessageDatabaseCore* database)
     }
     catch (const std::invalid_argument&)
     {
-        delete extras;
         ThrowRXConfigConstructionError();
     }
 
-    return extras;
+    return extras.release();
 }
 
 void py_oem::FreeDatabaseExtras(void* extras)
@@ -35,22 +35,13 @@ void py_oem::FreeDatabaseExtras(void* extras)
     delete typedExtras;
 }
 
-py_oem::DatabaseExtras& py_oem::GetDatabaseExtras(py_common::PyMessageDatabaseCore& database)
-{
-    if (database.GetMessageFamily() != "OEM") { throw py_common::FailureException("Database extras are only available for OEM message families."); }
-
-    void* extras = database.GetMessageFamilyExtras();
-    if (!extras) { throw py_common::FailureException("OEM database extras are not initialized for this database."); }
-
-    return *static_cast<DatabaseExtras*>(extras);
-}
-
 const py_oem::DatabaseExtras& py_oem::GetDatabaseExtras(const py_common::PyMessageDatabaseCore& database)
 {
-    if (database.GetMessageFamily() != "OEM") { throw py_common::FailureException("Database extras are only available for OEM message families."); }
+    // TODO: This check can be removed if we ever add safeguards around modifying database after initial use
+    if (database.GetMessageFamily() != "OEM" && database.GetMessageFamily() != "")
+    {
+        throw py_common::FailureException("Database extras are only available for OEM message families.");
+    }
 
-    void* extras = database.GetMessageFamilyExtras();
-    if (!extras) { throw py_common::FailureException("OEM database extras are not initialized for this database."); }
-
-    return *static_cast<const DatabaseExtras*>(extras);
+    return *static_cast<const DatabaseExtras*>(database.GetMessageFamilyExtras());
 }

--- a/python/src/py_oem/implementations/message_database.cpp
+++ b/python/src/py_oem/implementations/message_database.cpp
@@ -6,17 +6,51 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace novatel::edie;
 
-void py_oem::PyMessageDatabase::Initialize()
+void py_oem::ThrowRXConfigConstructionError() { throw py_common::FailureException("RXConfig definition in database cannot be handled."); }
+
+void* py_oem::AllocateDatabaseExtras(py_common::PyMessageDatabaseCore* database)
 {
-    pclEncoder = std::make_unique<oem::Encoder>(this->pclMessageDb);
+    auto* extras = new DatabaseExtras();
+    extras->database = database;
+
+    auto ownedDb = database->GetSharedPtr();
+    extras->encoder = std::make_unique<oem::Encoder>(ownedDb);
+
     try
     {
-        pclRxConfigHandler = std::make_unique<oem::RxConfigHandler>(this->pclMessageDb);
+        extras->rxConfigHandler = std::make_unique<oem::RxConfigHandler>(ownedDb);
     }
     catch (const std::invalid_argument&)
     {
+        delete extras;
         ThrowRXConfigConstructionError();
     }
+
+    return extras;
 }
 
-py_oem::PyMessageDatabase::PyMessageDatabase(py_common::PyMessageDatabaseCore::Ptr message_db) : pclMessageDb(message_db) { Initialize(); }
+void py_oem::FreeDatabaseExtras(void* extras)
+{
+    auto* typedExtras = static_cast<DatabaseExtras*>(extras);
+    delete typedExtras;
+}
+
+py_oem::DatabaseExtras& py_oem::GetDatabaseExtras(py_common::PyMessageDatabaseCore& database)
+{
+    if (database.GetMessageFamily() != "OEM") { throw py_common::FailureException("Database extras are only available for OEM message families."); }
+
+    void* extras = database.GetMessageFamilyExtras();
+    if (!extras) { throw py_common::FailureException("OEM database extras are not initialized for this database."); }
+
+    return *static_cast<DatabaseExtras*>(extras);
+}
+
+const py_oem::DatabaseExtras& py_oem::GetDatabaseExtras(const py_common::PyMessageDatabaseCore& database)
+{
+    if (database.GetMessageFamily() != "OEM") { throw py_common::FailureException("Database extras are only available for OEM message families."); }
+
+    void* extras = database.GetMessageFamilyExtras();
+    if (!extras) { throw py_common::FailureException("OEM database extras are not initialized for this database."); }
+
+    return *static_cast<const DatabaseExtras*>(extras);
+}

--- a/python/src/py_oem/implementations/message_database.cpp
+++ b/python/src/py_oem/implementations/message_database.cpp
@@ -8,7 +8,7 @@ using namespace novatel::edie;
 
 void py_oem::ThrowRXConfigConstructionError() { throw py_common::FailureException("RXConfig definition in database cannot be handled."); }
 
-std::unique_ptr<py_common::MessageDBExtrasBase> py_oem::AllocateDatabaseExtras(py_common::PyMessageDatabaseCore::Ptr database)
+std::unique_ptr<py_common::MessageDBExtrasBase> py_oem::AllocateDatabaseExtras(MessageDatabase::Ptr database)
 {
     auto extras = std::make_unique<DatabaseExtras>();
     extras->encoder = std::make_unique<oem::Encoder>(database);

--- a/python/src/py_oem/implementations/message_database.cpp
+++ b/python/src/py_oem/implementations/message_database.cpp
@@ -8,9 +8,8 @@ using namespace novatel::edie;
 
 void py_oem::ThrowRXConfigConstructionError() { throw py_common::FailureException("RXConfig definition in database cannot be handled."); }
 
-void* py_oem::AllocateDatabaseExtras(py_common::PyMessageDatabaseCore* database)
+std::unique_ptr<py_common::MessageDBExtrasBase> py_oem::AllocateDatabaseExtras(py_common::PyMessageDatabaseCore* database)
 {
-    // Use unique pointer for cleanup if method throws
     auto extras = std::make_unique<DatabaseExtras>();
     extras->database = database;
 
@@ -26,22 +25,12 @@ void* py_oem::AllocateDatabaseExtras(py_common::PyMessageDatabaseCore* database)
         ThrowRXConfigConstructionError();
     }
 
-    return extras.release();
-}
-
-void py_oem::FreeDatabaseExtras(void* extras)
-{
-    auto* typedExtras = static_cast<DatabaseExtras*>(extras);
-    delete typedExtras;
+    return extras;
 }
 
 const py_oem::DatabaseExtras& py_oem::GetDatabaseExtras(const py_common::PyMessageDatabaseCore& database)
 {
-    // TODO: This check can be removed if we ever add safeguards around modifying database after initial use
-    if (database.GetMessageFamily() != "OEM" && database.GetMessageFamily() != "")
-    {
-        throw py_common::FailureException("Database extras are only available for OEM message families.");
-    }
-
-    return *static_cast<const DatabaseExtras*>(database.GetMessageFamilyExtras());
+    const auto* typedExtras = dynamic_cast<const DatabaseExtras*>(database.GetMessageFamilyExtras());
+    if (!typedExtras) { throw py_common::FailureException("Database extras are only available for OEM message families."); }
+    return *typedExtras;
 }

--- a/python/src/py_oem/implementations/message_database.cpp
+++ b/python/src/py_oem/implementations/message_database.cpp
@@ -8,17 +8,14 @@ using namespace novatel::edie;
 
 void py_oem::ThrowRXConfigConstructionError() { throw py_common::FailureException("RXConfig definition in database cannot be handled."); }
 
-std::unique_ptr<py_common::MessageDBExtrasBase> py_oem::AllocateDatabaseExtras(py_common::PyMessageDatabaseCore* database)
+std::unique_ptr<py_common::MessageDBExtrasBase> py_oem::AllocateDatabaseExtras(py_common::PyMessageDatabaseCore::Ptr database)
 {
     auto extras = std::make_unique<DatabaseExtras>();
-    extras->database = database;
-
-    auto ownedDb = database->GetSharedPtr();
-    extras->encoder = std::make_unique<oem::Encoder>(ownedDb);
+    extras->encoder = std::make_unique<oem::Encoder>(database);
 
     try
     {
-        extras->rxConfigHandler = std::make_unique<oem::RxConfigHandler>(ownedDb);
+        extras->rxConfigHandler = std::make_unique<oem::RxConfigHandler>(database);
     }
     catch (const std::invalid_argument&)
     {
@@ -28,7 +25,7 @@ std::unique_ptr<py_common::MessageDBExtrasBase> py_oem::AllocateDatabaseExtras(p
     return extras;
 }
 
-const py_oem::DatabaseExtras& py_oem::GetDatabaseExtras(const py_common::PyMessageDatabaseCore& database)
+const py_oem::DatabaseExtras& py_oem::GetDatabaseExtras(const py_common::PyMessageDatabase& database)
 {
     const auto* typedExtras = dynamic_cast<const DatabaseExtras*>(database.GetMessageFamilyExtras());
     if (!typedExtras) { throw py_common::FailureException("Database extras are only available for OEM message families."); }

--- a/python/src/py_oem/implementations/message_db_singleton.cpp
+++ b/python/src/py_oem/implementations/message_db_singleton.cpp
@@ -25,7 +25,7 @@ py_common::PyMessageDatabaseCore::Ptr& py_oem::MessageDbSingleton::get()
     if (!nb::cast<bool>(builtins.attr("bool")(module_spec)))
     {
         // If the package does not exist, return an empty database
-        json_db = std::make_shared<py_common::PyMessageDatabaseCore>(MessageDatabase());
+        json_db = py_common::PyMessageDatabaseCore::Create();
         return json_db;
     }
 
@@ -34,7 +34,7 @@ py_common::PyMessageDatabaseCore::Ptr& py_oem::MessageDbSingleton::get()
     if (!nb::cast<bool>(builtins.attr("bool")(module_origin)))
     {
         // Return an empty database if the package is empty
-        json_db = std::make_shared<py_common::PyMessageDatabaseCore>(MessageDatabase());
+        json_db = py_common::PyMessageDatabaseCore::Create();
         return json_db;
     }
     nb::object novatel_edie_path = os_path.attr("dirname")(module_spec.attr("origin"));
@@ -43,11 +43,11 @@ py_common::PyMessageDatabaseCore::Ptr& py_oem::MessageDbSingleton::get()
     bool db_exists = nb::cast<bool>(os_path.attr("isfile")(db_path));
     if (!db_exists)
     {
-        json_db = std::make_shared<py_common::PyMessageDatabaseCore>(MessageDatabase());
+        json_db = py_common::PyMessageDatabaseCore::Create();
         return json_db;
     }
     // If the database file exists, load it
     std::string default_json_db_path = nb::cast<std::string>(db_path);
-    json_db = std::make_shared<py_common::PyMessageDatabaseCore>(*LoadJsonDbFile(default_json_db_path));
+    json_db = py_common::PyMessageDatabaseCore::Create(*LoadJsonDbFile(default_json_db_path));
     return json_db;
 }

--- a/python/src/py_oem/implementations/message_db_singleton.cpp
+++ b/python/src/py_oem/implementations/message_db_singleton.cpp
@@ -8,9 +8,9 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace novatel::edie;
 
-py_common::PyMessageDatabaseCore::Ptr& py_oem::MessageDbSingleton::get()
+py_common::PyMessageDatabase::Ptr& py_oem::MessageDbSingleton::get()
 {
-    static py_common::PyMessageDatabaseCore::Ptr json_db = nullptr;
+    static py_common::PyMessageDatabase::Ptr json_db = nullptr;
 
     // If the database has already been loaded, return it
     if (json_db) { return json_db; }
@@ -25,7 +25,7 @@ py_common::PyMessageDatabaseCore::Ptr& py_oem::MessageDbSingleton::get()
     if (!nb::cast<bool>(builtins.attr("bool")(module_spec)))
     {
         // If the package does not exist, return an empty database
-        json_db = py_common::PyMessageDatabaseCore::Create();
+        json_db = std::make_shared<py_common::PyMessageDatabase>();
         return json_db;
     }
 
@@ -34,7 +34,7 @@ py_common::PyMessageDatabaseCore::Ptr& py_oem::MessageDbSingleton::get()
     if (!nb::cast<bool>(builtins.attr("bool")(module_origin)))
     {
         // Return an empty database if the package is empty
-        json_db = py_common::PyMessageDatabaseCore::Create();
+        json_db = std::make_shared<py_common::PyMessageDatabase>();
         return json_db;
     }
     nb::object novatel_edie_path = os_path.attr("dirname")(module_spec.attr("origin"));
@@ -43,11 +43,11 @@ py_common::PyMessageDatabaseCore::Ptr& py_oem::MessageDbSingleton::get()
     bool db_exists = nb::cast<bool>(os_path.attr("isfile")(db_path));
     if (!db_exists)
     {
-        json_db = py_common::PyMessageDatabaseCore::Create();
+        json_db = std::make_shared<py_common::PyMessageDatabase>();
         return json_db;
     }
     // If the database file exists, load it
     std::string default_json_db_path = nb::cast<std::string>(db_path);
-    json_db = py_common::PyMessageDatabaseCore::Create(*LoadJsonDbFile(default_json_db_path));
+    json_db = std::make_shared<py_common::PyMessageDatabase>(std::move(*LoadJsonDbFile(default_json_db_path)));
     return json_db;
 }

--- a/python/test/test_message_database.py
+++ b/python/test/test_message_database.py
@@ -22,6 +22,9 @@
 #
 ################################################################################=
 
+import gc
+import weakref
+
 import pytest
 
 from novatel_edie import MessageDatabase, FailureException
@@ -71,6 +74,26 @@ def test_remove_message(json_db: MessageDatabase):
     assert new_db.get_msg_type("BESTPOS") is None
     assert new_db.get_msg_def(range_id) == range_def
     assert new_db.get_msg_type("RANGE") is new_range_type
+
+def test_database_does_not_leak():
+    """The OEM Encoder/RxConfigHandler used to hold shared_ptrs back to the
+    database core, creating a cycle that prevented deallocation. The
+    PyMessageDatabase wrapper now owns the extras alongside the core, breaking
+    that cycle so a dropped database is actually collected."""
+    json = (
+        '{"enums": ['
+        '{"name": "Responses", "_id": "0", "enumerators": []},'
+        '{"name": "Commands", "_id": "0", "enumerators": []},'
+        '{"name": "PortAddress", "_id": "0", "enumerators": []},'
+        '{"name": "GPSTimeStatus", "_id": "0", "enumerators": []}'
+        '], "messages": []}'
+    )
+    db = MessageDatabase.from_string(json)
+    db_ref = weakref.ref(db)
+    del db
+    gc.collect()
+    assert db_ref() is None, "MessageDatabase kept alive by an internal cycle (encoder/rxconfig back-refs)"
+
 
 def test_merge(json_db: MessageDatabase):
     """Tests that one databases messages can be merged into another."""

--- a/python/test/test_message_database.py
+++ b/python/test/test_message_database.py
@@ -22,9 +22,6 @@
 #
 ################################################################################=
 
-import gc
-import weakref
-
 import pytest
 
 from novatel_edie import MessageDatabase, FailureException
@@ -74,26 +71,6 @@ def test_remove_message(json_db: MessageDatabase):
     assert new_db.get_msg_type("BESTPOS") is None
     assert new_db.get_msg_def(range_id) == range_def
     assert new_db.get_msg_type("RANGE") is new_range_type
-
-def test_database_does_not_leak():
-    """The OEM Encoder/RxConfigHandler used to hold shared_ptrs back to the
-    database core, creating a cycle that prevented deallocation. The
-    PyMessageDatabase wrapper now owns the extras alongside the core, breaking
-    that cycle so a dropped database is actually collected."""
-    json = (
-        '{"enums": ['
-        '{"name": "Responses", "_id": "0", "enumerators": []},'
-        '{"name": "Commands", "_id": "0", "enumerators": []},'
-        '{"name": "PortAddress", "_id": "0", "enumerators": []},'
-        '{"name": "GPSTimeStatus", "_id": "0", "enumerators": []}'
-        '], "messages": []}'
-    )
-    db = MessageDatabase.from_string(json)
-    db_ref = weakref.ref(db)
-    del db
-    gc.collect()
-    assert db_ref() is None, "MessageDatabase kept alive by an internal cycle (encoder/rxconfig back-refs)"
-
 
 def test_merge(json_db: MessageDatabase):
     """Tests that one databases messages can be merged into another."""


### PR DESCRIPTION
# Consolidate Database with Registration-Based Extras

Replaces the two-class database arrangement on main (`py_common::PyMessageDatabaseCore` + `py_oem::PyMessageDatabase`) with a single Python-facing `py_common::PyMessageDatabase` that owns the underlying `MessageDatabase`, its Python type caches, and any registered message-family extras (e.g. OEM `Encoder`, `RxConfigHandler`).

Family-specific components attach via a registration callback instead of being hard-coded into an OEM-specific wrapper class.

## Key Changes

- **Removed** `py_common::PyMessageDatabaseCore` — its Python type caches, definition mappings, `bindToModule`, and family resolution are now on `PyMessageDatabase`.
- **Removed** `py_oem::PyMessageDatabase` — its `Encoder` + `RxConfigHandler` ownership absorbed by the new `py_common::PyMessageDatabase` via the OEM-specific `DatabaseExtras` allocator.
- **Added** `py_common::PyMessageDatabase` — single class holding `shared_ptr<MessageDatabase>` + Python type caches + extras. Bound to Python as `MessageDatabase`.
- **Added** `MessageFamilyRegistration` — replaces the simple `family → nb::handle` map with `{messageType, allocateExtras}`, so families can attach C++ components without modifying py_common.
- **Added** `py_oem::DatabaseExtras` — OEM allocator that produces the `Encoder` and `RxConfigHandler` previously embedded directly in `py_oem::PyMessageDatabase`.
- **Added** public `MessageDatabase::SetMessageFamily(...)` on the C++ base class, so the new wrapper can mutate metadata without inheriting.
- **Changed** parsers / decoders / file_parser / commander / rxconfig_handler / range_decompressor bindings to accept `PyMessageDatabase::Ptr` and forward `wrapper->core()` to the underlying C++ class.

## Benefits

- **Single point of ownership** for a given database. Python users, decoders, parsers, fields, and messages all reference the same `PyMessageDatabase` instance instead of a wrapper-around-a-core split across two namespaces.
- **Family-agnostic core.** OEM-specific components (`Encoder`, `RxConfigHandler`) are no longer hard-coded into a py_oem class. They attach via a registration callback, so future message families can plug in their own extras with no changes to py_common.
- **Reduces responsibility of Decoder and Parser.** They hold a database pointer rather than reconstructing a family-specific wrapper around it.
- **Allows for more powerful generic code to exist in the database class.** In particular this refactor makes it much more feasible to support pythonic message construction. E.g. `BESTPOS(latitude=0, longitude=0)`.
