### PR TITLE
Initialize python logger on package import

### DIFF
--- a/python/include/py_common/py_logger.hpp
+++ b/python/include/py_common/py_logger.hpp
@@ -239,6 +239,17 @@ class PyLoggerManager : public LoggerManager
 
   public:
     //----------------------------------------------------------------------------
+    //! \brief Constructs the PyLoggerManager.
+    //!
+    //! Initializes a `novatel_edie` logger on the python side.
+    //----------------------------------------------------------------------------
+    PyLoggerManager()
+    {
+        nb::handle logging = nb::module_::import_("logging");
+        logging.attr("getLogger")("novatel_edie");
+    }
+
+    //----------------------------------------------------------------------------
     //! \brief Destructs the PyLoggerManager.
     //!
     //! Shutdown should be called first.


### PR DESCRIPTION
Initializes the "novatel_edie" python logger when the package is imported instead of doing it lazily on use. This makes the `logging.getChildren` function more convenient to use with the package. 