### PR TITLE
Fix double field format specifiers to prevent encoding errors

### DIFF
--- a/src/decoders/oem/src/encoder.cpp
+++ b/src/decoders/oem/src/encoder.cpp
@@ -237,13 +237,20 @@ void Encoder::InitFieldMaps()
 
     jsonFieldMap[CalculateBlockCrc32("e")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::scientific, fc_.fieldDef->precision);
+        if (fc_.fieldDef->dataType.length == 4)
+        {
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::scientific,
+                                      fc_.fieldDef->precision);
+        }
+        if (fc_.fieldDef->dataType.length == 8)
+        {
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::scientific,
+                                      fc_.fieldDef->precision);
+        }
+        return false;
     };
 
-    jsonFieldMap[CalculateBlockCrc32("le")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
-                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::scientific, fc_.fieldDef->precision);
-    };
+    jsonFieldMap[CalculateBlockCrc32("le")] = jsonFieldMap[CalculateBlockCrc32("e")];
 
     jsonFieldMap[CalculateBlockCrc32("k")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {


### PR DESCRIPTION
## Background
Hello! Thanks for your work on this repo. Here's a bug I found while using it and how I fixed it.

While testing with IONUTC messages, I encountered `Exception: std::get: wrong index for variant` when trying to encode to JSON format.

After investigating, I found that some DOUBLE fields across 10 messages were using the `%e` format specifier, which routes to a handler expecting `float` type. Since these fields store `double` values, the encoder throws the exception when calling `std::get<float>()`.

## My Solution
Changed DOUBLE fields in `database/database.json` to use `%le` instead of using `%e`. 

Tested encoding IONUTC messages before and after the fix:
- **Before**: Exception thrown during JSON encoding
- **After**: Successfully encodes with correct double precision values and sends correct response


Thanks again and please let me know if there is anything you would like me to update about this PR.