### PR TITLE
Cleanup Logging Behavior

### DIFF
--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -662,6 +662,15 @@ class MessageDatabase
     using ConstPtr = std::shared_ptr<const MessageDatabase>;
 };
 
+//----------------------------------------------------------------------------
+//! \brief Report a missing message definition. Logs at info the first time a
+//! given ID is reported on the calling thread, and at debug thereafter.
+//
+//! \param[in] pclLogger_ The logger to emit the notice through.
+//! \param[in] iMsgId_ The message ID with no matching definition.
+//----------------------------------------------------------------------------
+void LogMissingMsgDef(spdlog::logger& pclLogger_, int32_t iMsgId_);
+
 } // namespace novatel::edie
 
 #endif

--- a/src/decoders/common/src/message_database.cpp
+++ b/src/decoders/common/src/message_database.cpp
@@ -26,6 +26,8 @@
 
 #include "novatel_edie/decoders/common/message_database.hpp"
 
+#include <unordered_set>
+
 #include "novatel_edie/decoders/common/common.hpp"
 
 namespace novatel::edie {
@@ -142,6 +144,15 @@ MessageDefinition::ConstPtr MessageDatabase::GetMsgDef(const int32_t iMsgId_) co
 {
     const auto it = mMessageId.find(iMsgId_);
     return it != mMessageId.end() ? it->second : nullptr;
+}
+
+//-----------------------------------------------------------------------
+void LogMissingMsgDef(spdlog::logger& pclLogger_, const int32_t iMsgId_)
+{
+    thread_local std::unordered_set<int32_t> loggedMissingMsgDefs;
+    const bool bFirstReport = loggedMissingMsgDefs.insert(iMsgId_).second;
+    if (bFirstReport) { SPDLOG_LOGGER_INFO(&pclLogger_, "No log definition for ID {}", iMsgId_); }
+    else { SPDLOG_LOGGER_DEBUG(&pclLogger_, "No log definition for ID {}", iMsgId_); }
 }
 
 // -------------------------------------------------------------------------------------------------------

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -990,14 +990,14 @@ MessageDecoderBase::Decode(const unsigned char* pucMessage_, std::vector<FieldCo
 
         if (vMsgDef == nullptr)
         {
-            SPDLOG_LOGGER_INFO(pclMyLogger, "No log definition for ID {}", stMetaData_.usMessageId);
+            LogMissingMsgDef(*pclMyLogger, stMetaData_.usMessageId);
             return STATUS::NO_DEFINITION;
         }
     }
 
     if (stMetaData_.messageName == "RXCONFIG")
     {
-        SPDLOG_LOGGER_INFO(pclMyLogger, "RXCONFIG payload decoding is unsupported by this version of EDIE. Support coming soon!");
+        SPDLOG_LOGGER_INFO(pclMyLogger, "RXCONFIG payload must be decoded via RxConfigHandler, not MessageDecoder.");
         return STATUS::UNSUPPORTED;
     }
     const std::vector<BaseField::Ptr>& msgFields =


### PR DESCRIPTION
Makes the missing definition log less annoying when logging at INFO level and update message decoder log to better reflect current state of project.