### PR TITLE
Python Message Database + Message Definition Structs Refactor

### DIFF
--- a/include/novatel_edie/decoders/common/encoder.hpp
+++ b/include/novatel_edie/decoders/common/encoder.hpp
@@ -562,7 +562,7 @@ template <typename Derived> class EncoderBase
                     break;
                 case FIELD_TYPE::ENUM: {
                     const auto* enumField = dynamic_cast<const EnumField*>(field.fieldDef.get());
-                    if (enumField->length == 2)
+                    if (enumField->dataType.length == 2)
                     {
                         if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, GetEnumString(enumField->enumDef, std::get<int16_t>(field.fieldValue))) ||
                             !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))

--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -326,13 +326,14 @@ struct BaseField
     virtual ~BaseField() = default;
 
     //----------------------------------------------------------------------------
-    //! \brief Structural equality. Returns true when `other` has the same
-    //! runtime type and every visible field compares equal.
+    //! \brief Compares the non-cached fields. Returns true when `other` has the
+    //! same runtime type and every non-cached field compares equal.
     //
-    //! `EnumField::enumDef` is intentionally not part of the comparison —
-    //! it's a cache derived from `enumId`, and we want two `EnumField`
-    //! instances that name the same enum to compare equal regardless of
-    //! which database happens to have resolved their cache pointer.
+    //! Cached fields are intentionally excluded from the comparison. For
+    //! example, `EnumField::enumDef` is a cache derived from `enumId`, and we
+    //! want two `EnumField` instances that name the same enum to compare equal
+    //! regardless of which database happens to have resolved their cache
+    //! pointer.
     //----------------------------------------------------------------------------
     [[nodiscard]] bool operator==(const BaseField& other) const { return typeid(*this) == typeid(other) && equalsImpl(other); }
 
@@ -568,10 +569,11 @@ struct MessageDefinition
     const std::vector<BaseField::Ptr>& GetMsgDefFromCrc(spdlog::logger& pclLogger_, uint32_t uiMsgDefCrc_) const;
 
     //----------------------------------------------------------------------------
-    //! \brief Structural equality. Two `MessageDefinition`s compare equal if
-    //! every scalar field matches and every `BaseField::Ptr` in `fields`
-    //! dereferences to a structurally-equal field. Pointer identity is not
-    //! required, so a deep-copied definition compares equal to its source.
+    //! \brief Compares the non-cached fields. Two `MessageDefinition`s compare
+    //! equal if every scalar field matches and every `BaseField::Ptr` in
+    //! `fields` dereferences to an equal field (which likewise compares only
+    //! non-cached fields). Pointer identity is not required, so a deep-copied
+    //! definition compares equal to its source.
     //----------------------------------------------------------------------------
     [[nodiscard]] bool operator==(const MessageDefinition& other) const
     {

--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -226,6 +226,47 @@ struct EnumDefinition
 
     using Ptr = std::shared_ptr<EnumDefinition>;
     using ConstPtr = std::shared_ptr<const EnumDefinition>;
+
+    EnumDefinition() = default;
+    ~EnumDefinition() = default;
+
+    //----------------------------------------------------------------------------
+    //! \brief Deep copy. The lookup maps are rebuilt against the new
+    //! `enumerators` vector — a default copy would alias the source's
+    //! enumerator strings via the `string_view` keys, dangling once the source
+    //! is destroyed.
+    //----------------------------------------------------------------------------
+    EnumDefinition(const EnumDefinition& other) : _id(other._id), name(other.name), enumerators(other.enumerators), unknownValue(other.unknownValue)
+    {
+        for (const auto& enumerator : enumerators)
+        {
+            nameValue[enumerator.name] = enumerator.value;
+            valueName[enumerator.value] = enumerator.name;
+            descriptionValue[enumerator.description] = enumerator.value;
+        }
+    }
+
+    EnumDefinition& operator=(const EnumDefinition& other)
+    {
+        if (this == &other) { return *this; }
+        _id = other._id;
+        name = other.name;
+        enumerators = other.enumerators;
+        unknownValue = other.unknownValue;
+        nameValue.clear();
+        valueName.clear();
+        descriptionValue.clear();
+        for (const auto& enumerator : enumerators)
+        {
+            nameValue[enumerator.name] = enumerator.value;
+            valueName[enumerator.value] = enumerator.name;
+            descriptionValue[enumerator.description] = enumerator.value;
+        }
+        return *this;
+    }
+
+    EnumDefinition(EnumDefinition&&) = default;
+    EnumDefinition& operator=(EnumDefinition&&) = default;
 };
 
 //-----------------------------------------------------------------------
@@ -522,6 +563,49 @@ struct MessageDefinition
     }
 
     [[nodiscard]] bool operator!=(const MessageDefinition& other) const { return !(*this == other); }
+
+    MessageDefinition() = default;
+    ~MessageDefinition() = default;
+
+    //----------------------------------------------------------------------------
+    //! \brief Deep copy. The default copy would alias every `BaseField::Ptr`
+    //! in `fields`; this walks each variant and replaces it with
+    //! `field->clone()` so the new definition shares no field storage with
+    //! the source.
+    //----------------------------------------------------------------------------
+    MessageDefinition(const MessageDefinition& other)
+        : _id(other._id), logID(other.logID), name(other.name), description(other.description), messageStyle(other.messageStyle),
+          latestMessageCrc(other.latestMessageCrc)
+    {
+        for (const auto& [crc, fieldVec] : other.fields)
+        {
+            auto& copyVec = fields[crc];
+            copyVec.reserve(fieldVec.size());
+            for (const auto& f : fieldVec) { copyVec.push_back(f ? f->clone() : nullptr); }
+        }
+    }
+
+    MessageDefinition& operator=(const MessageDefinition& other)
+    {
+        if (this == &other) { return *this; }
+        _id = other._id;
+        logID = other.logID;
+        name = other.name;
+        description = other.description;
+        messageStyle = other.messageStyle;
+        latestMessageCrc = other.latestMessageCrc;
+        fields.clear();
+        for (const auto& [crc, fieldVec] : other.fields)
+        {
+            auto& copyVec = fields[crc];
+            copyVec.reserve(fieldVec.size());
+            for (const auto& f : fieldVec) { copyVec.push_back(f ? f->clone() : nullptr); }
+        }
+        return *this;
+    }
+
+    MessageDefinition(MessageDefinition&&) = default;
+    MessageDefinition& operator=(MessageDefinition&&) = default;
 
     using Ptr = std::shared_ptr<MessageDefinition>;
     using ConstPtr = std::shared_ptr<const MessageDefinition>;

--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -513,7 +513,6 @@ struct MessageDefinition
     uint32_t logID{0};
     std::string name;
     std::string description;
-    std::string messageStyle;
     std::unordered_map<uint32_t, std::vector<BaseField::Ptr>> fields; // map of crc keys to field definitions
     uint32_t latestMessageCrc{0};
 
@@ -528,7 +527,7 @@ struct MessageDefinition
     [[nodiscard]] bool operator==(const MessageDefinition& other) const
     {
         if (_id != other._id || logID != other.logID || name != other.name || description != other.description ||
-            messageStyle != other.messageStyle || latestMessageCrc != other.latestMessageCrc || fields.size() != other.fields.size())
+            latestMessageCrc != other.latestMessageCrc || fields.size() != other.fields.size())
         {
             return false;
         }
@@ -562,8 +561,7 @@ struct MessageDefinition
     //! the source.
     //----------------------------------------------------------------------------
     MessageDefinition(const MessageDefinition& other)
-        : _id(other._id), logID(other.logID), name(other.name), description(other.description), messageStyle(other.messageStyle),
-          latestMessageCrc(other.latestMessageCrc)
+        : _id(other._id), logID(other.logID), name(other.name), description(other.description), latestMessageCrc(other.latestMessageCrc)
     {
         for (const auto& [crc, fieldVec] : other.fields)
         {
@@ -580,7 +578,6 @@ struct MessageDefinition
         logID = other.logID;
         name = other.name;
         description = other.description;
-        messageStyle = other.messageStyle;
         latestMessageCrc = other.latestMessageCrc;
         fields.clear();
         for (const auto& [crc, fieldVec] : other.fields)

--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -367,38 +367,43 @@ struct BaseField
 
     void SetConversion(std::string&& sConversion_)
     {
-        conversion = std::move(sConversion_);
-        width = {};
-        precision = {};
-
-        const char* sConvertString = conversion.c_str();
+        const char* sConvertString = sConversion_.c_str();
 
         if (*sConvertString != '%') { throw std::runtime_error("Encountered an unexpected character in conversion string"); }
-
         ++sConvertString;
 
+        std::optional<int32_t> newWidth;
         if (std::isdigit(*sConvertString))
         {
-            width = std::stoi(sConvertString);
-            sConvertString += std::to_string(*width).length();
+            newWidth = std::stoi(sConvertString);
+            sConvertString += std::to_string(*newWidth).length();
         }
 
         if (*sConvertString == '.') { ++sConvertString; }
 
+        std::optional<int32_t> newPrecision;
         if (std::isdigit(*sConvertString))
         {
-            precision = std::stoi(sConvertString);
-            sConvertString += std::to_string(*precision).length();
+            newPrecision = std::stoi(sConvertString);
+            sConvertString += std::to_string(*newPrecision).length();
         }
-
-        conversionHash = 0;
 
         if (!std::isalpha(*sConvertString)) { throw std::runtime_error("Conversion string must contain a character"); }
 
-        while (std::isalpha(*sConvertString)) { CalculateCharacterCrc32(conversionHash, *sConvertString++); }
+        uint32_t newHash = 0;
+        while (std::isalpha(*sConvertString)) { CalculateCharacterCrc32(newHash, *sConvertString++); }
 
         if (*sConvertString != '\0') { throw std::runtime_error("Encountered an unexpected character in conversion string"); }
 
+        conversion = std::move(sConversion_);
+        width = newWidth;
+        precision = newPrecision;
+        conversionHash = newHash;
+        RecomputeStringFlags();
+    }
+
+    void RecomputeStringFlags()
+    {
         isString = type == FIELD_TYPE::STRING || conversionHash == CalculateBlockCrc32("s") || conversionHash == CalculateBlockCrc32("S");
         isCsv = !isString && conversionHash != CalculateBlockCrc32("Z") && conversionHash != CalculateBlockCrc32("P");
     }
@@ -496,6 +501,23 @@ struct FieldArrayField : ArrayField
                     std::vector<std::shared_ptr<BaseField>> fields_)
         : ArrayField(std::move(name_), type_, std::move(conversion_), eDataTypeName_, arrayLength_), fields(std::move(fields_))
     {
+        uint32_t childTotal = 0;
+        for (const auto& f : fields)
+        {
+            if (!f) { continue; }
+            switch (f->type)
+            {
+            case FIELD_TYPE::SIMPLE:
+            case FIELD_TYPE::ENUM: childTotal += f->dataType.length; break;
+            case FIELD_TYPE::FIXED_LENGTH_ARRAY:
+            case FIELD_TYPE::VARIABLE_LENGTH_ARRAY:
+            case FIELD_TYPE::STRING:
+                if (const auto* a = dynamic_cast<const ArrayField*>(f.get())) { childTotal += f->dataType.length * a->arrayLength; }
+                break;
+            default: break;
+            }
+        }
+        fieldSize = arrayLength * childTotal;
     }
 
     [[nodiscard]] std::shared_ptr<BaseField> clone() const override

--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -306,22 +306,30 @@ struct BaseField
     FIELD_TYPE type{FIELD_TYPE::UNKNOWN};
     std::string description;
     std::string conversion;
-    uint32_t conversionHash{0ULL};       // cached
-    std::optional<int32_t> width;        // cached
-    std::optional<int32_t> precision;    // cached
-    bool isString{false};                // cached; has a FIELD_TYPE of STRING or conversion string of either %s or %S
-    bool isCsv{false};                   // cached; Ascii encoding of this field is comma-separated,
-                                         // true for arrays which are not strings and do not use the %Z or %P conversion strings
+    uint32_t conversionHash{0ULL};    // cached
+    std::optional<int32_t> width;     // cached
+    std::optional<int32_t> precision; // cached
+    bool isString{false};             // cached; has a FIELD_TYPE of STRING or conversion string of either %s or %S
+    bool isCsv{false};                // cached; Ascii encoding of this field is comma-separated,
+                                      // true for arrays which are not strings and do not use the %Z or %P conversion strings
     SimpleDataType dataType;
 
     BaseField() = default;
 
+    // TODO: Remove this? A DATA_TYPE should only have one length
     BaseField(std::string name_, const FIELD_TYPE type_, std::string&& sConversion_, const size_t length_, const DATA_TYPE eDataTypeName_)
         : name(std::move(name_)), type(type_)
     {
         SetConversion(std::move(sConversion_));
         dataType.length = static_cast<uint16_t>(length_);
         dataType.name = eDataTypeName_;
+    }
+
+    BaseField(std::string name_, FIELD_TYPE type_, std::string conversion_, DATA_TYPE eDataTypeName_) : name(std::move(name_)), type(type_)
+    {
+        dataType.name = eDataTypeName_;
+        dataType.length = static_cast<uint16_t>(DataTypeSize(eDataTypeName_));
+        if (!conversion_.empty()) { SetConversion(std::move(conversion_)); }
     }
 
     virtual ~BaseField() = default;
@@ -421,6 +429,13 @@ struct EnumField : BaseField
     std::string enumId;
     EnumDefinition::ConstPtr enumDef{nullptr}; // cached
 
+    EnumField() = default;
+
+    EnumField(std::string name_, FIELD_TYPE type_, std::string conversion_, DATA_TYPE eDataTypeName_, std::string enumId_)
+        : BaseField(std::move(name_), type_, std::move(conversion_), eDataTypeName_), enumId(std::move(enumId_))
+    {
+    }
+
     [[nodiscard]] std::shared_ptr<BaseField> clone() const override { return std::make_shared<EnumField>(*this); }
 
     using Ptr = std::shared_ptr<EnumField>;
@@ -445,6 +460,13 @@ struct ArrayField : BaseField
     std::string arrayLengthRef;
     uint8_t arrayLengthFieldSize{0}; // in bytes, only for variable-length and field arrays
 
+    ArrayField() = default;
+
+    ArrayField(std::string name_, FIELD_TYPE type_, std::string conversion_, DATA_TYPE eDataTypeName_, uint32_t arrayLength_)
+        : BaseField(std::move(name_), type_, std::move(conversion_), eDataTypeName_), arrayLength(arrayLength_)
+    {
+    }
+
     [[nodiscard]] std::shared_ptr<BaseField> clone() const override { return std::make_shared<ArrayField>(*this); }
 
     using Ptr = std::shared_ptr<ArrayField>;
@@ -467,6 +489,14 @@ struct FieldArrayField : ArrayField
 {
     uint32_t fieldSize{0}; // cached
     std::vector<std::shared_ptr<BaseField>> fields;
+
+    FieldArrayField() = default;
+
+    FieldArrayField(std::string name_, FIELD_TYPE type_, std::string conversion_, DATA_TYPE eDataTypeName_, uint32_t arrayLength_,
+                    std::vector<std::shared_ptr<BaseField>> fields_)
+        : ArrayField(std::move(name_), type_, std::move(conversion_), eDataTypeName_, arrayLength_), fields(std::move(fields_))
+    {
+    }
 
     [[nodiscard]] std::shared_ptr<BaseField> clone() const override
     {
@@ -562,6 +592,13 @@ struct MessageDefinition
 
     MessageDefinition() = default;
     ~MessageDefinition() = default;
+
+    MessageDefinition(std::string id_, uint32_t logID_, std::string name_, std::string description_, uint32_t latestMessageCrc_,
+                      std::unordered_map<uint32_t, std::vector<BaseField::Ptr>> fields_)
+        : _id(std::move(id_)), logID(logID_), name(std::move(name_)), description(std::move(description_)), fields(std::move(fields_)),
+          latestMessageCrc(latestMessageCrc_)
+    {
+    }
 
     //----------------------------------------------------------------------------
     //! \brief Deep copy. The default copy would alias every `BaseField::Ptr`

--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -219,9 +219,9 @@ struct EnumDefinition
     std::string _id;
     std::string name;
     std::vector<EnumDataType> enumerators;
-    std::unordered_map<std::string_view, uint32_t> nameValue;
-    std::unordered_map<std::string_view, uint32_t> descriptionValue;
-    std::unordered_map<uint32_t, std::string_view> valueName;
+    std::unordered_map<std::string_view, uint32_t> nameValue;        // cached
+    std::unordered_map<std::string_view, uint32_t> descriptionValue; // cached
+    std::unordered_map<uint32_t, std::string_view> valueName;        // cached
     uint32_t unknownValue;
 
     using Ptr = std::shared_ptr<EnumDefinition>;
@@ -297,12 +297,12 @@ struct BaseField
     FIELD_TYPE type{FIELD_TYPE::UNKNOWN};
     std::string description;
     std::string conversion;
-    uint32_t conversionHash{0ULL};
-    std::optional<int32_t> width;
-    std::optional<int32_t> precision;
-    bool isString{false}; // Has a FIELD_TYPE of STRING or conversion string of either %s or %S
-    bool isCsv{false};    // Ascii encoding of this field is comma-separated,
-                          // true for arrays which are not strings and do not use the %Z or %P conversion strings
+    uint32_t conversionHash{0ULL};       // cached
+    std::optional<int32_t> width;        // cached
+    std::optional<int32_t> precision;    // cached
+    bool isString{false};                // cached; has a FIELD_TYPE of STRING or conversion string of either %s or %S
+    bool isCsv{false};                   // cached; Ascii encoding of this field is comma-separated,
+                                         // true for arrays which are not strings and do not use the %Z or %P conversion strings
     SimpleDataType dataType;
 
     BaseField() = default;
@@ -376,6 +376,8 @@ struct BaseField
 
         conversionHash = 0;
 
+        if (!std::isalpha(*sConvertString)) { throw std::runtime_error("Conversion string must contain a character"); }
+
         while (std::isalpha(*sConvertString)) { CalculateCharacterCrc32(conversionHash, *sConvertString++); }
 
         if (*sConvertString != '\0') { throw std::runtime_error("Encountered an unexpected character in conversion string"); }
@@ -408,8 +410,7 @@ struct BaseField
 struct EnumField : BaseField
 {
     std::string enumId;
-    EnumDefinition::ConstPtr enumDef{nullptr};
-    uint32_t length{0};
+    EnumDefinition::ConstPtr enumDef{nullptr}; // cached
 
     [[nodiscard]] std::shared_ptr<BaseField> clone() const override { return std::make_shared<EnumField>(*this); }
 
@@ -421,7 +422,7 @@ struct EnumField : BaseField
     {
         if (!BaseField::equalsImpl(other)) { return false; }
         const auto& o = static_cast<const EnumField&>(other);
-        return enumId == o.enumId && length == o.length;
+        return enumId == o.enumId;
     }
 };
 
@@ -455,7 +456,7 @@ struct ArrayField : BaseField
 //-----------------------------------------------------------------------
 struct FieldArrayField : ArrayField
 {
-    uint32_t fieldSize{0};
+    uint32_t fieldSize{0}; // cached
     std::vector<std::shared_ptr<BaseField>> fields;
 
     [[nodiscard]] std::shared_ptr<BaseField> clone() const override

--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -399,10 +399,10 @@ struct BaseField
         width = newWidth;
         precision = newPrecision;
         conversionHash = newHash;
-        RecomputeStringFlags();
+        ComputeStringFlags();
     }
 
-    void RecomputeStringFlags()
+    void ComputeStringFlags()
     {
         isString = type == FIELD_TYPE::STRING || conversionHash == CalculateBlockCrc32("s") || conversionHash == CalculateBlockCrc32("S");
         isCsv = !isString && conversionHash != CalculateBlockCrc32("Z") && conversionHash != CalculateBlockCrc32("P");
@@ -420,8 +420,7 @@ struct BaseField
     [[nodiscard]] virtual bool equalsImpl(const BaseField& other) const
     {
         return name == other.name && type == other.type && description == other.description && conversion == other.conversion &&
-               conversionHash == other.conversionHash && width == other.width && precision == other.precision && isString == other.isString &&
-               isCsv == other.isCsv && dataType == other.dataType;
+               dataType == other.dataType;
     }
 };
 
@@ -535,15 +534,13 @@ struct FieldArrayField : ArrayField
     {
         if (!ArrayField::equalsImpl(other)) { return false; }
         const auto& o = static_cast<const FieldArrayField&>(other);
-        if (fieldSize != o.fieldSize) { return false; }
         if (fields.size() != o.fields.size()) { return false; }
         for (size_t i = 0; i < fields.size(); ++i)
         {
-            if (!fields[i] || !o.fields[i])
-            {
-                if (fields[i] != o.fields[i]) { return false; }
-            }
-            else if (*fields[i] != *o.fields[i]) { return false; }
+            const bool lhs_null = !fields[i];
+            const bool rhs_null = !o.fields[i];
+            if (lhs_null != rhs_null) { return false; }
+            if (!lhs_null && *fields[i] != *o.fields[i]) { return false; }
         }
         return true;
     }
@@ -600,11 +597,10 @@ struct MessageDefinition
             if (fieldVec.size() != otherVec.size()) { return false; }
             for (size_t i = 0; i < fieldVec.size(); ++i)
             {
-                if (!fieldVec[i] || !otherVec[i])
-                {
-                    if (fieldVec[i] != otherVec[i]) { return false; }
-                }
-                else if (*fieldVec[i] != *otherVec[i]) { return false; }
+                const bool lhs_null = !fieldVec[i];
+                const bool rhs_null = !otherVec[i];
+                if (lhs_null != rhs_null) { return false; }
+                if (!lhs_null && *fieldVec[i] != *otherVec[i]) { return false; }
             }
         }
         return true;

--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -202,6 +202,12 @@ struct EnumDataType
     uint32_t value{0};
     std::string name;
     std::string description;
+
+    [[nodiscard]] bool operator==(const EnumDataType& other) const
+    {
+        return value == other.value && name == other.name && description == other.description;
+    }
+    [[nodiscard]] bool operator!=(const EnumDataType& other) const { return !(*this == other); }
 };
 
 //-----------------------------------------------------------------------
@@ -232,6 +238,12 @@ struct BaseDataType
     DATA_TYPE name{DATA_TYPE::UNKNOWN};
     uint16_t length{0};
     std::string description;
+
+    [[nodiscard]] bool operator==(const BaseDataType& other) const
+    {
+        return name == other.name && length == other.length && description == other.description;
+    }
+    [[nodiscard]] bool operator!=(const BaseDataType& other) const { return !(*this == other); }
 };
 
 //-----------------------------------------------------------------------
@@ -242,6 +254,9 @@ struct BaseDataType
 struct SimpleDataType : BaseDataType
 {
     std::unordered_map<int32_t, EnumDataType> enums;
+
+    [[nodiscard]] bool operator==(const SimpleDataType& other) const { return BaseDataType::operator==(other) && enums == other.enums; }
+    [[nodiscard]] bool operator!=(const SimpleDataType& other) const { return !(*this == other); }
 };
 
 //-----------------------------------------------------------------------
@@ -273,6 +288,37 @@ struct BaseField
     }
 
     virtual ~BaseField() = default;
+
+    //----------------------------------------------------------------------------
+    //! \brief Structural equality. Returns true when `other` has the same
+    //! runtime type and every visible field compares equal.
+    //
+    //! `EnumField::enumDef` is intentionally not part of the comparison —
+    //! it's a cache derived from `enumId`, and we want two `EnumField`
+    //! instances that name the same enum to compare equal regardless of
+    //! which database happens to have resolved their cache pointer.
+    //----------------------------------------------------------------------------
+    [[nodiscard]] bool operator==(const BaseField& other) const { return typeid(*this) == typeid(other) && equalsImpl(other); }
+
+    [[nodiscard]] bool operator!=(const BaseField& other) const { return !(*this == other); }
+
+    //----------------------------------------------------------------------------
+    //! \brief Produce a deep copy of this field definition.
+    //
+    //! Subclasses must override to preserve their runtime type. The base
+    //! implementation copy-constructs a plain `BaseField` and is correct only
+    //! for `FIELD_TYPE`s that don't have a subclass (`SIMPLE`, `STRING`,
+    //! `RESPONSE_ID`, `RESPONSE_STR`, `BITFIELD`, `RXCONFIG_*`, `UNKNOWN`).
+    //
+    //! `FieldArrayField::clone()` recursively deep-copies its nested `fields`
+    //! vector so the resulting tree shares no `shared_ptr<BaseField>` storage
+    //! with the source.
+    //
+    //! `EnumField::enumDef` and other `*Definition::ConstPtr` members are
+    //! shallow-copied: those entities are treated as immutable values, so
+    //! sharing the pointer is safe.
+    //----------------------------------------------------------------------------
+    [[nodiscard]] virtual std::shared_ptr<BaseField> clone() const { return std::make_shared<BaseField>(*this); }
 
     void SetConversion(std::string&& sConversion_)
     {
@@ -312,6 +358,19 @@ struct BaseField
 
     using Ptr = std::shared_ptr<BaseField>;
     using ConstPtr = std::shared_ptr<const BaseField>;
+
+  protected:
+    //----------------------------------------------------------------------------
+    //! \brief Virtual hook used by `operator==` after a runtime-type match.
+    //! Subclasses override to compare their own members in addition to the
+    //! base class fields.
+    //----------------------------------------------------------------------------
+    [[nodiscard]] virtual bool equalsImpl(const BaseField& other) const
+    {
+        return name == other.name && type == other.type && description == other.description && conversion == other.conversion
+               && conversionHash == other.conversionHash && width == other.width && precision == other.precision && isString == other.isString
+               && isCsv == other.isCsv && dataType == other.dataType;
+    }
 };
 
 //-----------------------------------------------------------------------
@@ -324,8 +383,18 @@ struct EnumField : BaseField
     EnumDefinition::ConstPtr enumDef{nullptr};
     uint32_t length{0};
 
+    [[nodiscard]] std::shared_ptr<BaseField> clone() const override { return std::make_shared<EnumField>(*this); }
+
     using Ptr = std::shared_ptr<EnumField>;
     using ConstPtr = std::shared_ptr<const EnumField>;
+
+  protected:
+    [[nodiscard]] bool equalsImpl(const BaseField& other) const override
+    {
+        if (!BaseField::equalsImpl(other)) { return false; }
+        const auto& o = static_cast<const EnumField&>(other);
+        return enumId == o.enumId && length == o.length;
+    }
 };
 
 //-----------------------------------------------------------------------
@@ -338,8 +407,18 @@ struct ArrayField : BaseField
     std::string arrayLengthRef;
     uint8_t arrayLengthFieldSize{0}; // in bytes, only for variable-length and field arrays
 
+    [[nodiscard]] std::shared_ptr<BaseField> clone() const override { return std::make_shared<ArrayField>(*this); }
+
     using Ptr = std::shared_ptr<ArrayField>;
     using ConstPtr = std::shared_ptr<const ArrayField>;
+
+  protected:
+    [[nodiscard]] bool equalsImpl(const BaseField& other) const override
+    {
+        if (!BaseField::equalsImpl(other)) { return false; }
+        const auto& o = static_cast<const ArrayField&>(other);
+        return arrayLength == o.arrayLength && arrayLengthRef == o.arrayLengthRef && arrayLengthFieldSize == o.arrayLengthFieldSize;
+    }
 };
 
 //-----------------------------------------------------------------------
@@ -351,8 +430,33 @@ struct FieldArrayField : ArrayField
     uint32_t fieldSize{0};
     std::vector<std::shared_ptr<BaseField>> fields;
 
+    [[nodiscard]] std::shared_ptr<BaseField> clone() const override
+    {
+        auto copy = std::make_shared<FieldArrayField>(*this);
+        for (auto& sub : copy->fields) { sub = sub->clone(); }
+        return copy;
+    }
+
     using Ptr = std::shared_ptr<FieldArrayField>;
     using ConstPtr = std::shared_ptr<const FieldArrayField>;
+
+  protected:
+    [[nodiscard]] bool equalsImpl(const BaseField& other) const override
+    {
+        if (!ArrayField::equalsImpl(other)) { return false; }
+        const auto& o = static_cast<const FieldArrayField&>(other);
+        if (fieldSize != o.fieldSize) { return false; }
+        if (fields.size() != o.fields.size()) { return false; }
+        for (size_t i = 0; i < fields.size(); ++i)
+        {
+            if (!fields[i] || !o.fields[i])
+            {
+                if (fields[i] != o.fields[i]) { return false; }
+            }
+            else if (*fields[i] != *o.fields[i]) { return false; }
+        }
+        return true;
+    }
 };
 
 //-----------------------------------------------------------------------
@@ -385,6 +489,39 @@ struct MessageDefinition
     uint32_t latestMessageCrc{0};
 
     const std::vector<BaseField::Ptr>& GetMsgDefFromCrc(spdlog::logger& pclLogger_, uint32_t uiMsgDefCrc_) const;
+
+    //----------------------------------------------------------------------------
+    //! \brief Structural equality. Two `MessageDefinition`s compare equal if
+    //! every scalar field matches and every `BaseField::Ptr` in `fields`
+    //! dereferences to a structurally-equal field. Pointer identity is not
+    //! required, so a deep-copied definition compares equal to its source.
+    //----------------------------------------------------------------------------
+    [[nodiscard]] bool operator==(const MessageDefinition& other) const
+    {
+        if (_id != other._id || logID != other.logID || name != other.name || description != other.description
+            || messageStyle != other.messageStyle || latestMessageCrc != other.latestMessageCrc || fields.size() != other.fields.size())
+        {
+            return false;
+        }
+        for (const auto& [crc, fieldVec] : fields)
+        {
+            auto it = other.fields.find(crc);
+            if (it == other.fields.end()) { return false; }
+            const auto& otherVec = it->second;
+            if (fieldVec.size() != otherVec.size()) { return false; }
+            for (size_t i = 0; i < fieldVec.size(); ++i)
+            {
+                if (!fieldVec[i] || !otherVec[i])
+                {
+                    if (fieldVec[i] != otherVec[i]) { return false; }
+                }
+                else if (*fieldVec[i] != *otherVec[i]) { return false; }
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool operator!=(const MessageDefinition& other) const { return !(*this == other); }
 
     using Ptr = std::shared_ptr<MessageDefinition>;
     using ConstPtr = std::shared_ptr<const MessageDefinition>;

--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -270,33 +270,20 @@ struct EnumDefinition
 };
 
 //-----------------------------------------------------------------------
-//! \struct BaseDataType
-//! \brief Struct containing basic elements of data type fields in the
+//! \struct SimpleDataType
+//! \brief Struct containing elements of simple data type fields in the
 //! UI DB.
 //-----------------------------------------------------------------------
-struct BaseDataType
+struct SimpleDataType
 {
     DATA_TYPE name{DATA_TYPE::UNKNOWN};
     uint16_t length{0};
     std::string description;
 
-    [[nodiscard]] bool operator==(const BaseDataType& other) const
+    [[nodiscard]] bool operator==(const SimpleDataType& other) const
     {
         return name == other.name && length == other.length && description == other.description;
     }
-    [[nodiscard]] bool operator!=(const BaseDataType& other) const { return !(*this == other); }
-};
-
-//-----------------------------------------------------------------------
-//! \struct SimpleDataType
-//! \brief Struct containing elements of simple data type fields in the
-//! UI DB.
-//-----------------------------------------------------------------------
-struct SimpleDataType : BaseDataType
-{
-    std::unordered_map<int32_t, EnumDataType> enums;
-
-    [[nodiscard]] bool operator==(const SimpleDataType& other) const { return BaseDataType::operator==(other) && enums == other.enums; }
     [[nodiscard]] bool operator!=(const SimpleDataType& other) const { return !(*this == other); }
 };
 
@@ -408,9 +395,9 @@ struct BaseField
     //----------------------------------------------------------------------------
     [[nodiscard]] virtual bool equalsImpl(const BaseField& other) const
     {
-        return name == other.name && type == other.type && description == other.description && conversion == other.conversion
-               && conversionHash == other.conversionHash && width == other.width && precision == other.precision && isString == other.isString
-               && isCsv == other.isCsv && dataType == other.dataType;
+        return name == other.name && type == other.type && description == other.description && conversion == other.conversion &&
+               conversionHash == other.conversionHash && width == other.width && precision == other.precision && isString == other.isString &&
+               isCsv == other.isCsv && dataType == other.dataType;
     }
 };
 
@@ -539,8 +526,8 @@ struct MessageDefinition
     //----------------------------------------------------------------------------
     [[nodiscard]] bool operator==(const MessageDefinition& other) const
     {
-        if (_id != other._id || logID != other.logID || name != other.name || description != other.description
-            || messageStyle != other.messageStyle || latestMessageCrc != other.latestMessageCrc || fields.size() != other.fields.size())
+        if (_id != other._id || logID != other.logID || name != other.name || description != other.description ||
+            messageStyle != other.messageStyle || latestMessageCrc != other.latestMessageCrc || fields.size() != other.fields.size())
         {
             return false;
         }

--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -316,15 +316,6 @@ struct BaseField
 
     BaseField() = default;
 
-    // TODO: Remove this? A DATA_TYPE should only have one length
-    BaseField(std::string name_, const FIELD_TYPE type_, std::string&& sConversion_, const size_t length_, const DATA_TYPE eDataTypeName_)
-        : name(std::move(name_)), type(type_)
-    {
-        SetConversion(std::move(sConversion_));
-        dataType.length = static_cast<uint16_t>(length_);
-        dataType.name = eDataTypeName_;
-    }
-
     BaseField(std::string name_, FIELD_TYPE type_, std::string conversion_, DATA_TYPE eDataTypeName_) : name(std::move(name_)), type(type_)
     {
         dataType.name = eDataTypeName_;

--- a/include/novatel_edie/decoders/common/message_database.hpp
+++ b/include/novatel_edie/decoders/common/message_database.hpp
@@ -27,6 +27,8 @@
 #ifndef MESSAGE_DATABASE_HPP
 #define MESSAGE_DATABASE_HPP
 
+#include <algorithm>
+#include <cassert>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -222,7 +224,7 @@ struct EnumDefinition
     std::unordered_map<std::string_view, uint32_t> nameValue;        // cached
     std::unordered_map<std::string_view, uint32_t> descriptionValue; // cached
     std::unordered_map<uint32_t, std::string_view> valueName;        // cached
-    uint32_t unknownValue;
+    uint32_t unknownValue{0};                                        // cached; one greater than the largest enumerator value
 
     using Ptr = std::shared_ptr<EnumDefinition>;
     using ConstPtr = std::shared_ptr<const EnumDefinition>;
@@ -230,21 +232,19 @@ struct EnumDefinition
     EnumDefinition() = default;
     ~EnumDefinition() = default;
 
+    EnumDefinition(std::string id_, std::string name_, std::vector<EnumDataType> enumerators_)
+        : _id(std::move(id_)), name(std::move(name_)), enumerators(std::move(enumerators_))
+    {
+        RebuildCaches();
+    }
+
     //----------------------------------------------------------------------------
     //! \brief Deep copy. The lookup maps are rebuilt against the new
     //! `enumerators` vector — a default copy would alias the source's
     //! enumerator strings via the `string_view` keys, dangling once the source
     //! is destroyed.
     //----------------------------------------------------------------------------
-    EnumDefinition(const EnumDefinition& other) : _id(other._id), name(other.name), enumerators(other.enumerators), unknownValue(other.unknownValue)
-    {
-        for (const auto& enumerator : enumerators)
-        {
-            nameValue[enumerator.name] = enumerator.value;
-            valueName[enumerator.value] = enumerator.name;
-            descriptionValue[enumerator.description] = enumerator.value;
-        }
-    }
+    EnumDefinition(const EnumDefinition& other) : _id(other._id), name(other.name), enumerators(other.enumerators) { RebuildCaches(); }
 
     EnumDefinition& operator=(const EnumDefinition& other)
     {
@@ -252,21 +252,30 @@ struct EnumDefinition
         _id = other._id;
         name = other.name;
         enumerators = other.enumerators;
-        unknownValue = other.unknownValue;
-        nameValue.clear();
-        valueName.clear();
-        descriptionValue.clear();
-        for (const auto& enumerator : enumerators)
-        {
-            nameValue[enumerator.name] = enumerator.value;
-            valueName[enumerator.value] = enumerator.name;
-            descriptionValue[enumerator.description] = enumerator.value;
-        }
+        RebuildCaches();
         return *this;
     }
 
     EnumDefinition(EnumDefinition&&) = default;
     EnumDefinition& operator=(EnumDefinition&&) = default;
+
+    void RebuildCaches()
+    {
+        nameValue.clear();
+        valueName.clear();
+        descriptionValue.clear();
+        uint32_t maxVal = 0;
+        for (const auto& enumerator : enumerators)
+        {
+            maxVal = std::max(maxVal, enumerator.value);
+            nameValue[enumerator.name] = enumerator.value;
+            valueName[enumerator.value] = enumerator.name;
+            descriptionValue[enumerator.description] = enumerator.value;
+        }
+        unknownValue = maxVal + 1;
+        assert(unknownValue > maxVal &&
+               "Overflow encountered when determining placeholder value. Enumerator values are expected to be within [0, 2^31).");
+    }
 };
 
 //-----------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ build-verbosity = 1
 archs = "auto64"
 manylinux-x86_64-image = "manylinux_2_28"
 
+[tool.cibuildwheel.windows]
+# Don't try to fetch DLLs that are already bundled in the wheel
+repair-wheel-command = "delvewheel repair --ignore-existing -w {dest_dir} {wheel}"
+
 [tool.cibuildwheel.macos.environment]
 # Needed for full C++17 support
 MACOSX_DEPLOYMENT_TARGET = "13.0"

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -153,6 +153,7 @@ add_custom_target(
     common_stubs ALL
     COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/scripts/create_binding_stubs.py
     --import $<TARGET_FILE_DIR:common_bindings>
+    --pattern-file ${CMAKE_CURRENT_SOURCE_DIR}/common_stubgen_pattern.txt
     -m common_bindings
     -o ${CMAKE_CURRENT_BINARY_DIR}/stubs/common_bindings.pyi
     DEPENDS common_bindings decoders_common

--- a/python/common_stubgen_pattern.txt
+++ b/python/common_stubgen_pattern.txt
@@ -1,0 +1,15 @@
+common_bindings.MessageDatabase.clone$:
+    \from typing_extensions import deprecated
+    @deprecated("MessageDatabase.clone() is deprecated; use MessageDatabase.fork() instead.")
+    def clone(self) -> "MessageDatabase":
+        \doc
+
+common_bindings.SatelliteId.prn_or_slot$:
+    \from typing_extensions import deprecated
+    @property
+    @deprecated("SatelliteId.prn_or_slot is deprecated; use 'prn' instead.")
+    def prn_or_slot(self) -> int:
+        """DEPRECATED: Use 'prn' field instead."""
+    @prn_or_slot.setter
+    @deprecated("SatelliteId.prn_or_slot is deprecated; use 'prn' instead.")
+    def prn_or_slot(self, arg: int, /) -> None: ...

--- a/python/include/py_common/message_database.hpp
+++ b/python/include/py_common/message_database.hpp
@@ -49,7 +49,12 @@ class PyMessageDatabase
     using Ptr = std::shared_ptr<PyMessageDatabase>;
     using ConstPtr = std::shared_ptr<const PyMessageDatabase>;
 
-    explicit PyMessageDatabase(MessageDatabase&& message_db = MessageDatabase());
+    // Factory — must be used instead of constructing directly. Publishes the
+    // Python wrapper before running Python-touching init so nb::find(this)
+    // works during Initialize(). Returns the Python wrapper directly; cast
+    // back to Ptr with nb::cast<Ptr>(...) if the caller needs the shared_ptr.
+    // Requires the GIL to be held.
+    [[nodiscard]] static nb::object Create(MessageDatabase&& message_db = MessageDatabase());
 
     PyMessageDatabase(const PyMessageDatabase&) = delete;
     PyMessageDatabase& operator=(const PyMessageDatabase&) = delete;
@@ -179,9 +184,11 @@ class PyMessageDatabase
         for (const auto& [enum_def, enum_type] : enum_types) { enumsMod_.attr(enum_def->name.c_str()) = enum_type; }
     }
 
-    [[nodiscard]] Ptr clone() const;
+    [[nodiscard]] nb::object clone() const;
 
   private:
+    explicit PyMessageDatabase(MessageDatabase&& message_db);
+
     void Initialize();
     void ResolveBaseType();
     void allocateExtras();
@@ -200,8 +207,7 @@ class PyMessageDatabase
 
     void UpdatePythonEnums();
     void UpdatePythonMessageTypes();
-    void AddFieldType(std::vector<std::shared_ptr<BaseField>> fields, std::string base_name, std::string parent_message, nb::handle type_cons,
-                      nb::handle type_tuple, nb::handle type_dict);
+    void AddFieldType(std::vector<std::shared_ptr<BaseField>> fields, std::string base_name, std::string parent_message, nb::handle type_cons);
 
     const MessageFamilyRegistration* message_family_registration_ = nullptr;
     std::unordered_map<const MessageDefinition*, std::map<uint32_t, nb::object>> messages_types{};

--- a/python/include/py_common/message_database.hpp
+++ b/python/include/py_common/message_database.hpp
@@ -58,6 +58,20 @@ struct MessageFamilyRegistration
 std::unordered_map<std::string, MessageFamilyRegistration>& GetMessageFamilyRegistrations();
 const MessageFamilyRegistration* GetMessageFamilyRegistration(const std::string& message_family);
 
+// Deep-copy helpers that duplicate every `BaseField` in the definition. Used by
+// callers that publish a definition into a database (or hand it back out to
+// Python) where the recipient might mutate the shared `EnumField::enumDef`
+// cache and corrupt the source.
+[[nodiscard]] MessageDefinition::Ptr cloneMessageDef(const MessageDefinition& source);
+[[nodiscard]] std::vector<MessageDefinition::ConstPtr> cloneMessageDefs(const std::vector<MessageDefinition::ConstPtr>& source);
+
+// Deep-copy helpers for enum definitions. The default copy would alias the
+// source's enumerator strings via the `string_view`-keyed lookup maps; this
+// rebuilds those maps from the copied `enumerators` vector so the new
+// definition owns all of its storage.
+[[nodiscard]] EnumDefinition::Ptr cloneEnumDef(const EnumDefinition& source);
+[[nodiscard]] std::vector<EnumDefinition::ConstPtr> cloneEnumDefs(const std::vector<EnumDefinition::ConstPtr>& source);
+
 //============================================================================
 //! \class PyMessageDatabase
 //! \brief A Python-facing message database that owns a MessageDatabase, the

--- a/python/include/py_common/message_database.hpp
+++ b/python/include/py_common/message_database.hpp
@@ -58,20 +58,6 @@ struct MessageFamilyRegistration
 std::unordered_map<std::string, MessageFamilyRegistration>& GetMessageFamilyRegistrations();
 const MessageFamilyRegistration* GetMessageFamilyRegistration(const std::string& message_family);
 
-// Deep-copy helpers that duplicate every `BaseField` in the definition. Used by
-// callers that publish a definition into a database (or hand it back out to
-// Python) where the recipient might mutate the shared `EnumField::enumDef`
-// cache and corrupt the source.
-[[nodiscard]] MessageDefinition::Ptr cloneMessageDef(const MessageDefinition& source);
-[[nodiscard]] std::vector<MessageDefinition::ConstPtr> cloneMessageDefs(const std::vector<MessageDefinition::ConstPtr>& source);
-
-// Deep-copy helpers for enum definitions. The default copy would alias the
-// source's enumerator strings via the `string_view`-keyed lookup maps; this
-// rebuilds those maps from the copied `enumerators` vector so the new
-// definition owns all of its storage.
-[[nodiscard]] EnumDefinition::Ptr cloneEnumDef(const EnumDefinition& source);
-[[nodiscard]] std::vector<EnumDefinition::ConstPtr> cloneEnumDefs(const std::vector<EnumDefinition::ConstPtr>& source);
-
 //============================================================================
 //! \class PyMessageDatabase
 //! \brief A Python-facing message database that owns a MessageDatabase, the

--- a/python/include/py_common/message_database.hpp
+++ b/python/include/py_common/message_database.hpp
@@ -25,6 +25,22 @@ struct FieldLookupEntry
 
 using FieldNameMap = std::unordered_map<std::string, FieldLookupEntry>;
 
+struct MessageTypeLookupEntry
+{
+    const MessageDefinition* def;
+    uint32_t crc;
+};
+
+struct HandlePtrHash
+{
+    size_t operator()(nb::handle h) const noexcept { return std::hash<PyObject*>{}(h.ptr()); }
+};
+
+struct HandlePtrEq
+{
+    bool operator()(nb::handle a, nb::handle b) const noexcept { return a.ptr() == b.ptr(); }
+};
+
 class MessageDBExtrasBase
 {
   public:
@@ -111,6 +127,24 @@ class PyMessageDatabase
     [[nodiscard]] nb::object GetMessageType(std::string_view messageName) const { return GetMessageType(GetMsgDef(messageName).get()); }
     [[nodiscard]] nb::object GetMessageType(int32_t id, uint32_t crc) const { return GetMessageType(GetMsgDef(id).get(), crc); }
     [[nodiscard]] nb::object GetMessageType(int32_t id) const { return GetMessageType(GetMsgDef(id).get()); }
+
+    [[nodiscard]] const MessageTypeLookupEntry* GetMessageTypeLookup(nb::handle cls) const
+    {
+        auto it = message_type_lookup_.find(cls);
+        return it == message_type_lookup_.end() ? nullptr : &it->second;
+    }
+
+    [[nodiscard]] const BaseField* GetFieldTypeLookup(nb::handle cls) const
+    {
+        auto it = field_type_lookup_.find(cls);
+        return it == field_type_lookup_.end() ? nullptr : it->second;
+    }
+
+    [[nodiscard]] const EnumDefinition* GetEnumTypeLookup(nb::handle cls) const
+    {
+        auto it = enum_type_lookup_.find(cls);
+        return it == enum_type_lookup_.end() ? nullptr : it->second;
+    }
 
     [[nodiscard]] const std::unordered_map<const BaseField*, nb::object> GetFieldsByDefDict() const { return field_types; }
 
@@ -223,6 +257,9 @@ class PyMessageDatabase
     std::unordered_map<const EnumDefinition*, nb::object> enum_types{};
     std::unordered_map<const BaseField*, FieldNameMap> field_name_maps_{};
     std::unordered_map<const MessageDefinition*, std::map<uint32_t, FieldNameMap>> message_field_name_maps_{};
+    std::unordered_map<nb::handle, MessageTypeLookupEntry, HandlePtrHash, HandlePtrEq> message_type_lookup_{};
+    std::unordered_map<nb::handle, const BaseField*, HandlePtrHash, HandlePtrEq> field_type_lookup_{};
+    std::unordered_map<nb::handle, const EnumDefinition*, HandlePtrHash, HandlePtrEq> enum_type_lookup_{};
 
     std::unique_ptr<MessageDBExtrasBase> extras_;
     MessageDatabase::Ptr core_;

--- a/python/include/py_common/message_database.hpp
+++ b/python/include/py_common/message_database.hpp
@@ -12,6 +12,11 @@ namespace nb = nanobind;
 
 namespace novatel::edie::py_common {
 
+// Forward declarations for nanobind GC type slots; declared as friends of
+// PyMessageDatabase so they can poke at private state during traversal/clear.
+int db_tp_traverse(PyObject* self, visitproc visit, void* arg);
+int db_tp_clear(PyObject* self);
+
 struct FieldLookupEntry
 {
     size_t index;
@@ -187,6 +192,9 @@ class PyMessageDatabase
     [[nodiscard]] nb::object clone() const;
 
   private:
+    friend int db_tp_traverse(PyObject* self, visitproc visit, void* arg);
+    friend int db_tp_clear(PyObject* self);
+
     explicit PyMessageDatabase(MessageDatabase&& message_db);
 
     void Initialize();

--- a/python/include/py_common/message_database.hpp
+++ b/python/include/py_common/message_database.hpp
@@ -85,6 +85,14 @@ class PyMessageDatabase
     [[nodiscard]] const MessageDatabase::Ptr& core() const { return core_; }
     [[nodiscard]] const MessageDBExtrasBase* GetMessageFamilyExtras() const { return extras_.get(); }
 
+    // Lock state — once locked, any mutator throws UnsupportedException.
+    void Lock() { locked_ = true; }
+    [[nodiscard]] bool IsLocked() const { return locked_; }
+    void ThrowIfLocked() const
+    {
+        if (locked_) { throw UnsupportedException("MessageDatabase is locked and cannot be mutated."); }
+    }
+
     // Mutators — wrap MessageDatabase mutations so the Python caches stay in sync.
     void Merge(const Ptr& other);
     void AppendMessages(const std::vector<MessageDefinition::ConstPtr>& vMessageDefinitions_);
@@ -223,7 +231,7 @@ class PyMessageDatabase
         for (const auto& [enum_def, enum_type] : enum_types) { enumsMod_.attr(enum_def->name.c_str()) = enum_type; }
     }
 
-    [[nodiscard]] nb::object clone() const;
+    [[nodiscard]] nb::object clone();
 
   private:
     friend int db_tp_traverse(PyObject* self, visitproc visit, void* arg);
@@ -263,6 +271,7 @@ class PyMessageDatabase
 
     std::unique_ptr<MessageDBExtrasBase> extras_;
     MessageDatabase::Ptr core_;
+    bool locked_ = false;
 };
 
 } // namespace novatel::edie::py_common

--- a/python/include/py_common/message_database.hpp
+++ b/python/include/py_common/message_database.hpp
@@ -231,7 +231,11 @@ class PyMessageDatabase
         for (const auto& [enum_def, enum_type] : enum_types) { enumsMod_.attr(enum_def->name.c_str()) = enum_type; }
     }
 
-    [[nodiscard]] nb::object clone();
+    // Returns a mutable copy of this database that shares the same definitions
+    // and types for messages and enums. As a side effect, the existing database
+    // (this one) is locked: any subsequent call that would modify it raises an
+    // exception (see Lock / ThrowIfLocked).
+    [[nodiscard]] nb::object fork();
 
   private:
     friend int db_tp_traverse(PyObject* self, visitproc visit, void* arg);

--- a/python/include/py_oem/message_db_singleton.hpp
+++ b/python/include/py_oem/message_db_singleton.hpp
@@ -25,6 +25,16 @@ class MessageDbSingleton
     //! If the instance does not yet exist, it will be created and returned.
     //----------------------------------------------------------------------------
     [[nodiscard]] static py_common::PyMessageDatabase::Ptr& get();
+
+    //----------------------------------------------------------------------------
+    //! \brief Frees the singleton database.
+    //!
+    //! Must be called at Python interpreter exit; relying on static destruction
+    //! leads to this being done too late.
+    //----------------------------------------------------------------------------
+    static void cleanup();
+
+    static py_common::PyMessageDatabase::Ptr json_db;
 };
 
 } // namespace novatel::edie::py_oem

--- a/python/novatel_edie_files/__init__.py
+++ b/python/novatel_edie_files/__init__.py
@@ -40,7 +40,7 @@ from .common_bindings import (
     FIELD_TYPE, DATA_TYPE,
     MessageDatabase,
     MessageDefinition, FieldDefinition, ArrayFieldDefinition, FieldArrayFieldDefinition, EnumFieldDefinition,
-    EnumDataType,
+    EnumDefinition, EnumDataType,
     ENCODE_FORMAT, HEADER_FORMAT,
     MAX_MESSAGE_LENGTH, MAX_ASCII_MESSAGE_LENGTH, MAX_SHORT_ASCII_MESSAGE_LENGTH, MAX_BINARY_MESSAGE_LENGTH, MAX_SHORT_BINARY_MESSAGE_LENGTH,
     MAX_ABB_ASCII_RESPONSE_LENGTH, MAX_NMEA_MESSAGE_LENGTH,
@@ -49,6 +49,7 @@ from .common_bindings import (
     UNKNOWN_REASON, UnknownBytes, Field, FieldArray, MessageData,
     FramerManager, MetaDataBase
 )
+EnummeratorDefinition = EnumDefinition
 
 from .oem.oem_bindings import get_builtin_database
 

--- a/python/readme.md
+++ b/python/readme.md
@@ -467,6 +467,20 @@ builtin_db = get_builtin_database()
 bestpos_type = builtin_db.get_message_type('BESTPOS')
 ```
 
+### Locking
+
+Once a database is put to use, it is *locked* to ensure that the data decoded against it stays consistent.
+Any attempt to mutate a locked database (e.g. `merge`, `append_messages`, `remove_message`, or setting `message_family`)
+raises an exception. Whether a database is locked can be checked via its `is_locked` property.
+
+A database becomes locked when any of the following happen:
+
+- **Explicit lock**: calling `db.lock()`.
+- **Used by a consumer**: constructing a `Parser`, `FileParser`, `Decoder`, `Commander`, `RxConfigHandler`, or `RangeDecompressor` with the database locks it.
+- **Generating a type**: requesting a generated message or enum type via `get_msg_type`, `get_enum_type_by_name`, or `get_enum_type_by_id`.
+- **Merging into another database**: `other_db.merge(db)` locks the source database `db`.
+- **Cloning**: `db.clone()` locks the source database (the returned copy is unlocked).
+
 ## Logging
 
 `novatel_edie` preforms all its logging via the python standard library `logging` module 

--- a/python/readme.md
+++ b/python/readme.md
@@ -479,7 +479,7 @@ A database becomes locked when any of the following happen:
 - **Used by a consumer**: constructing a `Parser`, `FileParser`, `Decoder`, `Commander`, `RxConfigHandler`, or `RangeDecompressor` with the database locks it.
 - **Generating a type**: requesting a generated message or enum type via `get_msg_type`, `get_enum_type_by_name`, or `get_enum_type_by_id`.
 - **Merging into another database**: `other_db.merge(db)` locks the source database `db`.
-- **Cloning**: `db.clone()` locks the source database (the returned copy is unlocked).
+- **Forking**: `db.fork()` locks the source database (the returned copy is unlocked). (`db.clone()` is a deprecated alias for `fork()`.)
 
 ## Logging
 

--- a/python/src/py_common/bindings/field_objects.cpp
+++ b/python/src/py_common/bindings/field_objects.cpp
@@ -17,6 +17,25 @@ using namespace novatel::edie;
 void py_common::init_field_objects(nb::module_& m)
 {
     nb::class_<py_common::PyField>(m, "Field", nb::is_weak_referenceable())
+        .def_static(
+            "__new__",
+            [](nb::handle cls, [[maybe_unused]] nb::kwargs kwargs) {
+                py_common::PyMessageDatabase::Ptr database = nb::cast<py_common::PyMessageDatabase::Ptr>(cls.attr("_owner_db"));
+                if (!database) { throw py_common::FailureException("Constructor could not resolve owning MessageDatabase for this type."); }
+
+                const BaseField* field_def = database->GetFieldTypeLookup(cls);
+                if (!field_def) { throw py_common::FailureException("Constructor could not resolve BaseField for this type."); }
+
+                nb::object field_pyinst = nb::inst_alloc(cls);
+                py_common::PyField* field_cinst = nb::inst_ptr<py_common::PyField>(field_pyinst);
+                new (field_cinst) py_common::PyField(std::vector<FieldContainer>{}, field_def, database);
+                nb::inst_mark_ready(field_pyinst);
+                return field_pyinst;
+            },
+            "cls"_a, "kwargs"_a)
+        .def(
+            "__init__", [](nb::handle self, nb::kwargs kwargs) { throw py_common::FailureException("Field initialization not implemented."); },
+            "kwargs"_a)
         .def("__getattr__", &py_common::PyField::getattr, "field_name"_a)
         .def("__repr__",
              [](nb::handle self) {

--- a/python/src/py_common/bindings/logger.cpp
+++ b/python/src/py_common/bindings/logger.cpp
@@ -24,14 +24,13 @@ void py_common::init_common_logger(nb::module_& m, nb::module_& internal_m)
         "enable_internal_logging", [manager]() { manager->EnableInternalLogging(); },
         "Enable logging which originates from novatel_edie's native C++ code.");
 
-    // Create python entry-point to custom setLevel and cleanup functions
+    // Create python entry-point to custom setLevel function
     internal_m.def("set_level", [manager](nb::handle self, nb::args args_, nb::kwargs kwargs_) { manager->SetLoggerLevel(self, args_, kwargs_); });
-    internal_m.def("exit_cleanup", [manager]() { manager->Shutdown(); });
 
-    // Provide these the setLevel entry-point to the LoggerManager
+    // Provide the setLevel entry-point to the LoggerManager
     manager->SetInternalMod(internal_m);
 
     // Run the custom cleanup code before any normal termination of the Python interpreter
     nb::module_ atexit = nb::module_::import_("atexit");
-    atexit.attr("register")(internal_m.attr("exit_cleanup"));
+    atexit.attr("register")(nb::cpp_function([manager]() { manager->Shutdown(); }));
 }

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -100,9 +100,9 @@ void py_common::init_common_message_database(nb::module_& m)
 
     nb::class_<EnumDataType>(m, "EnumDataType", "Enum Data Type representing contents of UI DB")
         .def(nb::init())
-        .def_rw("value", &EnumDataType::value)
-        .def_rw("name", &EnumDataType::name)
-        .def_rw("description", &EnumDataType::description)
+        .def_ro("value", &EnumDataType::value)
+        .def_ro("name", &EnumDataType::name)
+        .def_ro("description", &EnumDataType::description)
         .def("__eq__", [](const EnumDataType& self, const EnumDataType& other) { return self == other; })
         .def("__repr__", [](const EnumDataType& enum_data_type) {
             if (enum_data_type.description.empty())
@@ -113,9 +113,9 @@ void py_common::init_common_message_database(nb::module_& m)
 
     nb::class_<EnumDefinition>(m, "EnummeratorDefinition", "Enum Definition representing contents of UI DB")
         .def(nb::init())
-        .def_rw("id", &EnumDefinition::_id)
-        .def_rw("name", &EnumDefinition::name)
-        .def_rw("enumerators", &EnumDefinition::enumerators)
+        .def_ro("id", &EnumDefinition::_id)
+        .def_ro("name", &EnumDefinition::name)
+        .def_ro("enumerators", &EnumDefinition::enumerators)
         .def("__repr__", [](const EnumDefinition& enum_def) {
             return nb::str("EnumDefinition(id={!r}, name={!r}, enumerators={!r})").format(enum_def._id, enum_def.name, enum_def.enumerators);
         });
@@ -169,7 +169,7 @@ void py_common::init_common_message_database(nb::module_& m)
             },
             "name"_a, "enumerators"_a)
         .def_rw("enum_id", &EnumField::enumId)
-        .def_rw("enum_def", &EnumField::enumDef)
+        .def_ro("enum_def", &EnumField::enumDef)
         .def_rw("length", &EnumField::length)
         .def("__repr__", [](const EnumField& field) {
             const std::string& desc = field.description == "[Brief Description]" ? "" : field.description;
@@ -245,27 +245,9 @@ void py_common::init_common_message_database(nb::module_& m)
                 return def ? std::make_shared<MessageDefinition>(*def) : nullptr;
             },
             "msg_id"_a)
-        .def(
-            "get_enum_def",
-            [](const py_common::PyMessageDatabase& self, const std::string& enum_id) -> EnumDefinition::ConstPtr {
-                auto def = self.GetEnumDefId(enum_id);
-                return def ? std::make_shared<EnumDefinition>(*def) : nullptr;
-            },
-            "enum_id"_a)
-        .def(
-            "get_enum_def_by_id",
-            [](const py_common::PyMessageDatabase& self, const std::string& enum_id) -> EnumDefinition::ConstPtr {
-                auto def = self.GetEnumDefId(enum_id);
-                return def ? std::make_shared<EnumDefinition>(*def) : nullptr;
-            },
-            "enum_id"_a)
-        .def(
-            "get_enum_def_by_name",
-            [](const py_common::PyMessageDatabase& self, const std::string& enum_name) -> EnumDefinition::ConstPtr {
-                auto def = self.GetEnumDefName(enum_name);
-                return def ? std::make_shared<EnumDefinition>(*def) : nullptr;
-            },
-            "enum_name"_a)
+        .def("get_enum_def", &py_common::PyMessageDatabase::GetEnumDefId, "enum_id"_a)
+        .def("get_enum_def_by_id", &py_common::PyMessageDatabase::GetEnumDefId, "enum_id"_a)
+        .def("get_enum_def_by_name", &py_common::PyMessageDatabase::GetEnumDefName, "enum_name"_a)
         .def(
             "get_msg_type", [](py_common::PyMessageDatabase& self, std::string name) { return self.GetMessageType(name); }, "name"_a)
         .def(

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -100,9 +100,10 @@ void py_common::init_common_message_database(nb::module_& m)
 
     nb::class_<EnumDataType>(m, "EnumDataType", "Enum Data Type representing contents of UI DB")
         .def(nb::init())
-        .def_ro("value", &EnumDataType::value)
-        .def_ro("name", &EnumDataType::name)
-        .def_ro("description", &EnumDataType::description)
+        .def(nb::init<uint32_t, std::string, std::string>(), "value"_a, "name"_a, "description"_a)
+        .def_rw("value", &EnumDataType::value)
+        .def_rw("name", &EnumDataType::name)
+        .def_rw("description", &EnumDataType::description)
         .def("__eq__", [](const EnumDataType& self, const EnumDataType& other) { return self == other; })
         .def("__repr__", [](const EnumDataType& enum_data_type) {
             if (enum_data_type.description.empty())
@@ -111,32 +112,64 @@ void py_common::init_common_message_database(nb::module_& m)
                 .format(enum_data_type.name, enum_data_type.value, enum_data_type.description);
         });
 
-    nb::class_<EnumDefinition>(m, "EnummeratorDefinition", "Enum Definition representing contents of UI DB")
+    nb::class_<EnumDefinition>(m, "EnumDefinition", "Enum Definition representing contents of UI DB")
         .def(nb::init())
-        .def_ro("id", &EnumDefinition::_id)
-        .def_ro("name", &EnumDefinition::name)
-        .def_ro("enumerators", &EnumDefinition::enumerators)
+        .def(
+            "__init__",
+            [](EnumDefinition* t, std::string id, std::string name, std::vector<EnumDataType> enumerators) {
+                auto* def = new (t) EnumDefinition; // NOLINT(*.NewDeleteLeaks)
+                def->_id = std::move(id);
+                def->name = std::move(name);
+                def->enumerators = std::move(enumerators);
+                for (const auto& enumerator : def->enumerators)
+                {
+                    def->nameValue[enumerator.name] = enumerator.value;
+                    def->valueName[enumerator.value] = enumerator.name;
+                    def->descriptionValue[enumerator.description] = enumerator.value;
+                }
+            },
+            "id"_a = std::string{}, "name"_a = std::string{}, "enumerators"_a = std::vector<EnumDataType>{})
+        .def_rw("id", &EnumDefinition::_id)
+        .def_rw("name", &EnumDefinition::name)
+        .def_rw("enumerators", &EnumDefinition::enumerators)
         .def("__repr__", [](const EnumDefinition& enum_def) {
             return nb::str("EnumDefinition(id={!r}, name={!r}, enumerators={!r})").format(enum_def._id, enum_def.name, enum_def.enumerators);
         });
 
-    nb::class_<SimpleDataType>(m, "SimpleDataType", "Struct containing elements of simple data type fields in the UI DB")
-        .def(nb::init())
-        .def_rw("name", &SimpleDataType::name)
-        .def_rw("length", &SimpleDataType::length)
-        .def_rw("description", &SimpleDataType::description)
-        .def("__eq__", [](const SimpleDataType& self, const SimpleDataType& other) { return self == other; });
-
     nb::class_<BaseField>(m, "FieldDefinition", "Struct containing elements of basic fields in the UI DB")
         .def(nb::init())
-        .def(nb::init<std::string, FIELD_TYPE, std::string, size_t, DATA_TYPE>(), "name"_a, "type"_a, "conversion"_a, "length"_a, "data_type"_a)
+        .def(
+            "__init__",
+            [](BaseField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type) {
+                auto* field = new (t) BaseField; // NOLINT(*.NewDeleteLeaks)
+                field->name = std::move(name);
+                field->type = type;
+                field->dataType.name = data_type;
+                field->dataType.length = static_cast<uint16_t>(DataTypeSize(data_type));
+                if (!conversion.empty()) { field->SetConversion(std::move(conversion)); }
+            },
+            "name"_a = std::string{}, "type"_a = FIELD_TYPE::UNKNOWN, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN)
         .def_rw("name", &BaseField::name)
         .def_rw("type", &BaseField::type)
         .def_rw("description", &BaseField::description)
-        .def_rw("conversion", &BaseField::conversion)
-        .def_rw("width", &BaseField::width)
-        .def_rw("precision", &BaseField::precision)
-        .def_rw("data_type", &BaseField::dataType)
+        .def_prop_rw(
+            "conversion", [](const BaseField& self) -> const std::string& { return self.conversion; },
+            [](BaseField& self, std::string value) {
+                try
+                {
+                    self.SetConversion(std::move(value));
+                }
+                catch (const std::exception& e)
+                {
+                    throw nb::attribute_error(e.what());
+                }
+            })
+        .def_prop_rw(
+            "data_type", [](const BaseField& self) { return self.dataType.name; },
+            [](BaseField& self, DATA_TYPE value) {
+                self.dataType.name = value;
+                self.dataType.length = static_cast<uint16_t>(DataTypeSize(value));
+            })
         .def("set_conversion", &BaseField::SetConversion, "conversion"_a)
         .def("__eq__", [](const BaseField& self, const BaseField& other) { return self == other; })
         .def("__repr__", [](const BaseField& field) {
@@ -150,30 +183,74 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<EnumField, BaseField>(m, "EnumFieldDefinition", "Struct containing elements of enum fields in the UI DB")
-        .def(nb::init())
         .def(
             "__init__",
-            [](EnumField* t, std::string name, std::vector<EnumDataType> enumerators) {
-                auto enum_def = std::make_shared<EnumDefinition>();
-                enum_def->name = name;
-                enum_def->enumerators = std::move(enumerators);
+            [](EnumField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type, std::string enum_id,
+               std::vector<EnumDataType> enumerators) {
                 auto* field = new (t) EnumField; // NOLINT(*.NewDeleteLeaks)
-                field->name = name;
-                field->enumDef = std::move(enum_def);
-                field->type = FIELD_TYPE::ENUM;
+                field->name = std::move(name);
+                field->type = type;
+                field->dataType.name = data_type;
+                field->dataType.length = static_cast<uint16_t>(DataTypeSize(data_type));
+                if (!conversion.empty()) { field->SetConversion(std::move(conversion)); }
+                field->enumId = std::move(enum_id);
+                if (!enumerators.empty())
+                {
+                    auto enum_def = std::make_shared<EnumDefinition>();
+                    enum_def->enumerators = std::move(enumerators);
+                    for (const auto& enumerator : enum_def->enumerators)
+                    {
+                        enum_def->nameValue[enumerator.name] = enumerator.value;
+                        enum_def->valueName[enumerator.value] = enumerator.name;
+                        enum_def->descriptionValue[enumerator.description] = enumerator.value;
+                    }
+                    field->enumDef = std::move(enum_def);
+                }
             },
-            "name"_a, "enumerators"_a)
+            "name"_a = std::string{}, "type"_a = FIELD_TYPE::ENUM, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN,
+            "enum_id"_a = std::string{}, "enumerators"_a = std::vector<EnumDataType>{})
         .def_rw("enum_id", &EnumField::enumId)
         .def_ro("enum_def", &EnumField::enumDef)
-        .def_rw("length", &EnumField::length)
+        .def_prop_rw(
+            "enumerators",
+            [](const EnumField& self) { return self.enumDef ? self.enumDef->enumerators : std::vector<EnumDataType>{}; },
+            [](EnumField& self, std::vector<EnumDataType> enumerators) {
+                auto new_def = std::make_shared<EnumDefinition>();
+                if (self.enumDef)
+                {
+                    new_def->_id = self.enumDef->_id;
+                    new_def->name = self.enumDef->name;
+                }
+                new_def->enumerators = std::move(enumerators);
+                for (const auto& enumerator : new_def->enumerators)
+                {
+                    new_def->nameValue[enumerator.name] = enumerator.value;
+                    new_def->valueName[enumerator.value] = enumerator.name;
+                    new_def->descriptionValue[enumerator.description] = enumerator.value;
+                }
+                self.enumDef = std::move(new_def);
+            })
         .def("__repr__", [](const EnumField& field) {
             const std::string& desc = field.description == "[Brief Description]" ? "" : field.description;
-            return nb::str("EnumField(name={!r}, type={}, data_type={}, description={!r}, conversion={!r}, enum_id={!r}, length={!r})")
-                .format(field.name, nb::cast(field.type), field.dataType.name, desc, field.conversion, field.enumId, field.length);
+            return nb::str("EnumField(name={!r}, type={}, data_type={}, description={!r}, conversion={!r}, enum_id={!r})")
+                .format(field.name, nb::cast(field.type), field.dataType.name, desc, field.conversion, field.enumId);
         });
 
     nb::class_<ArrayField, BaseField>(m, "ArrayFieldDefinition", "Struct containing elements of array fields in the UI DB")
         .def(nb::init())
+        .def(
+            "__init__",
+            [](ArrayField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type, uint32_t array_length) {
+                auto* field = new (t) ArrayField; // NOLINT(*.NewDeleteLeaks)
+                field->name = std::move(name);
+                field->type = type;
+                field->dataType.name = data_type;
+                field->dataType.length = static_cast<uint16_t>(DataTypeSize(data_type));
+                if (!conversion.empty()) { field->SetConversion(std::move(conversion)); }
+                field->arrayLength = array_length;
+            },
+            "name"_a = std::string{}, "type"_a = FIELD_TYPE::UNKNOWN, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN,
+            "array_length"_a = uint32_t{0})
         .def_rw("array_length", &ArrayField::arrayLength)
         .def("__repr__", [](const ArrayField& field) {
             const std::string& desc = field.description == "[Brief Description]" ? "" : field.description;
@@ -182,16 +259,28 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<FieldArrayField, BaseField>(m, "FieldArrayFieldDefinition", "Struct containing elements of field array fields in the UI DB")
-        .def(nb::init())
+        .def(
+            "__init__",
+            [](FieldArrayField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type, uint32_t array_length,
+               std::vector<std::shared_ptr<BaseField>> fields) {
+                auto* field = new (t) FieldArrayField; // NOLINT(*.NewDeleteLeaks)
+                field->name = std::move(name);
+                field->type = type;
+                field->dataType.name = data_type;
+                field->dataType.length = static_cast<uint16_t>(DataTypeSize(data_type));
+                if (!conversion.empty()) { field->SetConversion(std::move(conversion)); }
+                field->arrayLength = array_length;
+                field->fields = std::move(fields);
+            },
+            "name"_a = std::string{}, "type"_a = FIELD_TYPE::FIELD_ARRAY, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN,
+            "array_length"_a = uint32_t{0}, "fields"_a = std::vector<std::shared_ptr<BaseField>>{})
         .def_rw("array_length", &FieldArrayField::arrayLength)
-        .def_rw("field_size", &FieldArrayField::fieldSize)
         .def_rw("fields", &FieldArrayField::fields, nb::rv_policy::reference_internal)
         .def("__repr__", [](const FieldArrayField& field) {
             const std::string& desc = field.description == "[Brief Description]" ? "" : field.description;
-            return nb::str("FieldArrayField(name={!r}, type={}, data_type={}, description={!r}, conversion={!r}, array_length={!r}, field_size={!r}, "
+            return nb::str("FieldArrayField(name={!r}, type={}, data_type={}, description={!r}, conversion={!r}, array_length={!r}, "
                            "fields={!r})")
-                .format(field.name, nb::cast(field.type), field.dataType.name, desc, field.conversion, field.arrayLength, field.fieldSize,
-                        field.fields);
+                .format(field.name, nb::cast(field.type), field.dataType.name, desc, field.conversion, field.arrayLength, field.fields);
         });
 
     nb::class_<MessageDefinition>(m, "MessageDefinition", "Struct containing elements of message definitions in the UI DB")

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -285,16 +285,35 @@ void py_common::init_common_message_database(nb::module_& m)
 
     nb::class_<MessageDefinition>(m, "MessageDefinition", "Struct containing elements of message definitions in the UI DB")
         .def(nb::init())
+        .def(
+            "__init__",
+            [](MessageDefinition* t, std::string id, uint32_t log_id, std::string name, std::string description, uint32_t latest_message_crc,
+               std::unordered_map<uint32_t, std::vector<std::shared_ptr<BaseField>>> fields) {
+                auto* def = new (t) MessageDefinition; // NOLINT(*.NewDeleteLeaks)
+                def->_id = std::move(id);
+                def->logID = log_id;
+                def->name = std::move(name);
+                def->description = std::move(description);
+                def->latestMessageCrc = latest_message_crc;
+                def->fields = std::move(fields);
+            },
+            "id"_a = std::string{}, "log_id"_a = uint32_t{0}, "name"_a = std::string{}, "description"_a = std::string{},
+            "latest_message_crc"_a = uint32_t{0},
+            "fields"_a = std::unordered_map<uint32_t, std::vector<std::shared_ptr<BaseField>>>{})
         .def_rw("id", &MessageDefinition::_id)
         .def_rw("log_id", &MessageDefinition::logID)
         .def_rw("name", &MessageDefinition::name)
         .def_rw("description", &MessageDefinition::description)
-        .def_prop_ro("fields",
-                     [](MessageDefinition& self) {
-                         nb::dict py_map;
-                         for (const auto& [id, value] : self.fields) { py_map[nb::cast(id)] = nb::cast(value); }
-                         return py_map;
-                     })
+        .def_prop_rw(
+            "fields",
+            [](MessageDefinition& self) {
+                nb::dict py_map;
+                for (const auto& [id, value] : self.fields) { py_map[nb::cast(id)] = nb::cast(value); }
+                return py_map;
+            },
+            [](MessageDefinition& self, std::unordered_map<uint32_t, std::vector<std::shared_ptr<BaseField>>> fields) {
+                self.fields = std::move(fields);
+            })
         .def_rw("latest_message_crc", &MessageDefinition::latestMessageCrc)
         .def("__eq__", [](const MessageDefinition& self, const MessageDefinition& other) { return self == other; })
         .def("__repr__", [](nb::handle_t<MessageDefinition> self) {

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -341,5 +341,19 @@ void py_common::init_common_message_database(nb::module_& m)
             },
             "id"_a)
         .def_prop_rw("message_family", &py_common::PyMessageDatabase::GetMessageFamily, &py_common::PyMessageDatabase::SetMessageFamily)
-        .def("clone", &py_common::PyMessageDatabase::clone, "Create a copy of this database.", nb::sig("def clone(self) -> \"MessageDatabase\""));
+        .def("fork", &py_common::PyMessageDatabase::fork,
+             "Return a mutable copy of this database that shares the same definitions and types for messages and enums.\n\n"
+             "As a side effect, the existing database (this one) will be locked. Any subsequent call that would modify it "
+             "will raise an exception.",
+             nb::sig("def fork(self) -> \"MessageDatabase\""))
+        .def(
+            "clone",
+            [](py_common::PyMessageDatabase& self) {
+                GetBaseLoggerManager()
+                    ->RegisterLogger("deprecation_warning")
+                    ->warn("MessageDatabase.clone() is deprecated; use MessageDatabase.fork() instead.");
+                return self.fork();
+            },
+            "Deprecated alias for fork(); use fork() instead. Like fork(), this locks the source database as a side effect.",
+            nb::sig("def clone(self) -> \"MessageDatabase\""));
 }

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -120,16 +120,11 @@ void py_common::init_common_message_database(nb::module_& m)
             return nb::str("EnumDefinition(id={!r}, name={!r}, enumerators={!r})").format(enum_def._id, enum_def.name, enum_def.enumerators);
         });
 
-    nb::class_<BaseDataType>(m, "BaseDataType", "Struct containing basic elements of data type fields in the UI DB")
+    nb::class_<SimpleDataType>(m, "SimpleDataType", "Struct containing elements of simple data type fields in the UI DB")
         .def(nb::init())
-        .def_rw("name", &BaseDataType::name)
-        .def_rw("length", &BaseDataType::length)
-        .def_rw("description", &BaseDataType::description)
-        .def("__eq__", [](const BaseDataType& self, const BaseDataType& other) { return self == other; });
-
-    nb::class_<SimpleDataType, BaseDataType>(m, "SimpleDataType", "Struct containing elements of simple data type fields in the UI DB")
-        .def(nb::init())
-        .def_rw("enums", &SimpleDataType::enums)
+        .def_rw("name", &SimpleDataType::name)
+        .def_rw("length", &SimpleDataType::length)
+        .def_rw("description", &SimpleDataType::description)
         .def("__eq__", [](const SimpleDataType& self, const SimpleDataType& other) { return self == other; });
 
     nb::class_<BaseField>(m, "FieldDefinition", "Struct containing elements of basic fields in the UI DB")

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -235,35 +235,35 @@ void py_common::init_common_message_database(nb::module_& m)
             "get_msg_def",
             [](const py_common::PyMessageDatabase& self, std::string_view msg_name) -> MessageDefinition::ConstPtr {
                 auto def = self.GetMsgDef(msg_name);
-                return def ? py_common::cloneMessageDef(*def) : nullptr;
+                return def ? std::make_shared<MessageDefinition>(*def) : nullptr;
             },
             "msg_name"_a)
         .def(
             "get_msg_def",
             [](const py_common::PyMessageDatabase& self, int32_t msg_id) -> MessageDefinition::ConstPtr {
                 auto def = self.GetMsgDef(msg_id);
-                return def ? py_common::cloneMessageDef(*def) : nullptr;
+                return def ? std::make_shared<MessageDefinition>(*def) : nullptr;
             },
             "msg_id"_a)
         .def(
             "get_enum_def",
             [](const py_common::PyMessageDatabase& self, const std::string& enum_id) -> EnumDefinition::ConstPtr {
                 auto def = self.GetEnumDefId(enum_id);
-                return def ? py_common::cloneEnumDef(*def) : nullptr;
+                return def ? std::make_shared<EnumDefinition>(*def) : nullptr;
             },
             "enum_id"_a)
         .def(
             "get_enum_def_by_id",
             [](const py_common::PyMessageDatabase& self, const std::string& enum_id) -> EnumDefinition::ConstPtr {
                 auto def = self.GetEnumDefId(enum_id);
-                return def ? py_common::cloneEnumDef(*def) : nullptr;
+                return def ? std::make_shared<EnumDefinition>(*def) : nullptr;
             },
             "enum_id"_a)
         .def(
             "get_enum_def_by_name",
             [](const py_common::PyMessageDatabase& self, const std::string& enum_name) -> EnumDefinition::ConstPtr {
                 auto def = self.GetEnumDefName(enum_name);
-                return def ? py_common::cloneEnumDef(*def) : nullptr;
+                return def ? std::make_shared<EnumDefinition>(*def) : nullptr;
             },
             "enum_name"_a)
         .def(

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -12,6 +12,51 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace novatel::edie;
 
+// Register custom garbage collection logic for message database so that
+// it can share a lifetime with its owned types
+// https://nanobind.readthedocs.io/en/latest/refleaks.html#fixing-reference-leaks
+
+int py_common::db_tp_traverse(PyObject* self, visitproc visit, void* arg)
+{
+    // We must traverse the implicit dependency of an object on its
+    // associated type object.
+    Py_VISIT(Py_TYPE(self));
+
+    // The tp_traverse method may be called after __new__ but before or during
+    // __init__, before the C++ constructor has been completed. We must not
+    // inspect the C++ state if the constructor has not yet completed.
+    if (!nb::inst_ready(self)) { return 0; }
+
+    // Get the C++ object associated with 'self' (this always succeeds)
+    py_common::PyMessageDatabase* db = nb::inst_ptr<py_common::PyMessageDatabase>(self);
+
+    // Traverse all python types held by the database
+    for (auto& message_version_types : db->messages_types)
+    {
+        for (auto& message_type : message_version_types.second) { Py_VISIT(message_type.second.ptr()); }
+    }
+    for (auto& field_type : db->field_types) { Py_VISIT(field_type.second.ptr()); }
+    for (auto& enum_type : db->enum_types) { Py_VISIT(enum_type.second.ptr()); }
+
+    return 0;
+}
+
+int py_common::db_tp_clear(PyObject* self)
+{
+    // Get the C++ object associated with 'self' (this always succeeds)
+    py_common::PyMessageDatabase* db = nb::inst_ptr<py_common::PyMessageDatabase>(self);
+
+    // Break the reference cycle!
+    db->messages_types.clear();
+    db->field_types.clear();
+    db->enum_types.clear();
+
+    return 0;
+}
+
+// Table of custom type slots we want to install
+PyType_Slot db_slots[] = {{Py_tp_traverse, (void*)py_common::db_tp_traverse}, {Py_tp_clear, (void*)py_common::db_tp_clear}, {0, 0}};
+
 void py_common::init_common_message_database(nb::module_& m)
 {
     nb::enum_<DATA_TYPE>(m, "DATA_TYPE", "The concrete data types of base-level message fields.", nb::is_arithmetic())
@@ -166,14 +211,12 @@ void py_common::init_common_message_database(nb::module_& m)
                 .format(msg_def.name, msg_def._id, msg_def.logID, msg_def.description, self.attr("fields"), msg_def.latestMessageCrc);
         });
 
-    nb::class_<py_common::PyMessageDatabase>(m, "MessageDatabase")
+    nb::class_<py_common::PyMessageDatabase>(m, "MessageDatabase", nb::type_slots(db_slots))
         .def(nb::new_([]() { return py_common::PyMessageDatabase::Create(); }))
-        .def(nb::new_(
-                 [](std::filesystem::path& file_path) { return py_common::PyMessageDatabase::Create(std::move(*LoadJsonDbFile(file_path))); }),
+        .def(nb::new_([](std::filesystem::path& file_path) { return py_common::PyMessageDatabase::Create(std::move(*LoadJsonDbFile(file_path))); }),
              "file_path"_a)
         .def_static(
-            "from_string",
-            [](std::string_view json_data) { return py_common::PyMessageDatabase::Create(std::move(*ParseJsonDb(json_data))); },
+            "from_string", [](std::string_view json_data) { return py_common::PyMessageDatabase::Create(std::move(*ParseJsonDb(json_data))); },
             "json_data"_a)
         .def("merge", &py_common::PyMessageDatabase::Merge, "other_db"_a)
         .def("append_messages", &py_common::PyMessageDatabase::AppendMessages, "messages"_a)

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -99,8 +99,7 @@ void py_common::init_common_message_database(nb::module_& m)
     m.attr("str_to_FIELD_TYPE") = FieldTypeEnumLookup;
 
     nb::class_<EnumDataType>(m, "EnumDataType", "Enum Data Type representing contents of UI DB")
-        .def(nb::init())
-        .def(nb::init<uint32_t, std::string, std::string>(), "value"_a, "name"_a, "description"_a)
+        .def(nb::init<uint32_t, std::string, std::string>(), "value"_a = uint32_t{0}, "name"_a = std::string{}, "description"_a = std::string{})
         .def_rw("value", &EnumDataType::value)
         .def_rw("name", &EnumDataType::name)
         .def_rw("description", &EnumDataType::description)
@@ -113,9 +112,8 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<EnumDefinition>(m, "EnumDefinition", "Enum Definition representing contents of UI DB")
-        .def(nb::init())
-        .def(nb::init<std::string, std::string, std::vector<EnumDataType>>(),
-             "id"_a = std::string{}, "name"_a = std::string{}, "enumerators"_a = std::vector<EnumDataType>{})
+        .def(nb::init<std::string, std::string, std::vector<EnumDataType>>(), "id"_a = std::string{}, "name"_a = std::string{},
+             "enumerators"_a = std::vector<EnumDataType>{})
         .def_rw("id", &EnumDefinition::_id)
         .def_rw("name", &EnumDefinition::name)
         .def_rw("enumerators", &EnumDefinition::enumerators)
@@ -124,18 +122,8 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<BaseField>(m, "FieldDefinition", "Struct containing elements of basic fields in the UI DB")
-        .def(nb::init())
-        .def(
-            "__init__",
-            [](BaseField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type) {
-                auto* field = new (t) BaseField; // NOLINT(*.NewDeleteLeaks)
-                field->name = std::move(name);
-                field->type = type;
-                field->dataType.name = data_type;
-                field->dataType.length = static_cast<uint16_t>(DataTypeSize(data_type));
-                if (!conversion.empty()) { field->SetConversion(std::move(conversion)); }
-            },
-            "name"_a = std::string{}, "type"_a = FIELD_TYPE::UNKNOWN, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN)
+        .def(nb::init<std::string, FIELD_TYPE, std::string, DATA_TYPE>(), "name"_a = std::string{}, "type"_a = FIELD_TYPE::UNKNOWN,
+             "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN)
         .def_rw("name", &BaseField::name)
         .def_rw("type", &BaseField::type)
         .def_rw("description", &BaseField::description)
@@ -170,19 +158,8 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<EnumField, BaseField>(m, "EnumFieldDefinition", "Struct containing elements of enum fields in the UI DB")
-        .def(
-            "__init__",
-            [](EnumField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type, std::string enum_id) {
-                auto* field = new (t) EnumField; // NOLINT(*.NewDeleteLeaks)
-                field->name = std::move(name);
-                field->type = type;
-                field->dataType.name = data_type;
-                field->dataType.length = static_cast<uint16_t>(DataTypeSize(data_type));
-                if (!conversion.empty()) { field->SetConversion(std::move(conversion)); }
-                field->enumId = std::move(enum_id);
-            },
-            "name"_a = std::string{}, "type"_a = FIELD_TYPE::ENUM, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN,
-            "enum_id"_a = std::string{})
+        .def(nb::init<std::string, FIELD_TYPE, std::string, DATA_TYPE, std::string>(), "name"_a = std::string{}, "type"_a = FIELD_TYPE::ENUM,
+             "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN, "enum_id"_a = std::string{})
         .def_rw("enum_id", &EnumField::enumId)
         .def_ro("enum_def", &EnumField::enumDef)
         .def("__repr__", [](const EnumField& field) {
@@ -192,20 +169,8 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<ArrayField, BaseField>(m, "ArrayFieldDefinition", "Struct containing elements of array fields in the UI DB")
-        .def(nb::init())
-        .def(
-            "__init__",
-            [](ArrayField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type, uint32_t array_length) {
-                auto* field = new (t) ArrayField; // NOLINT(*.NewDeleteLeaks)
-                field->name = std::move(name);
-                field->type = type;
-                field->dataType.name = data_type;
-                field->dataType.length = static_cast<uint16_t>(DataTypeSize(data_type));
-                if (!conversion.empty()) { field->SetConversion(std::move(conversion)); }
-                field->arrayLength = array_length;
-            },
-            "name"_a = std::string{}, "type"_a = FIELD_TYPE::UNKNOWN, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN,
-            "array_length"_a = uint32_t{0})
+        .def(nb::init<std::string, FIELD_TYPE, std::string, DATA_TYPE, uint32_t>(), "name"_a = std::string{}, "type"_a = FIELD_TYPE::UNKNOWN,
+             "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN, "array_length"_a = uint32_t{0})
         .def_rw("array_length", &ArrayField::arrayLength)
         .def("__repr__", [](const ArrayField& field) {
             const std::string& desc = field.description == "[Brief Description]" ? "" : field.description;
@@ -214,21 +179,9 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<FieldArrayField, BaseField>(m, "FieldArrayFieldDefinition", "Struct containing elements of field array fields in the UI DB")
-        .def(
-            "__init__",
-            [](FieldArrayField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type, uint32_t array_length,
-               std::vector<std::shared_ptr<BaseField>> fields) {
-                auto* field = new (t) FieldArrayField; // NOLINT(*.NewDeleteLeaks)
-                field->name = std::move(name);
-                field->type = type;
-                field->dataType.name = data_type;
-                field->dataType.length = static_cast<uint16_t>(DataTypeSize(data_type));
-                if (!conversion.empty()) { field->SetConversion(std::move(conversion)); }
-                field->arrayLength = array_length;
-                field->fields = std::move(fields);
-            },
-            "name"_a = std::string{}, "type"_a = FIELD_TYPE::FIELD_ARRAY, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN,
-            "array_length"_a = uint32_t{0}, "fields"_a = std::vector<std::shared_ptr<BaseField>>{})
+        .def(nb::init<std::string, FIELD_TYPE, std::string, DATA_TYPE, uint32_t, std::vector<std::shared_ptr<BaseField>>>(), "name"_a = std::string{},
+             "type"_a = FIELD_TYPE::FIELD_ARRAY, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN, "array_length"_a = uint32_t{0},
+             "fields"_a = std::vector<std::shared_ptr<BaseField>>{})
         .def_rw("array_length", &FieldArrayField::arrayLength)
         .def_rw("fields", &FieldArrayField::fields, nb::rv_policy::reference_internal)
         .def("__repr__", [](const FieldArrayField& field) {
@@ -239,22 +192,10 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<MessageDefinition>(m, "MessageDefinition", "Struct containing elements of message definitions in the UI DB")
-        .def(nb::init())
-        .def(
-            "__init__",
-            [](MessageDefinition* t, std::string id, uint32_t log_id, std::string name, std::string description, uint32_t latest_message_crc,
-               std::unordered_map<uint32_t, std::vector<std::shared_ptr<BaseField>>> fields) {
-                auto* def = new (t) MessageDefinition; // NOLINT(*.NewDeleteLeaks)
-                def->_id = std::move(id);
-                def->logID = log_id;
-                def->name = std::move(name);
-                def->description = std::move(description);
-                def->latestMessageCrc = latest_message_crc;
-                def->fields = std::move(fields);
-            },
-            "id"_a = std::string{}, "log_id"_a = uint32_t{0}, "name"_a = std::string{}, "description"_a = std::string{},
-            "latest_message_crc"_a = uint32_t{0},
-            "fields"_a = std::unordered_map<uint32_t, std::vector<std::shared_ptr<BaseField>>>{})
+        .def(nb::init<std::string, uint32_t, std::string, std::string, uint32_t,
+                      std::unordered_map<uint32_t, std::vector<std::shared_ptr<BaseField>>>>(),
+             "id"_a = std::string{}, "log_id"_a = uint32_t{0}, "name"_a = std::string{}, "description"_a = std::string{},
+             "latest_message_crc"_a = uint32_t{0}, "fields"_a = std::unordered_map<uint32_t, std::vector<std::shared_ptr<BaseField>>>{})
         .def_rw("id", &MessageDefinition::_id)
         .def_rw("log_id", &MessageDefinition::logID)
         .def_rw("name", &MessageDefinition::name)
@@ -284,9 +225,23 @@ void py_common::init_common_message_database(nb::module_& m)
         .def_static(
             "from_string", [](std::string_view json_data) { return py_common::PyMessageDatabase::Create(std::move(*ParseJsonDb(json_data))); },
             "json_data"_a)
+        .def("lock", &py_common::PyMessageDatabase::Lock, "Prevent further mutation of this database.")
+        .def_prop_ro("is_locked", &py_common::PyMessageDatabase::IsLocked)
         .def("merge", &py_common::PyMessageDatabase::Merge, "other_db"_a)
-        .def("append_messages", &py_common::PyMessageDatabase::AppendMessages, "messages"_a)
-        .def("append_enumerations", &py_common::PyMessageDatabase::AppendEnumerations, "enums"_a)
+        .def(
+            "append_messages",
+            [](py_common::PyMessageDatabase& self, nb::object messages) {
+                self.ThrowIfLocked();
+                self.AppendMessages(nb::cast<std::vector<MessageDefinition::ConstPtr>>(messages));
+            },
+            "messages"_a)
+        .def(
+            "append_enumerations",
+            [](py_common::PyMessageDatabase& self, nb::object enums) {
+                self.ThrowIfLocked();
+                self.AppendEnumerations(nb::cast<std::vector<EnumDefinition::ConstPtr>>(enums));
+            },
+            "enums"_a)
         .def("remove_message", &py_common::PyMessageDatabase::RemoveMessage, "msg_id"_a)
         .def("remove_enumeration", &py_common::PyMessageDatabase::RemoveEnumeration, "enumeration"_a)
         .def(
@@ -307,11 +262,26 @@ void py_common::init_common_message_database(nb::module_& m)
         .def("get_enum_def_by_id", &py_common::PyMessageDatabase::GetEnumDefId, "enum_id"_a)
         .def("get_enum_def_by_name", &py_common::PyMessageDatabase::GetEnumDefName, "enum_name"_a)
         .def(
-            "get_msg_type", [](py_common::PyMessageDatabase& self, std::string name) { return self.GetMessageType(name); }, "name"_a)
+            "get_msg_type",
+            [](py_common::PyMessageDatabase& self, std::string name) {
+                self.Lock();
+                return self.GetMessageType(name);
+            },
+            "name"_a)
         .def(
-            "get_enum_type_by_name", [](py_common::PyMessageDatabase& self, std::string name) { return self.GetEnumTypeByName(name); }, "name"_a)
+            "get_enum_type_by_name",
+            [](py_common::PyMessageDatabase& self, std::string name) {
+                self.Lock();
+                return self.GetEnumTypeByName(name);
+            },
+            "name"_a)
         .def(
-            "get_enum_type_by_id", [](py_common::PyMessageDatabase& self, std::string id) { return self.GetEnumTypeById(id); }, "id"_a)
+            "get_enum_type_by_id",
+            [](py_common::PyMessageDatabase& self, std::string id) {
+                self.Lock();
+                return self.GetEnumTypeById(id);
+            },
+            "id"_a)
         .def_prop_rw("message_family", &py_common::PyMessageDatabase::GetMessageFamily, &py_common::PyMessageDatabase::SetMessageFamily)
-        .def("clone", &py_common::PyMessageDatabase::clone, "Create a copy of this database.");
+        .def("clone", &py_common::PyMessageDatabase::clone, "Create a copy of this database.", nb::sig("def clone(self) -> \"MessageDatabase\""));
 }

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -167,15 +167,13 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<py_common::PyMessageDatabase>(m, "MessageDatabase")
-        .def(nb::new_([]() { return std::make_shared<py_common::PyMessageDatabase>(); }))
+        .def(nb::new_([]() { return py_common::PyMessageDatabase::Create(); }))
         .def(nb::new_(
-                 [](std::filesystem::path& file_path) {
-                     return std::make_shared<py_common::PyMessageDatabase>(std::move(*LoadJsonDbFile(file_path)));
-                 }),
+                 [](std::filesystem::path& file_path) { return py_common::PyMessageDatabase::Create(std::move(*LoadJsonDbFile(file_path))); }),
              "file_path"_a)
         .def_static(
             "from_string",
-            [](std::string_view json_data) { return std::make_shared<py_common::PyMessageDatabase>(std::move(*ParseJsonDb(json_data))); },
+            [](std::string_view json_data) { return py_common::PyMessageDatabase::Create(std::move(*ParseJsonDb(json_data))); },
             "json_data"_a)
         .def("merge", &py_common::PyMessageDatabase::Merge, "other_db"_a)
         .def("append_messages", &py_common::PyMessageDatabase::AppendMessages, "messages"_a)

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -50,6 +50,9 @@ int py_common::db_tp_clear(PyObject* self)
     db->messages_types.clear();
     db->field_types.clear();
     db->enum_types.clear();
+    db->message_type_lookup_.clear();
+    db->field_type_lookup_.clear();
+    db->enum_type_lookup_.clear();
 
     return 0;
 }

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -103,6 +103,7 @@ void py_common::init_common_message_database(nb::module_& m)
         .def_rw("value", &EnumDataType::value)
         .def_rw("name", &EnumDataType::name)
         .def_rw("description", &EnumDataType::description)
+        .def("__eq__", [](const EnumDataType& self, const EnumDataType& other) { return self == other; })
         .def("__repr__", [](const EnumDataType& enum_data_type) {
             if (enum_data_type.description.empty())
                 return nb::str("EnumDataType(name={!r}, value={!r})").format(enum_data_type.name, enum_data_type.value);
@@ -123,11 +124,13 @@ void py_common::init_common_message_database(nb::module_& m)
         .def(nb::init())
         .def_rw("name", &BaseDataType::name)
         .def_rw("length", &BaseDataType::length)
-        .def_rw("description", &BaseDataType::description);
+        .def_rw("description", &BaseDataType::description)
+        .def("__eq__", [](const BaseDataType& self, const BaseDataType& other) { return self == other; });
 
     nb::class_<SimpleDataType, BaseDataType>(m, "SimpleDataType", "Struct containing elements of simple data type fields in the UI DB")
         .def(nb::init())
-        .def_rw("enums", &SimpleDataType::enums);
+        .def_rw("enums", &SimpleDataType::enums)
+        .def("__eq__", [](const SimpleDataType& self, const SimpleDataType& other) { return self == other; });
 
     nb::class_<BaseField>(m, "FieldDefinition", "Struct containing elements of basic fields in the UI DB")
         .def(nb::init())
@@ -140,6 +143,7 @@ void py_common::init_common_message_database(nb::module_& m)
         .def_rw("precision", &BaseField::precision)
         .def_rw("data_type", &BaseField::dataType)
         .def("set_conversion", &BaseField::SetConversion, "conversion"_a)
+        .def("__eq__", [](const BaseField& self, const BaseField& other) { return self == other; })
         .def("__repr__", [](const BaseField& field) {
             const std::string& desc = field.description == "[Brief Description]" ? "" : field.description;
             if (desc.empty() && field.conversion.empty())
@@ -208,6 +212,7 @@ void py_common::init_common_message_database(nb::module_& m)
                          return py_map;
                      })
         .def_rw("latest_message_crc", &MessageDefinition::latestMessageCrc)
+        .def("__eq__", [](const MessageDefinition& self, const MessageDefinition& other) { return self == other; })
         .def("__repr__", [](nb::handle_t<MessageDefinition> self) {
             auto& msg_def = nb::cast<MessageDefinition&>(self);
             return nb::str("MessageDefinition(name={!r}, id={!r}, log_id={!r}, description={!r}, fields={!r}, latest_message_crc={!r})")
@@ -226,11 +231,41 @@ void py_common::init_common_message_database(nb::module_& m)
         .def("append_enumerations", &py_common::PyMessageDatabase::AppendEnumerations, "enums"_a)
         .def("remove_message", &py_common::PyMessageDatabase::RemoveMessage, "msg_id"_a)
         .def("remove_enumeration", &py_common::PyMessageDatabase::RemoveEnumeration, "enumeration"_a)
-        .def("get_msg_def", nb::overload_cast<std::string_view>(&py_common::PyMessageDatabase::GetMsgDef, nb::const_), "msg_name"_a)
-        .def("get_msg_def", nb::overload_cast<int32_t>(&py_common::PyMessageDatabase::GetMsgDef, nb::const_), "msg_id"_a)
-        .def("get_enum_def", &py_common::PyMessageDatabase::GetEnumDefId, "enum_id"_a)
-        .def("get_enum_def_by_id", &py_common::PyMessageDatabase::GetEnumDefId, "enum_id"_a)
-        .def("get_enum_def_by_name", &py_common::PyMessageDatabase::GetEnumDefName, "enum_name"_a)
+        .def(
+            "get_msg_def",
+            [](const py_common::PyMessageDatabase& self, std::string_view msg_name) -> MessageDefinition::ConstPtr {
+                auto def = self.GetMsgDef(msg_name);
+                return def ? py_common::cloneMessageDef(*def) : nullptr;
+            },
+            "msg_name"_a)
+        .def(
+            "get_msg_def",
+            [](const py_common::PyMessageDatabase& self, int32_t msg_id) -> MessageDefinition::ConstPtr {
+                auto def = self.GetMsgDef(msg_id);
+                return def ? py_common::cloneMessageDef(*def) : nullptr;
+            },
+            "msg_id"_a)
+        .def(
+            "get_enum_def",
+            [](const py_common::PyMessageDatabase& self, const std::string& enum_id) -> EnumDefinition::ConstPtr {
+                auto def = self.GetEnumDefId(enum_id);
+                return def ? py_common::cloneEnumDef(*def) : nullptr;
+            },
+            "enum_id"_a)
+        .def(
+            "get_enum_def_by_id",
+            [](const py_common::PyMessageDatabase& self, const std::string& enum_id) -> EnumDefinition::ConstPtr {
+                auto def = self.GetEnumDefId(enum_id);
+                return def ? py_common::cloneEnumDef(*def) : nullptr;
+            },
+            "enum_id"_a)
+        .def(
+            "get_enum_def_by_name",
+            [](const py_common::PyMessageDatabase& self, const std::string& enum_name) -> EnumDefinition::ConstPtr {
+                auto def = self.GetEnumDefName(enum_name);
+                return def ? py_common::cloneEnumDef(*def) : nullptr;
+            },
+            "enum_name"_a)
         .def(
             "get_msg_type", [](py_common::PyMessageDatabase& self, std::string name) { return self.GetMessageType(name); }, "name"_a)
         .def(

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -114,21 +114,8 @@ void py_common::init_common_message_database(nb::module_& m)
 
     nb::class_<EnumDefinition>(m, "EnumDefinition", "Enum Definition representing contents of UI DB")
         .def(nb::init())
-        .def(
-            "__init__",
-            [](EnumDefinition* t, std::string id, std::string name, std::vector<EnumDataType> enumerators) {
-                auto* def = new (t) EnumDefinition; // NOLINT(*.NewDeleteLeaks)
-                def->_id = std::move(id);
-                def->name = std::move(name);
-                def->enumerators = std::move(enumerators);
-                for (const auto& enumerator : def->enumerators)
-                {
-                    def->nameValue[enumerator.name] = enumerator.value;
-                    def->valueName[enumerator.value] = enumerator.name;
-                    def->descriptionValue[enumerator.description] = enumerator.value;
-                }
-            },
-            "id"_a = std::string{}, "name"_a = std::string{}, "enumerators"_a = std::vector<EnumDataType>{})
+        .def(nb::init<std::string, std::string, std::vector<EnumDataType>>(),
+             "id"_a = std::string{}, "name"_a = std::string{}, "enumerators"_a = std::vector<EnumDataType>{})
         .def_rw("id", &EnumDefinition::_id)
         .def_rw("name", &EnumDefinition::name)
         .def_rw("enumerators", &EnumDefinition::enumerators)
@@ -185,8 +172,7 @@ void py_common::init_common_message_database(nb::module_& m)
     nb::class_<EnumField, BaseField>(m, "EnumFieldDefinition", "Struct containing elements of enum fields in the UI DB")
         .def(
             "__init__",
-            [](EnumField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type, std::string enum_id,
-               std::vector<EnumDataType> enumerators) {
+            [](EnumField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type, std::string enum_id) {
                 auto* field = new (t) EnumField; // NOLINT(*.NewDeleteLeaks)
                 field->name = std::move(name);
                 field->type = type;
@@ -194,42 +180,11 @@ void py_common::init_common_message_database(nb::module_& m)
                 field->dataType.length = static_cast<uint16_t>(DataTypeSize(data_type));
                 if (!conversion.empty()) { field->SetConversion(std::move(conversion)); }
                 field->enumId = std::move(enum_id);
-                if (!enumerators.empty())
-                {
-                    auto enum_def = std::make_shared<EnumDefinition>();
-                    enum_def->enumerators = std::move(enumerators);
-                    for (const auto& enumerator : enum_def->enumerators)
-                    {
-                        enum_def->nameValue[enumerator.name] = enumerator.value;
-                        enum_def->valueName[enumerator.value] = enumerator.name;
-                        enum_def->descriptionValue[enumerator.description] = enumerator.value;
-                    }
-                    field->enumDef = std::move(enum_def);
-                }
             },
             "name"_a = std::string{}, "type"_a = FIELD_TYPE::ENUM, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN,
-            "enum_id"_a = std::string{}, "enumerators"_a = std::vector<EnumDataType>{})
+            "enum_id"_a = std::string{})
         .def_rw("enum_id", &EnumField::enumId)
         .def_ro("enum_def", &EnumField::enumDef)
-        .def_prop_rw(
-            "enumerators",
-            [](const EnumField& self) { return self.enumDef ? self.enumDef->enumerators : std::vector<EnumDataType>{}; },
-            [](EnumField& self, std::vector<EnumDataType> enumerators) {
-                auto new_def = std::make_shared<EnumDefinition>();
-                if (self.enumDef)
-                {
-                    new_def->_id = self.enumDef->_id;
-                    new_def->name = self.enumDef->name;
-                }
-                new_def->enumerators = std::move(enumerators);
-                for (const auto& enumerator : new_def->enumerators)
-                {
-                    new_def->nameValue[enumerator.name] = enumerator.value;
-                    new_def->valueName[enumerator.value] = enumerator.name;
-                    new_def->descriptionValue[enumerator.description] = enumerator.value;
-                }
-                self.enumDef = std::move(new_def);
-            })
         .def("__repr__", [](const EnumField& field) {
             const std::string& desc = field.description == "[Brief Description]" ? "" : field.description;
             return nb::str("EnumField(name={!r}, type={}, data_type={}, description={!r}, conversion={!r}, enum_id={!r})")

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -116,16 +116,37 @@ void py_common::init_common_message_database(nb::module_& m)
              "enumerators"_a = std::vector<EnumDataType>{})
         .def_rw("id", &EnumDefinition::_id)
         .def_rw("name", &EnumDefinition::name)
-        .def_rw("enumerators", &EnumDefinition::enumerators)
+        .def_prop_rw(
+            "enumerators", [](EnumDefinition& self) -> std::vector<EnumDataType>& { return self.enumerators; },
+            [](EnumDefinition& self, std::vector<EnumDataType> value) {
+                self.enumerators = std::move(value);
+                self.RebuildCaches();
+            })
         .def("__repr__", [](const EnumDefinition& enum_def) {
             return nb::str("EnumDefinition(id={!r}, name={!r}, enumerators={!r})").format(enum_def._id, enum_def.name, enum_def.enumerators);
         });
 
     nb::class_<BaseField>(m, "FieldDefinition", "Struct containing elements of basic fields in the UI DB")
-        .def(nb::init<std::string, FIELD_TYPE, std::string, DATA_TYPE>(), "name"_a = std::string{}, "type"_a = FIELD_TYPE::UNKNOWN,
-             "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN)
+        .def(
+            "__init__",
+            [](BaseField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type) {
+                try
+                {
+                    new (t) BaseField(std::move(name), type, std::move(conversion), data_type); // NOLINT(*.NewDeleteLeaks)
+                }
+                catch (const std::exception& e)
+                {
+                    throw nb::value_error(e.what());
+                }
+            },
+            "name"_a = std::string{}, "type"_a = FIELD_TYPE::UNKNOWN, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN)
         .def_rw("name", &BaseField::name)
-        .def_rw("type", &BaseField::type)
+        .def_prop_rw(
+            "type", [](const BaseField& self) { return self.type; },
+            [](BaseField& self, FIELD_TYPE value) {
+                self.type = value;
+                self.RecomputeStringFlags();
+            })
         .def_rw("description", &BaseField::description)
         .def_prop_rw(
             "conversion", [](const BaseField& self) -> const std::string& { return self.conversion; },
@@ -158,8 +179,20 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<EnumField, BaseField>(m, "EnumFieldDefinition", "Struct containing elements of enum fields in the UI DB")
-        .def(nb::init<std::string, FIELD_TYPE, std::string, DATA_TYPE, std::string>(), "name"_a = std::string{}, "type"_a = FIELD_TYPE::ENUM,
-             "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN, "enum_id"_a = std::string{})
+        .def(
+            "__init__",
+            [](EnumField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type, std::string enum_id) {
+                try
+                {
+                    new (t) EnumField(std::move(name), type, std::move(conversion), data_type, std::move(enum_id)); // NOLINT(*.NewDeleteLeaks)
+                }
+                catch (const std::exception& e)
+                {
+                    throw nb::value_error(e.what());
+                }
+            },
+            "name"_a = std::string{}, "type"_a = FIELD_TYPE::ENUM, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN,
+            "enum_id"_a = std::string{})
         .def_rw("enum_id", &EnumField::enumId)
         .def_ro("enum_def", &EnumField::enumDef)
         .def("__repr__", [](const EnumField& field) {
@@ -169,8 +202,20 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<ArrayField, BaseField>(m, "ArrayFieldDefinition", "Struct containing elements of array fields in the UI DB")
-        .def(nb::init<std::string, FIELD_TYPE, std::string, DATA_TYPE, uint32_t>(), "name"_a = std::string{}, "type"_a = FIELD_TYPE::UNKNOWN,
-             "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN, "array_length"_a = uint32_t{0})
+        .def(
+            "__init__",
+            [](ArrayField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type, uint32_t array_length) {
+                try
+                {
+                    new (t) ArrayField(std::move(name), type, std::move(conversion), data_type, array_length); // NOLINT(*.NewDeleteLeaks)
+                }
+                catch (const std::exception& e)
+                {
+                    throw nb::value_error(e.what());
+                }
+            },
+            "name"_a = std::string{}, "type"_a = FIELD_TYPE::UNKNOWN, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN,
+            "array_length"_a = uint32_t{0})
         .def_rw("array_length", &ArrayField::arrayLength)
         .def("__repr__", [](const ArrayField& field) {
             const std::string& desc = field.description == "[Brief Description]" ? "" : field.description;
@@ -179,9 +224,22 @@ void py_common::init_common_message_database(nb::module_& m)
         });
 
     nb::class_<FieldArrayField, BaseField>(m, "FieldArrayFieldDefinition", "Struct containing elements of field array fields in the UI DB")
-        .def(nb::init<std::string, FIELD_TYPE, std::string, DATA_TYPE, uint32_t, std::vector<std::shared_ptr<BaseField>>>(), "name"_a = std::string{},
-             "type"_a = FIELD_TYPE::FIELD_ARRAY, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN, "array_length"_a = uint32_t{0},
-             "fields"_a = std::vector<std::shared_ptr<BaseField>>{})
+        .def(
+            "__init__",
+            [](FieldArrayField* t, std::string name, FIELD_TYPE type, std::string conversion, DATA_TYPE data_type, uint32_t array_length,
+               std::vector<std::shared_ptr<BaseField>> fields) {
+                try
+                {
+                    new (t) FieldArrayField(std::move(name), type, std::move(conversion), data_type, array_length,
+                                            std::move(fields)); // NOLINT(*.NewDeleteLeaks)
+                }
+                catch (const std::exception& e)
+                {
+                    throw nb::value_error(e.what());
+                }
+            },
+            "name"_a = std::string{}, "type"_a = FIELD_TYPE::FIELD_ARRAY, "conversion"_a = std::string{}, "data_type"_a = DATA_TYPE::UNKNOWN,
+            "array_length"_a = uint32_t{0}, "fields"_a = std::vector<std::shared_ptr<BaseField>>{})
         .def_rw("array_length", &FieldArrayField::arrayLength)
         .def_rw("fields", &FieldArrayField::fields, nb::rv_policy::reference_internal)
         .def("__repr__", [](const FieldArrayField& field) {

--- a/python/src/py_common/bindings/message_database.cpp
+++ b/python/src/py_common/bindings/message_database.cpp
@@ -145,7 +145,7 @@ void py_common::init_common_message_database(nb::module_& m)
             "type", [](const BaseField& self) { return self.type; },
             [](BaseField& self, FIELD_TYPE value) {
                 self.type = value;
-                self.RecomputeStringFlags();
+                self.ComputeStringFlags();
             })
         .def_rw("description", &BaseField::description)
         .def_prop_rw(

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -97,16 +97,71 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::Merge(const Ptr& other_)
     AppendMessageTypes(other_->core_->MessageDefinitions());
 }
 
+// Deep-copies a message definition. The underlying MessageDatabase::AppendMessages
+// writes through `EnumField::enumDef` via MapMessageEnumFields; without an owned
+// copy that mutation corrupts the source database's shared field defs.
+// `get_msg_def` returns a clone for the same reason: handing the caller a pointer
+// into our internal storage lets them mutate our state (directly, or by appending
+// the def into another database). Python-bound databases are the only callers
+// that legitimately share defs across databases, so the duplication lives here
+// rather than in the C++ base class.
+PYCOMMON_EXPORT MessageDefinition::Ptr py_common::cloneMessageDef(const MessageDefinition& source)
+{
+    auto copy = std::make_shared<MessageDefinition>(source);
+    for (auto& [_crc, fields] : copy->fields)
+    {
+        for (auto& field : fields) { field = field->clone(); }
+    }
+    return copy;
+}
+
+PYCOMMON_EXPORT std::vector<MessageDefinition::ConstPtr> py_common::cloneMessageDefs(const std::vector<MessageDefinition::ConstPtr>& source)
+{
+    std::vector<MessageDefinition::ConstPtr> copies;
+    copies.reserve(source.size());
+    for (const auto& msgDef : source) { copies.push_back(cloneMessageDef(*msgDef)); }
+    return copies;
+}
+
+PYCOMMON_EXPORT EnumDefinition::Ptr py_common::cloneEnumDef(const EnumDefinition& source)
+{
+    auto copy = std::make_shared<EnumDefinition>();
+    copy->_id = source._id;
+    copy->name = source.name;
+    copy->enumerators = source.enumerators;
+    copy->unknownValue = source.unknownValue;
+    // Rebuild the string_view-keyed lookup maps against the copied enumerators
+    // vector so the new definition owns all of its storage (the source's
+    // string_views point into the source's enumerator strings).
+    for (const auto& enumerator : copy->enumerators)
+    {
+        copy->nameValue[enumerator.name] = enumerator.value;
+        copy->valueName[enumerator.value] = enumerator.name;
+        copy->descriptionValue[enumerator.description] = enumerator.value;
+    }
+    return copy;
+}
+
+PYCOMMON_EXPORT std::vector<EnumDefinition::ConstPtr> py_common::cloneEnumDefs(const std::vector<EnumDefinition::ConstPtr>& source)
+{
+    std::vector<EnumDefinition::ConstPtr> copies;
+    copies.reserve(source.size());
+    for (const auto& enumDef : source) { copies.push_back(cloneEnumDef(*enumDef)); }
+    return copies;
+}
+
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendMessages(const std::vector<MessageDefinition::ConstPtr>& vMessageDefinitions_)
 {
-    core_->AppendMessages(vMessageDefinitions_);
-    AppendMessageTypes(vMessageDefinitions_);
+    auto owned = py_common::cloneMessageDefs(vMessageDefinitions_);
+    core_->AppendMessages(owned);
+    AppendMessageTypes(owned);
 }
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendEnumerations(const std::vector<EnumDefinition::ConstPtr>& vEnumDefinitions_)
 {
-    core_->AppendEnumerations(vEnumDefinitions_);
-    AppendEnumTypes(vEnumDefinitions_);
+    auto owned = py_common::cloneEnumDefs(vEnumDefinitions_);
+    core_->AppendEnumerations(owned);
+    AppendEnumTypes(owned);
 }
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveMessage(uint32_t iMsgId_)
@@ -121,7 +176,30 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveEnumeration(std::string
     core_->RemoveEnumeration(strEnumeration_);
 }
 
-PYCOMMON_EXPORT nb::object py_common::PyMessageDatabase::clone() const { return Create(MessageDatabase(*core_)); }
+PYCOMMON_EXPORT nb::object py_common::PyMessageDatabase::clone() const
+{
+    // Build a new wrapper around a shallow copy of the C++ database — same
+    // MessageDefinition / EnumDefinition / BaseField pointers, just a different
+    // MessageDatabase instance.
+    PyMessageDatabase::Ptr db(new PyMessageDatabase(MessageDatabase(*core_)));
+    nb::object wrapper = nb::cast(db);
+    db->ResolveBaseType();
+    // Share the Python type caches with the source. Map keys are raw pointers
+    // into the shared core_, so the same keys identify the same defs in either
+    // database. The dynamic Python types' `_owner_db` attr still points at the
+    // source, which is fine: the type belongs to whichever DB built it, and
+    // GetMessageTypeLookup works on either map.
+    db->messages_types = messages_types;
+    db->field_types = field_types;
+    db->enum_types = enum_types;
+    db->field_name_maps_ = field_name_maps_;
+    db->message_field_name_maps_ = message_field_name_maps_;
+    db->message_type_lookup_ = message_type_lookup_;
+    db->field_type_lookup_ = field_type_lookup_;
+    db->enum_type_lookup_ = enum_type_lookup_;
+    db->allocateExtras();
+    return wrapper;
+}
 
 static void cleanString(std::string& str)
 {

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -222,8 +222,7 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendMessageTypes(const std:
     nb::dict globals;
     globals["field_type"] = nb::type<py_common::PyField>();
     globals["message_type"] = message_family_registration_->messageType;
-    nb::handle my_py_obj = nb::find(this);
-    globals["db"] = nb::none();
+    globals["db"] = nb::find(this);
 
     nb::exec(R"(
     def message_type_cons(name):

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -83,6 +83,7 @@ PYCOMMON_EXPORT std::string py_common::PyMessageDatabase::GetMessageFamily() con
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::SetMessageFamily(const std::string& messageFamily)
 {
+    ThrowIfLocked();
     core_->SetMessageFamily(messageFamily);
     ResolveBaseType();
     UpdatePythonMessageTypes();
@@ -91,6 +92,8 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::SetMessageFamily(const std::s
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::Merge(const Ptr& other_)
 {
+    ThrowIfLocked();
+    other_->Lock();
     core_->AppendEnumerations(other_->core_->EnumDefinitions());
     AppendEnumTypes(other_->core_->EnumDefinitions());
     core_->AppendMessages(other_->core_->MessageDefinitions());
@@ -105,6 +108,7 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::Merge(const Ptr& other_)
 // rather than inside the C++ AppendMessages.
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendMessages(const std::vector<MessageDefinition::ConstPtr>& vMessageDefinitions_)
 {
+    ThrowIfLocked();
     std::vector<MessageDefinition::ConstPtr> owned;
     owned.reserve(vMessageDefinitions_.size());
     for (const auto& msgDef : vMessageDefinitions_) { owned.push_back(std::make_shared<MessageDefinition>(*msgDef)); }
@@ -114,24 +118,28 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendMessages(const std::vec
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendEnumerations(const std::vector<EnumDefinition::ConstPtr>& vEnumDefinitions_)
 {
+    ThrowIfLocked();
     core_->AppendEnumerations(vEnumDefinitions_);
     AppendEnumTypes(vEnumDefinitions_);
 }
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveMessage(uint32_t iMsgId_)
 {
+    ThrowIfLocked();
     RemoveMessageType(iMsgId_);
     core_->RemoveMessage(iMsgId_);
 }
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveEnumeration(std::string strEnumeration_)
 {
+    ThrowIfLocked();
     RemoveEnumType(strEnumeration_);
     core_->RemoveEnumeration(strEnumeration_);
 }
 
-PYCOMMON_EXPORT nb::object py_common::PyMessageDatabase::clone() const
+PYCOMMON_EXPORT nb::object py_common::PyMessageDatabase::clone()
 {
+    Lock();
     // Build a new wrapper around a shallow copy of the C++ database — same
     // MessageDefinition / EnumDefinition / BaseField pointers, just a different
     // MessageDatabase instance.

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -97,69 +97,26 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::Merge(const Ptr& other_)
     AppendMessageTypes(other_->core_->MessageDefinitions());
 }
 
-// Deep-copies a message definition. The underlying MessageDatabase::AppendMessages
-// writes through `EnumField::enumDef` via MapMessageEnumFields; without an owned
-// copy that mutation corrupts the source database's shared field defs.
-// `get_msg_def` returns a clone for the same reason: handing the caller a pointer
-// into our internal storage lets them mutate our state (directly, or by appending
-// the def into another database). Python-bound databases are the only callers
-// that legitimately share defs across databases, so the duplication lives here
-// rather than in the C++ base class.
-PYCOMMON_EXPORT MessageDefinition::Ptr py_common::cloneMessageDef(const MessageDefinition& source)
-{
-    auto copy = std::make_shared<MessageDefinition>(source);
-    for (auto& [_crc, fields] : copy->fields)
-    {
-        for (auto& field : fields) { field = field->clone(); }
-    }
-    return copy;
-}
-
-PYCOMMON_EXPORT std::vector<MessageDefinition::ConstPtr> py_common::cloneMessageDefs(const std::vector<MessageDefinition::ConstPtr>& source)
-{
-    std::vector<MessageDefinition::ConstPtr> copies;
-    copies.reserve(source.size());
-    for (const auto& msgDef : source) { copies.push_back(cloneMessageDef(*msgDef)); }
-    return copies;
-}
-
-PYCOMMON_EXPORT EnumDefinition::Ptr py_common::cloneEnumDef(const EnumDefinition& source)
-{
-    auto copy = std::make_shared<EnumDefinition>();
-    copy->_id = source._id;
-    copy->name = source.name;
-    copy->enumerators = source.enumerators;
-    copy->unknownValue = source.unknownValue;
-    // Rebuild the string_view-keyed lookup maps against the copied enumerators
-    // vector so the new definition owns all of its storage (the source's
-    // string_views point into the source's enumerator strings).
-    for (const auto& enumerator : copy->enumerators)
-    {
-        copy->nameValue[enumerator.name] = enumerator.value;
-        copy->valueName[enumerator.value] = enumerator.name;
-        copy->descriptionValue[enumerator.description] = enumerator.value;
-    }
-    return copy;
-}
-
-PYCOMMON_EXPORT std::vector<EnumDefinition::ConstPtr> py_common::cloneEnumDefs(const std::vector<EnumDefinition::ConstPtr>& source)
-{
-    std::vector<EnumDefinition::ConstPtr> copies;
-    copies.reserve(source.size());
-    for (const auto& enumDef : source) { copies.push_back(cloneEnumDef(*enumDef)); }
-    return copies;
-}
-
+// Why clone on the way in:
+// MessageDatabase::AppendMessages writes through `EnumField::enumDef` via
+// MapMessageEnumFields; without an owned copy that mutation corrupts the
+// source database's shared field defs. Python is the only client that
+// legitimately reuses a def across databases, so the duplication is paid here
+// rather than inside the C++ AppendMessages.
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendMessages(const std::vector<MessageDefinition::ConstPtr>& vMessageDefinitions_)
 {
-    auto owned = py_common::cloneMessageDefs(vMessageDefinitions_);
+    std::vector<MessageDefinition::ConstPtr> owned;
+    owned.reserve(vMessageDefinitions_.size());
+    for (const auto& msgDef : vMessageDefinitions_) { owned.push_back(std::make_shared<MessageDefinition>(*msgDef)); }
     core_->AppendMessages(owned);
     AppendMessageTypes(owned);
 }
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendEnumerations(const std::vector<EnumDefinition::ConstPtr>& vEnumDefinitions_)
 {
-    auto owned = py_common::cloneEnumDefs(vEnumDefinitions_);
+    std::vector<EnumDefinition::ConstPtr> owned;
+    owned.reserve(vEnumDefinitions_.size());
+    for (const auto& enumDef : vEnumDefinitions_) { owned.push_back(std::make_shared<EnumDefinition>(*enumDef)); }
     core_->AppendEnumerations(owned);
     AppendEnumTypes(owned);
 }

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -114,11 +114,8 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendMessages(const std::vec
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendEnumerations(const std::vector<EnumDefinition::ConstPtr>& vEnumDefinitions_)
 {
-    std::vector<EnumDefinition::ConstPtr> owned;
-    owned.reserve(vEnumDefinitions_.size());
-    for (const auto& enumDef : vEnumDefinitions_) { owned.push_back(std::make_shared<EnumDefinition>(*enumDef)); }
-    core_->AppendEnumerations(owned);
-    AppendEnumTypes(owned);
+    core_->AppendEnumerations(vEnumDefinitions_);
+    AppendEnumTypes(vEnumDefinitions_);
 }
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveMessage(uint32_t iMsgId_)

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -137,7 +137,7 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveEnumeration(std::string
     core_->RemoveEnumeration(strEnumeration_);
 }
 
-PYCOMMON_EXPORT nb::object py_common::PyMessageDatabase::clone()
+PYCOMMON_EXPORT nb::object py_common::PyMessageDatabase::fork()
 {
     Lock();
     // Build a new wrapper around a shallow copy of the C++ database — same

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -136,6 +136,7 @@ static void cleanString(std::string& str)
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::UpdatePythonEnums()
 {
     enum_types.clear();
+    enum_type_lookup_.clear();
     AppendEnumTypes(core_->EnumDefinitions());
 }
 
@@ -157,9 +158,9 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendEnumTypes(const std::ve
         }
         values["EDIE_UNKNOWN"] = enum_def->unknownValue;
         nb::object enum_type = IntEnum(enum_name, values);
-        enum_type.attr("_name") = enum_name;
-        enum_type.attr("_id") = enum_def->_id;
+        enum_type.attr("_owner_db") = nb::find(this);
         enum_types[enum_def.get()] = enum_type;
+        enum_type_lookup_[enum_type] = enum_def.get();
     }
 }
 
@@ -167,7 +168,13 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveEnumType(const std::str
 {
     // get the enum definition to retrieve the pointer
     EnumDefinition::ConstPtr enum_def = core_->GetEnumDefName(enum_name);
-    if (enum_def) { enum_types.erase(enum_def.get()); }
+    if (!enum_def) { return; }
+    auto enum_it = enum_types.find(enum_def.get());
+    if (enum_it != enum_types.end())
+    {
+        enum_type_lookup_.erase(enum_it->second);
+        enum_types.erase(enum_it);
+    }
 }
 
 static py_common::FieldNameMap BuildFieldNameMapFromDefs(const std::vector<BaseField::Ptr>& fields)
@@ -188,6 +195,8 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::UpdatePythonMessageTypes()
     messages_types.clear();
     field_name_maps_.clear();
     message_field_name_maps_.clear();
+    message_type_lookup_.clear();
+    field_type_lookup_.clear();
 
     // add message and message body types for each message definition
     AppendMessageTypes(core_->MessageDefinitions());
@@ -205,6 +214,7 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::AddFieldType(std::vector<std:
             std::string field_name = base_name + "_" + field_array_field->name + "_Field";
             nb::object field_type = type_constructor(field_name);
             field_types[field.get()] = field_type;
+            field_type_lookup_[field_type] = field.get();
             field_name_maps_[field.get()] = BuildFieldNameMapFromDefs(field_array_field->fields);
             AddFieldType(field_array_field->fields, field_name, parent_message, type_constructor);
         }
@@ -252,6 +262,7 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendMessageTypes(const std:
             // specify the python superclass for the message type
             nb::object msg_py_type = msg_type_cons(message_name);
             messages_types[message_def.get()][crc] = msg_py_type;
+            message_type_lookup_[msg_py_type] = {message_def.get(), crc};
             message_field_name_maps_[message_def.get()][crc] = BuildFieldNameMapFromDefs(message_fields);
 
             AddFieldType(message_fields, message_name, message_name, field_type_cons);
@@ -266,6 +277,11 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveMessageType(uint32_t me
     if (!message_def) { return; }
 
     // remove the message type
+    auto messages_it = messages_types.find(message_def.get());
+    if (messages_it != messages_types.end())
+    {
+        for (const auto& [crc, type_obj] : messages_it->second) { message_type_lookup_.erase(type_obj); }
+    }
     messages_types.erase(message_def.get());
     message_field_name_maps_.erase(message_def.get());
 
@@ -277,7 +293,12 @@ void py_common::PyMessageDatabase::RemoveFieldTypes(const std::vector<BaseField:
 {
     for (const auto& fieldDef : fieldDefs)
     {
-        field_types.erase(fieldDef.get());
+        auto field_it = field_types.find(fieldDef.get());
+        if (field_it != field_types.end())
+        {
+            field_type_lookup_.erase(field_it->second);
+            field_types.erase(field_it);
+        }
         field_name_maps_.erase(fieldDef.get());
         if (fieldDef->type == FIELD_TYPE::FIELD_ARRAY)
         {

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -4,6 +4,7 @@
 #include <iomanip>
 #include <sstream>
 
+#include <nanobind/eval.h>
 #include <nanobind/stl/unordered_map.h>
 
 #include "novatel_edie/decoders/common/message_database.hpp"
@@ -31,8 +32,19 @@ PYCOMMON_EXPORT const py_common::MessageFamilyRegistration* py_common::GetMessag
 PYCOMMON_EXPORT py_common::PyMessageDatabase::PyMessageDatabase(MessageDatabase&& message_db)
     : core_(std::make_shared<MessageDatabase>(std::move(message_db)))
 {
-    Initialize();
-    allocateExtras();
+}
+
+PYCOMMON_EXPORT nb::object py_common::PyMessageDatabase::Create(MessageDatabase&& message_db)
+{
+    PyMessageDatabase::Ptr db(new PyMessageDatabase(std::move(message_db)));
+    // Publish the Python wrapper into nanobind's instance map so nb::find(this)
+    // returns it during Initialize(). The returned nb::object keeps the wrapper
+    // alive for the caller; dropping it before Initialize would destroy the
+    // wrapper and unregister it from the instance map.
+    nb::object wrapper = nb::cast(db);
+    db->Initialize();
+    db->allocateExtras();
+    return wrapper;
 }
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::Initialize()
@@ -109,10 +121,7 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::RemoveEnumeration(std::string
     core_->RemoveEnumeration(strEnumeration_);
 }
 
-PYCOMMON_EXPORT py_common::PyMessageDatabase::Ptr py_common::PyMessageDatabase::clone() const
-{
-    return std::make_shared<PyMessageDatabase>(MessageDatabase(*core_));
-}
+PYCOMMON_EXPORT nb::object py_common::PyMessageDatabase::clone() const { return Create(MessageDatabase(*core_)); }
 
 static void cleanString(std::string& str)
 {
@@ -185,8 +194,7 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::UpdatePythonMessageTypes()
 }
 
 PYCOMMON_EXPORT void py_common::PyMessageDatabase::AddFieldType(std::vector<std::shared_ptr<BaseField>> fields, std::string base_name,
-                                                                std::string parent_message, nb::handle type_constructor, nb::handle type_tuple,
-                                                                nb::handle type_dict)
+                                                                std::string parent_message, nb::handle type_constructor)
 {
     // rescursively add field types for each field array element within the provided vector
     for (const auto& field : fields)
@@ -195,10 +203,10 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::AddFieldType(std::vector<std:
         {
             auto* field_array_field = dynamic_cast<FieldArrayField*>(field.get());
             std::string field_name = base_name + "_" + field_array_field->name + "_Field";
-            nb::object field_type = type_constructor(field_name, type_tuple, type_dict);
+            nb::object field_type = type_constructor(field_name);
             field_types[field.get()] = field_type;
             field_name_maps_[field.get()] = BuildFieldNameMapFromDefs(field_array_field->fields);
-            AddFieldType(field_array_field->fields, field_name, parent_message, type_constructor, type_tuple, type_dict);
+            AddFieldType(field_array_field->fields, field_name, parent_message, type_constructor);
         }
     }
 }
@@ -211,13 +219,22 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendMessageTypes(const std:
     }
 
     // get type constructor
-    nb::object type_constructor = nb::module_::import_("builtins").attr("type");
-    // specify the python superclass for the message body types
-    nb::tuple field_type_tuple = nb::make_tuple(nb::type<py_common::PyField>());
-    // provide no additional attributes via `__dict__`
-    nb::dict type_dict = nb::dict();
-    nb::tuple message_type_tuple = nb::make_tuple(message_family_registration_->messageType);
-    type_dict[nb::str("__slots__")] = nb::make_tuple();
+    nb::dict globals;
+    globals["field_type"] = nb::type<py_common::PyField>();
+    globals["message_type"] = message_family_registration_->messageType;
+    nb::handle my_py_obj = nb::find(this);
+    globals["db"] = nb::none();
+
+    nb::exec(R"(
+    def message_type_cons(name):
+        return type(name, (message_type,), {'__slots__': (), '_owner_db': db})
+
+    def field_type_cons(name):
+        return type(name, (field_type,), {'__slots__': (), '_owner_db': db})
+    )",
+             globals);
+    nb::object msg_type_cons = globals["message_type_cons"];
+    nb::object field_type_cons = globals["field_type_cons"];
 
     // add message and message body types for each message definition
     for (const auto& message_def : message_defs)
@@ -234,11 +251,11 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendMessageTypes(const std:
             std::string message_name = ss.str();
 
             // specify the python superclass for the message type
-            nb::object msg_py_type = type_constructor(message_name, message_type_tuple, type_dict);
+            nb::object msg_py_type = msg_type_cons(message_name);
             messages_types[message_def.get()][crc] = msg_py_type;
             message_field_name_maps_[message_def.get()][crc] = BuildFieldNameMapFromDefs(message_fields);
 
-            AddFieldType(message_fields, message_name, message_name, type_constructor, field_type_tuple, type_dict);
+            AddFieldType(message_fields, message_name, message_name, field_type_cons);
         }
     }
 }

--- a/python/src/py_common/implementations/message_database.cpp
+++ b/python/src/py_common/implementations/message_database.cpp
@@ -270,6 +270,8 @@ PYCOMMON_EXPORT void py_common::PyMessageDatabase::AppendMessageTypes(const std:
 
     // get type constructor
     nb::dict globals;
+    // Initializing builtins appears necessary to access 'type' functions in older python versions
+    globals["__builtins__"] = nb::module_::import_("builtins");
     globals["field_type"] = nb::type<py_common::PyField>();
     globals["message_type"] = message_family_registration_->messageType;
     globals["db"] = nb::find(this);

--- a/python/src/py_oem/bindings/commander.cpp
+++ b/python/src/py_oem/bindings/commander.cpp
@@ -18,6 +18,7 @@ void py_oem::init_novatel_commander(nb::module_& m)
             "__init__",
             [](oem::Commander* t, py_common::PyMessageDatabase::Ptr message_db) {
                 if (!message_db) { message_db = py_oem::MessageDbSingleton::get(); };
+                message_db->Lock();
                 new (t) oem::Commander(message_db->core());
             },
             nb::arg("message_db") = nb::none()) // NOLINT(*.NewDeleteLeaks)

--- a/python/src/py_oem/bindings/decoder.cpp
+++ b/python/src/py_oem/bindings/decoder.cpp
@@ -40,6 +40,7 @@ void py_oem::init_novatel_decoder(nb::module_& m)
             "__init__",
             [](py_oem::PyDecoder* self, py_common::PyMessageDatabase::Ptr message_db) {
                 if (!message_db) { message_db = py_oem::MessageDbSingleton::get(); }
+                message_db->Lock();
                 new (self) py_oem::PyDecoder(message_db);
             },
             nb::arg("message_db") = nb::none(),

--- a/python/src/py_oem/bindings/file_parser.cpp
+++ b/python/src/py_oem/bindings/file_parser.cpp
@@ -83,6 +83,7 @@ void py_oem::init_novatel_file_parser(nb::module_& m)
             "__init__",
             [](py_oem::PyFileParser* self, const std::filesystem::path& file_path, py_common::PyMessageDatabase::Ptr message_db) {
                 if (!message_db) { message_db = py_oem::MessageDbSingleton::get(); }
+                message_db->Lock();
                 new (self) py_oem::PyFileParser(file_path, message_db);
             },
             "file_path"_a, nb::arg("message_db") = nb::none(),

--- a/python/src/py_oem/bindings/init_modules.cpp
+++ b/python/src/py_oem/bindings/init_modules.cpp
@@ -12,4 +12,7 @@ void py_oem::init_message_db_singleton(nb::module_& m, nb::module_& messagesMod,
 {
     m.def("get_builtin_database", &py_oem::MessageDbSingleton::get, "Get the JSON database built-in to the package.");
     py_oem::MessageDbSingleton::get()->bindToModule(messagesMod, enumsMod);
+    nb::module_ atexit = nb::module_::import_("atexit");
+    // Register singleton to be freed during interpreter teardown
+    atexit.attr("register")(nb::cpp_function(&py_oem::MessageDbSingleton::cleanup));
 }

--- a/python/src/py_oem/bindings/parser.cpp
+++ b/python/src/py_oem/bindings/parser.cpp
@@ -98,6 +98,7 @@ void py_oem::init_novatel_parser(nb::module_& m)
             "__init__",
             [](py_oem::PyParser* self, py_common::PyMessageDatabase::Ptr message_db) {
                 if (!message_db) { message_db = py_oem::MessageDbSingleton::get(); }
+                message_db->Lock();
                 new (self) py_oem::PyParser(message_db);
             },
             nb::arg("message_db") = nb::none(),

--- a/python/src/py_oem/bindings/py_message_objects.cpp
+++ b/python/src/py_oem/bindings/py_message_objects.cpp
@@ -275,6 +275,33 @@ void py_oem::init_message_objects(nb::module_& m)
             )doc");
 
     nb::class_<py_oem::PyMessage, py_common::PyField>(m, "Message")
+        .def_static(
+            "__new__",
+            [](nb::handle cls, py_oem::PyHeader* header, [[maybe_unused]] nb::kwargs kwargs) {
+                PyMessageDatabase::Ptr database = nb::cast<PyMessageDatabase::Ptr>(cls.attr("_owner_db"));
+
+                if (!database) { throw py_common::FailureException("Constructor could not resolve owning MessageDatabase for this type."); }
+
+                const py_common::MessageTypeLookupEntry* type_lookup = database->GetMessageTypeLookup(cls);
+                if (!type_lookup || !type_lookup->def)
+                {
+                    throw py_common::FailureException("Constructor could not resolve MessageDefinition for this type.");
+                }
+
+                nb::object message_pyinst = nb::inst_alloc(cls);
+                py_oem::PyMessage* message_cinst = nb::inst_ptr<py_oem::PyMessage>(message_pyinst);
+                new (message_cinst)
+                    py_oem::PyMessage(std::vector<FieldContainer>{}, database, py_oem::PyHeader{}, type_lookup->def, type_lookup->crc);
+                nb::inst_mark_ready(message_pyinst);
+                return message_pyinst;
+            },
+            "cls"_a, nb::arg("header") = nb::none(), "kwargs"_a)
+        .def(
+            "__init__",
+            [](nb::handle self, py_oem::PyHeader* header, nb::kwargs kwargs) {
+                throw py_common::FailureException("Message initialization not implemented.");
+            },
+            nb::arg("header") = nb::none(), "kwargs"_a)
         .def("encode", &py_oem::PyMessage::encode)
         .def("to_ascii", &py_oem::PyMessage::to_ascii)
         .def("to_abbrev_ascii", &py_oem::PyMessage::to_abbrev_ascii)

--- a/python/src/py_oem/bindings/range_decompressor.cpp
+++ b/python/src/py_oem/bindings/range_decompressor.cpp
@@ -20,6 +20,7 @@ void py_oem::init_novatel_range_decompressor(nb::module_& m)
             "__init__",
             [](oem::RangeDecompressor* t, py_common::PyMessageDatabase::Ptr message_db) {
                 if (!message_db) { message_db = py_oem::MessageDbSingleton::get(); };
+                message_db->Lock();
                 new (t) oem::RangeDecompressor(message_db->core());
                 t->GetLogger()->warn(
                     "The RangeDecompressor interface is currently unstable! It may undergo breaking changes between minor version increments.");

--- a/python/src/py_oem/bindings/rxconfig_handler.cpp
+++ b/python/src/py_oem/bindings/rxconfig_handler.cpp
@@ -18,6 +18,7 @@ void py_oem::init_novatel_rxconfig_handler(nb::module_& m)
             "__init__",
             [](oem::RxConfigHandler* t, py_common::PyMessageDatabase::Ptr message_db) {
                 if (!message_db) { message_db = py_oem::MessageDbSingleton::get(); };
+                message_db->Lock();
                 new (t) oem::RxConfigHandler(message_db->core());
                 t->GetLogger()->warn(
                     "The RXConfigHandler interface is currently unstable! It may undergo breaking changes between minor version increments.");

--- a/python/src/py_oem/implementations/message_db_singleton.cpp
+++ b/python/src/py_oem/implementations/message_db_singleton.cpp
@@ -25,7 +25,7 @@ py_common::PyMessageDatabase::Ptr& py_oem::MessageDbSingleton::get()
     if (!nb::cast<bool>(builtins.attr("bool")(module_spec)))
     {
         // If the package does not exist, return an empty database
-        json_db = std::make_shared<py_common::PyMessageDatabase>();
+        json_db = nb::cast<py_common::PyMessageDatabase::Ptr>(py_common::PyMessageDatabase::Create());
         return json_db;
     }
 
@@ -34,7 +34,7 @@ py_common::PyMessageDatabase::Ptr& py_oem::MessageDbSingleton::get()
     if (!nb::cast<bool>(builtins.attr("bool")(module_origin)))
     {
         // Return an empty database if the package is empty
-        json_db = std::make_shared<py_common::PyMessageDatabase>();
+        json_db = nb::cast<py_common::PyMessageDatabase::Ptr>(py_common::PyMessageDatabase::Create());
         return json_db;
     }
     nb::object novatel_edie_path = os_path.attr("dirname")(module_spec.attr("origin"));
@@ -43,11 +43,11 @@ py_common::PyMessageDatabase::Ptr& py_oem::MessageDbSingleton::get()
     bool db_exists = nb::cast<bool>(os_path.attr("isfile")(db_path));
     if (!db_exists)
     {
-        json_db = std::make_shared<py_common::PyMessageDatabase>();
+        json_db = nb::cast<py_common::PyMessageDatabase::Ptr>(py_common::PyMessageDatabase::Create());
         return json_db;
     }
     // If the database file exists, load it
     std::string default_json_db_path = nb::cast<std::string>(db_path);
-    json_db = std::make_shared<py_common::PyMessageDatabase>(std::move(*LoadJsonDbFile(default_json_db_path)));
+    json_db = nb::cast<py_common::PyMessageDatabase::Ptr>(py_common::PyMessageDatabase::Create(std::move(*LoadJsonDbFile(default_json_db_path))));
     return json_db;
 }

--- a/python/src/py_oem/implementations/message_db_singleton.cpp
+++ b/python/src/py_oem/implementations/message_db_singleton.cpp
@@ -25,29 +25,32 @@ py_common::PyMessageDatabase::Ptr& py_oem::MessageDbSingleton::get()
     {
         // If the package does not exist, return an empty database
         json_db = nb::cast<py_common::PyMessageDatabase::Ptr>(py_common::PyMessageDatabase::Create());
-        return json_db;
     }
-
-    // Determine the path to the database file within the novatel_edie package
-    nb::object module_origin = module_spec.attr("origin");
-    if (!nb::cast<bool>(builtins.attr("bool")(module_origin)))
+    else
     {
-        // Return an empty database if the package is empty
-        json_db = nb::cast<py_common::PyMessageDatabase::Ptr>(py_common::PyMessageDatabase::Create());
-        return json_db;
+        // Determine the path to the database file within the novatel_edie package
+        nb::object module_origin = module_spec.attr("origin");
+        if (!nb::cast<bool>(builtins.attr("bool")(module_origin)))
+        {
+            // Return an empty database if the package is empty
+            json_db = nb::cast<py_common::PyMessageDatabase::Ptr>(py_common::PyMessageDatabase::Create());
+        }
+        else
+        {
+            nb::object novatel_edie_path = os_path.attr("dirname")(module_spec.attr("origin"));
+            nb::object db_path = os_path.attr("join")(novatel_edie_path, "database.json");
+            // If the database file does not exist, return an empty database
+            bool db_exists = nb::cast<bool>(os_path.attr("isfile")(db_path));
+            if (!db_exists) { json_db = nb::cast<py_common::PyMessageDatabase::Ptr>(py_common::PyMessageDatabase::Create()); }
+            else
+            {
+                std::string default_json_db_path = nb::cast<std::string>(db_path);
+                json_db = nb::cast<py_common::PyMessageDatabase::Ptr>(
+                    py_common::PyMessageDatabase::Create(std::move(*LoadJsonDbFile(default_json_db_path))));
+            }
+        }
     }
-    nb::object novatel_edie_path = os_path.attr("dirname")(module_spec.attr("origin"));
-    nb::object db_path = os_path.attr("join")(novatel_edie_path, "database.json");
-    // If the database file does not exist, return an empty database
-    bool db_exists = nb::cast<bool>(os_path.attr("isfile")(db_path));
-    if (!db_exists)
-    {
-        json_db = nb::cast<py_common::PyMessageDatabase::Ptr>(py_common::PyMessageDatabase::Create());
-        return json_db;
-    }
-    // If the database file exists, load it
-    std::string default_json_db_path = nb::cast<std::string>(db_path);
-    json_db = nb::cast<py_common::PyMessageDatabase::Ptr>(py_common::PyMessageDatabase::Create(std::move(*LoadJsonDbFile(default_json_db_path))));
+    json_db->Lock();
     return json_db;
 }
 

--- a/python/src/py_oem/implementations/message_db_singleton.cpp
+++ b/python/src/py_oem/implementations/message_db_singleton.cpp
@@ -2,16 +2,15 @@
 
 #include "novatel_edie/decoders/common/json_db_reader.hpp"
 #include "py_common/bindings_core.hpp"
-#include "py_common/message_database.hpp"
 
 namespace nb = nanobind;
 using namespace nb::literals;
 using namespace novatel::edie;
 
+py_common::PyMessageDatabase::Ptr py_oem::MessageDbSingleton::json_db;
+
 py_common::PyMessageDatabase::Ptr& py_oem::MessageDbSingleton::get()
 {
-    static py_common::PyMessageDatabase::Ptr json_db = nullptr;
-
     // If the database has already been loaded, return it
     if (json_db) { return json_db; }
 
@@ -51,3 +50,5 @@ py_common::PyMessageDatabase::Ptr& py_oem::MessageDbSingleton::get()
     json_db = nb::cast<py_common::PyMessageDatabase::Ptr>(py_common::PyMessageDatabase::Create(std::move(*LoadJsonDbFile(default_json_db_path))));
     return json_db;
 }
+
+void py_oem::MessageDbSingleton::cleanup() { json_db = nullptr; }

--- a/python/stubgen_pattern.txt
+++ b/python/stubgen_pattern.txt
@@ -47,4 +47,32 @@ oem_bindings.Response.response_enum:
     if TYPE_CHECKING:
         from novatel_edie.enums import Responses
     @property
-    def response_enum(self) -> Responses
+    def response_enum(self) -> Responses: ...
+
+oem_bindings.MetaData.measurement_source$:
+    \from typing_extensions import deprecated
+    @property
+    @deprecated("MetaData.measurement_source is deprecated; use 'sibling_id' instead.")
+    def measurement_source(self) -> common_bindings.MEASUREMENT_SOURCE: ...
+    @measurement_source.setter
+    @deprecated("MetaData.measurement_source is deprecated; use 'sibling_id' instead.")
+    def measurement_source(self, arg: common_bindings.MEASUREMENT_SOURCE, /) -> None: ...
+
+oem_bindings.MetaData.message_description$:
+    \from typing_extensions import deprecated
+    @property
+    @deprecated("MetaData.message_description is deprecated as it relies on the builtin MessageDatabase matching the MetaData.")
+    def message_description(self) -> object: ...
+
+oem_bindings.MetaData.message_fields$:
+    \from typing_extensions import deprecated
+    @property
+    @deprecated("MetaData.message_fields is deprecated as it relies on the builtin MessageDatabase matching the MetaData.")
+    def message_fields(self) -> object: ...
+
+oem_bindings.MessageType.source$:
+    \from typing_extensions import deprecated
+    @property
+    @deprecated("MessageType.source is deprecated; use 'sibling_id' instead.")
+    def source(self) -> common_bindings.MEASUREMENT_SOURCE:
+        """Where the message originates from."""

--- a/python/test/test_message_database.py
+++ b/python/test/test_message_database.py
@@ -31,7 +31,7 @@ from novatel_edie import MessageDefinition, EnumFieldDefinition, EnumDefinition,
 from novatel_edie import FieldDefinition, ArrayFieldDefinition, FieldArrayFieldDefinition, FIELD_TYPE, DATA_TYPE
 from novatel_edie.oem import Header
 
-class TestDatabaseDefinitionObjects:
+class TestDatabaseObjects:
     """Tests that verify the interface for definition objects."""
 
     @pytest.mark.parametrize("values", [
@@ -232,7 +232,11 @@ class TestDatabaseDefinitionObjects:
 
     @pytest.mark.parametrize("values", [
         {},
-        {"id": "1", "log_id": 42, "name": "BESTPOS", "description": "best position log", "latest_message_crc": 1234},
+        {"id": "1", "log_id": 42, "name": "BESTPOS", "description": "best position log", "latest_message_crc": 1234,
+         "fields": {1234: [
+             FieldDefinition(name="lat", type=FIELD_TYPE.SIMPLE, data_type=DATA_TYPE.DOUBLE),
+             FieldDefinition(name="lon", type=FIELD_TYPE.SIMPLE, data_type=DATA_TYPE.DOUBLE),
+         ]}},
         {"id": "0", "log_id": 0, "name": "", "description": "", "latest_message_crc": 0}])
     class TestMessageDefinition:
         """Tests for MessageDefinition."""
@@ -262,115 +266,116 @@ class TestDatabaseDefinitionObjects:
                 assert getattr(msg_def, attr) == values.get(attr, default)
 
 
+class TestDatabaseActions:
+    """Tests for the effect of preforming actions on a database."""
+    def test_message_db_enums(self, json_db):
+        # Act
+        datum_enum = json_db.get_enum_type_by_name("Datum")
+        # Assert
+        assert datum_enum.WGS84 == 61
+        assert datum_enum.WGS84.name == "WGS84"
+        assert datum_enum.WGS84 == Datum.WGS84
 
-def test_message_db_enums(json_db):
-    # Act
-    datum_enum = json_db.get_enum_type_by_name("Datum")
-    # Assert
-    assert datum_enum.WGS84 == 61
-    assert datum_enum.WGS84.name == "WGS84"
-    assert datum_enum.WGS84 == Datum.WGS84
+    def test_append_messages(self, json_db: MessageDatabase):
+        # Arrange
+        new_db = MessageDatabase()
+        bestpos_id = 42
+        bestpos_def = json_db.get_msg_def(bestpos_id)
+        bestpos_type = json_db.get_msg_type("BESTPOS")
+        range_id = 43
+        range_def = json_db.get_msg_def(range_id)
+        range_type = json_db.get_msg_type("RANGE")
 
-def test_append_messages(json_db: MessageDatabase):
-    # Arrange
-    new_db = MessageDatabase()
-    bestpos_id = 42
-    bestpos_def = json_db.get_msg_def(bestpos_id)
-    bestpos_type = json_db.get_msg_type("BESTPOS")
-    range_id = 43
-    range_def = json_db.get_msg_def(range_id)
-    range_type = json_db.get_msg_type("RANGE")
+        # Act
+        new_db.append_messages([bestpos_def, range_def])
 
-    # Act
-    new_db.append_messages([bestpos_def, range_def])
+        # Assert
+        assert json_db.get_msg_def(bestpos_id) == bestpos_def
+        assert json_db.get_msg_type("BESTPOS") is bestpos_type
+        assert json_db.get_msg_def(range_id) == range_def
+        assert json_db.get_msg_type("RANGE") is range_type
 
-    # Assert
-    assert json_db.get_msg_def(bestpos_id) == bestpos_def
-    assert json_db.get_msg_type("BESTPOS") is bestpos_type
-    assert json_db.get_msg_def(range_id) == range_def
-    assert json_db.get_msg_type("RANGE") is range_type
+        assert new_db.get_msg_def(bestpos_id) == bestpos_def
+        assert new_db.get_msg_type("BESTPOS") is not bestpos_type
+        assert new_db.get_msg_type("BESTPOS") is not None
+        assert new_db.get_msg_def(range_id) == range_def
+        assert new_db.get_msg_type("RANGE") is not range_type
+        assert new_db.get_msg_type("RANGE") is not None
 
-    assert new_db.get_msg_def(bestpos_id) == bestpos_def
-    assert new_db.get_msg_type("BESTPOS") is not bestpos_type
-    assert new_db.get_msg_type("BESTPOS") is not None
-    assert new_db.get_msg_def(range_id) == range_def
-    assert new_db.get_msg_type("RANGE") is not range_type
-    assert new_db.get_msg_type("RANGE") is not None
+    def test_remove_message(self, json_db: MessageDatabase):
+        # Arrange
+        new_db = MessageDatabase()
+        bestpos_id = 42
+        bestpos_def = json_db.get_msg_def(bestpos_id)
+        bestpos_type = json_db.get_msg_type("BESTPOS")
+        range_id = 43
+        range_def = json_db.get_msg_def(range_id)
+        new_db.append_messages([bestpos_def, range_def])
+        new_range_type = new_db.get_msg_type("RANGE")
 
-def test_remove_message(json_db: MessageDatabase):
-    # Arrange
-    new_db = MessageDatabase()
-    bestpos_id = 42
-    bestpos_def = json_db.get_msg_def(bestpos_id)
-    bestpos_type = json_db.get_msg_type("BESTPOS")
-    range_id = 43
-    range_def = json_db.get_msg_def(range_id)
-    new_db.append_messages([bestpos_def, range_def])
-    new_range_type = new_db.get_msg_type("RANGE")
+        # Act
+        new_db.remove_message(bestpos_id)
 
-    # Act
-    new_db.remove_message(bestpos_id)
+        # Assert
+        assert json_db.get_msg_def(bestpos_id) == bestpos_def
+        assert json_db.get_msg_type("BESTPOS") is bestpos_type
 
-    # Assert
-    assert json_db.get_msg_def(bestpos_id) == bestpos_def
-    assert json_db.get_msg_type("BESTPOS") is bestpos_type
+        assert new_db.get_msg_def(bestpos_id) is None
+        assert new_db.get_msg_type("BESTPOS") is None
+        assert new_db.get_msg_def(range_id) == range_def
+        assert new_db.get_msg_type("RANGE") is new_range_type
 
-    assert new_db.get_msg_def(bestpos_id) is None
-    assert new_db.get_msg_type("BESTPOS") is None
-    assert new_db.get_msg_def(range_id) == range_def
-    assert new_db.get_msg_type("RANGE") is new_range_type
+    def test_merge(self, json_db: MessageDatabase):
+        """Tests that one databases messages can be merged into another."""
+        # Arrange
+        oem_minus_bestpos_db = json_db.clone()
+        new_db_with_bestpos = MessageDatabase()
+        bestpos_name = "BESTPOS"
+        bestpos_msg_def = oem_minus_bestpos_db.get_msg_def(bestpos_name)
+        new_db_with_bestpos.append_messages([bestpos_msg_def])
+        bestpos_msg_type = new_db_with_bestpos.get_msg_type(bestpos_name)
+        other_msg_name = "RANGE"
+        other_msg_def = oem_minus_bestpos_db.get_msg_def(other_msg_name)
+        oem_minus_bestpos_db.remove_message(bestpos_msg_def.log_id)
+        other_msg_type = oem_minus_bestpos_db.get_msg_type(other_msg_name)
 
-def test_merge(json_db: MessageDatabase):
-    """Tests that one databases messages can be merged into another."""
-    # Arrange
-    oem_minus_bestpos_db = json_db.clone()
-    new_db_with_bestpos = MessageDatabase()
-    bestpos_name = "BESTPOS"
-    bestpos_msg_def = oem_minus_bestpos_db.get_msg_def(bestpos_name)
-    new_db_with_bestpos.append_messages([bestpos_msg_def])
-    bestpos_msg_type = new_db_with_bestpos.get_msg_type(bestpos_name)
-    other_msg_name = "RANGE"
-    other_msg_def = oem_minus_bestpos_db.get_msg_def(other_msg_name)
-    oem_minus_bestpos_db.remove_message(bestpos_msg_def.log_id)
-    other_msg_type = oem_minus_bestpos_db.get_msg_type(other_msg_name)
+        # Act
+        new_db_with_bestpos.merge(oem_minus_bestpos_db)
 
-    # Act
-    new_db_with_bestpos.merge(oem_minus_bestpos_db)
+        # Assert
+        assert new_db_with_bestpos.get_msg_def(bestpos_name) == bestpos_msg_def
+        assert new_db_with_bestpos.get_msg_type(bestpos_name) is bestpos_msg_type
+        assert new_db_with_bestpos.get_msg_def(other_msg_name) == other_msg_def
+        assert new_db_with_bestpos.get_msg_type(other_msg_name) is not None
+        assert new_db_with_bestpos.get_msg_type(other_msg_name) != other_msg_type
 
-    # Assert
-    assert new_db_with_bestpos.get_msg_def(bestpos_name) == bestpos_msg_def
-    assert new_db_with_bestpos.get_msg_type(bestpos_name) is bestpos_msg_type
-    assert new_db_with_bestpos.get_msg_def(other_msg_name) == other_msg_def
-    assert new_db_with_bestpos.get_msg_type(other_msg_name) is not None
-    assert new_db_with_bestpos.get_msg_type(other_msg_name) != other_msg_type
+        # The source database must be unaffected by the merge.
+        assert oem_minus_bestpos_db.get_msg_def(bestpos_name) is None
+        assert oem_minus_bestpos_db.get_msg_type(bestpos_name) is None
+        assert oem_minus_bestpos_db.get_msg_def(other_msg_name) == other_msg_def
+        assert oem_minus_bestpos_db.get_msg_type(other_msg_name) is other_msg_type
 
-    # The source database must be unaffected by the merge.
-    assert oem_minus_bestpos_db.get_msg_def(bestpos_name) is None
-    assert oem_minus_bestpos_db.get_msg_type(bestpos_name) is None
-    assert oem_minus_bestpos_db.get_msg_def(other_msg_name) == other_msg_def
-    assert oem_minus_bestpos_db.get_msg_type(other_msg_name) is other_msg_type
+    def test_clone(self, json_db: MessageDatabase):
+        """Tests that a cloned database exposes the same messages and types as the original."""
+        # Arrange
+        bestpos_name = "BESTPOS"
+        bestpos_def = json_db.get_msg_def(bestpos_name)
+        bestpos_type = json_db.get_msg_type(bestpos_name)
+        range_name = "RANGE"
+        range_def = json_db.get_msg_def(range_name)
+        range_type = json_db.get_msg_type(range_name)
 
-def test_clone(json_db: MessageDatabase):
-    """Tests that a cloned database exposes the same messages and types as the original."""
-    # Arrange
-    bestpos_name = "BESTPOS"
-    bestpos_def = json_db.get_msg_def(bestpos_name)
-    bestpos_type = json_db.get_msg_type(bestpos_name)
-    range_name = "RANGE"
-    range_def = json_db.get_msg_def(range_name)
-    range_type = json_db.get_msg_type(range_name)
+        # Act
+        cloned_db = json_db.clone()
 
-    # Act
-    cloned_db = json_db.clone()
+        # Assert
+        assert cloned_db is not json_db
+        assert cloned_db.get_msg_def(bestpos_name) == bestpos_def
+        assert cloned_db.get_msg_type(bestpos_name) is bestpos_type
+        assert cloned_db.get_msg_def(range_name) == range_def
+        assert cloned_db.get_msg_type(range_name) is range_type
 
-    # Assert
-    assert cloned_db is not json_db
-    assert cloned_db.get_msg_def(bestpos_name) == bestpos_def
-    assert cloned_db.get_msg_type(bestpos_name) is bestpos_type
-    assert cloned_db.get_msg_def(range_name) == range_def
-    assert cloned_db.get_msg_type(range_name) is range_type
-
-    assert json_db.get_msg_def(bestpos_name) == bestpos_def
-    assert json_db.get_msg_type(bestpos_name) is bestpos_type
-    assert json_db.get_msg_def(range_name) == range_def
-    assert json_db.get_msg_type(range_name) is range_type
+        assert json_db.get_msg_def(bestpos_name) == bestpos_def
+        assert json_db.get_msg_type(bestpos_name) is bestpos_type
+        assert json_db.get_msg_def(range_name) == range_def
+        assert json_db.get_msg_type(range_name) is range_type

--- a/python/test/test_message_database.py
+++ b/python/test/test_message_database.py
@@ -41,16 +41,25 @@ def test_append_messages(json_db: MessageDatabase):
     new_db = MessageDatabase()
     bestpos_id = 42
     bestpos_def = json_db.get_msg_def(bestpos_id)
+    bestpos_type = json_db.get_msg_type("BESTPOS")
     range_id = 43
     range_def = json_db.get_msg_def(range_id)
+    range_type = json_db.get_msg_type("RANGE")
 
     # Act
     new_db.append_messages([bestpos_def, range_def])
 
     # Assert
+    assert json_db.get_msg_def(bestpos_id) == bestpos_def
+    assert json_db.get_msg_type("BESTPOS") is bestpos_type
+    assert json_db.get_msg_def(range_id) == range_def
+    assert json_db.get_msg_type("RANGE") is range_type
+
     assert new_db.get_msg_def(bestpos_id) == bestpos_def
+    assert new_db.get_msg_type("BESTPOS") is not bestpos_type
     assert new_db.get_msg_type("BESTPOS") is not None
     assert new_db.get_msg_def(range_id) == range_def
+    assert new_db.get_msg_type("RANGE") is not range_type
     assert new_db.get_msg_type("RANGE") is not None
 
 def test_remove_message(json_db: MessageDatabase):
@@ -58,6 +67,7 @@ def test_remove_message(json_db: MessageDatabase):
     new_db = MessageDatabase()
     bestpos_id = 42
     bestpos_def = json_db.get_msg_def(bestpos_id)
+    bestpos_type = json_db.get_msg_type("BESTPOS")
     range_id = 43
     range_def = json_db.get_msg_def(range_id)
     new_db.append_messages([bestpos_def, range_def])
@@ -67,6 +77,9 @@ def test_remove_message(json_db: MessageDatabase):
     new_db.remove_message(bestpos_id)
 
     # Assert
+    assert json_db.get_msg_def(bestpos_id) == bestpos_def
+    assert json_db.get_msg_type("BESTPOS") is bestpos_type
+
     assert new_db.get_msg_def(bestpos_id) is None
     assert new_db.get_msg_type("BESTPOS") is None
     assert new_db.get_msg_def(range_id) == range_def
@@ -83,8 +96,8 @@ def test_merge(json_db: MessageDatabase):
     bestpos_msg_type = new_db_with_bestpos.get_msg_type(bestpos_name)
     other_msg_name = "RANGE"
     other_msg_def = oem_minus_bestpos_db.get_msg_def(other_msg_name)
-    other_msg_type = oem_minus_bestpos_db.get_msg_type(other_msg_name)
     oem_minus_bestpos_db.remove_message(bestpos_msg_def.log_id)
+    other_msg_type = oem_minus_bestpos_db.get_msg_type(other_msg_name)
 
     # Act
     new_db_with_bestpos.merge(oem_minus_bestpos_db)
@@ -95,3 +108,34 @@ def test_merge(json_db: MessageDatabase):
     assert new_db_with_bestpos.get_msg_def(other_msg_name) == other_msg_def
     assert new_db_with_bestpos.get_msg_type(other_msg_name) is not None
     assert new_db_with_bestpos.get_msg_type(other_msg_name) != other_msg_type
+
+    # The source database must be unaffected by the merge.
+    assert oem_minus_bestpos_db.get_msg_def(bestpos_name) is None
+    assert oem_minus_bestpos_db.get_msg_type(bestpos_name) is None
+    assert oem_minus_bestpos_db.get_msg_def(other_msg_name) == other_msg_def
+    assert oem_minus_bestpos_db.get_msg_type(other_msg_name) is other_msg_type
+
+def test_clone(json_db: MessageDatabase):
+    """Tests that a cloned database exposes the same messages and types as the original."""
+    # Arrange
+    bestpos_name = "BESTPOS"
+    bestpos_def = json_db.get_msg_def(bestpos_name)
+    bestpos_type = json_db.get_msg_type(bestpos_name)
+    range_name = "RANGE"
+    range_def = json_db.get_msg_def(range_name)
+    range_type = json_db.get_msg_type(range_name)
+
+    # Act
+    cloned_db = json_db.clone()
+
+    # Assert
+    assert cloned_db is not json_db
+    assert cloned_db.get_msg_def(bestpos_name) == bestpos_def
+    assert cloned_db.get_msg_type(bestpos_name) is bestpos_type
+    assert cloned_db.get_msg_def(range_name) == range_def
+    assert cloned_db.get_msg_type(range_name) is range_type
+
+    assert json_db.get_msg_def(bestpos_name) == bestpos_def
+    assert json_db.get_msg_type(bestpos_name) is bestpos_type
+    assert json_db.get_msg_def(range_name) == range_def
+    assert json_db.get_msg_type(range_name) is range_type

--- a/python/test/test_message_database.py
+++ b/python/test/test_message_database.py
@@ -136,7 +136,7 @@ class TestDatabaseObjects:
 
     @pytest.mark.parametrize("values", [
         {},
-        {"name": "field1", "type": FIELD_TYPE.SIMPLE, "conversion": "%d", "data_type": DATA_TYPE.ULONG, "enum_id": "42", "enumerators": [EnumDataType(1, "A", "first"), EnumDataType(2, "B", "second")]},
+        {"name": "field1", "type": FIELD_TYPE.SIMPLE, "conversion": "%d", "data_type": DATA_TYPE.ULONG, "enum_id": "42"},
         {"name": "field2"}])
     class TestEnumFieldDefinition:
         """Tests for EnumFieldDefinition."""
@@ -145,8 +145,7 @@ class TestDatabaseObjects:
             "type": FIELD_TYPE.ENUM,
             "conversion": "",
             "data_type": DATA_TYPE.UNKNOWN,
-            "enum_id": "",
-            "enumerators": [],
+            "enum_id": ""
         }
         def test_construct(self, values: dict):
             # Act
@@ -201,7 +200,7 @@ class TestDatabaseObjects:
         {"name": "fa2", "array_length": 0, "type": FIELD_TYPE.SIMPLE, "conversion": "%s", "data_type": DATA_TYPE.UNKNOWN},
         {"name": "fa3", "array_length": 2, "fields": [
             FieldDefinition(name="x", type=FIELD_TYPE.SIMPLE, data_type=DATA_TYPE.INT),
-            EnumFieldDefinition(name="kind", enum_id="42", enumerators=[EnumDataType(1, "A", "first")]),
+            EnumFieldDefinition(name="kind", enum_id="42"),
         ]}])
     class TestFieldArrayFieldDefinition:
         """Tests for FieldArrayFieldDefinition."""

--- a/python/test/test_message_database.py
+++ b/python/test/test_message_database.py
@@ -27,6 +27,241 @@ import pytest
 from novatel_edie import MessageDatabase, FailureException
 from novatel_edie.oem import Decoder
 from novatel_edie.oem.enums import Datum
+from novatel_edie import MessageDefinition, EnumFieldDefinition, EnumDefinition, EnumDataType
+from novatel_edie import FieldDefinition, ArrayFieldDefinition, FieldArrayFieldDefinition, FIELD_TYPE, DATA_TYPE
+from novatel_edie.oem import Header
+
+class TestDatabaseDefinitionObjects:
+    """Tests that verify the interface for definition objects."""
+
+    @pytest.mark.parametrize("values", [
+        {},
+        {"value": 2, "name": "val", "description": "a value of 2"},
+        {"value": 0, "name": "error", "description": "an error msg"}])
+    class TestEnumDataType:
+        """Tests for EnumDataType."""
+        defaults = {
+            "value": 0,
+            "name": "",
+            "description": ""
+        }
+        def test_construct(self, values: dict):
+            # Act
+            data = EnumDataType(**values)
+            # Assert
+            for attr, default in self.defaults.items():
+                assert getattr(data, attr) == values.get(attr, default)
+
+        def test_set_direct(self, values: dict):
+            # Arrange
+            data = EnumDataType()
+            # Act
+            for attr, value in values.items():
+                setattr(data, attr, value)
+            # Assert
+            for attr, default in self.defaults.items():
+                assert getattr(data, attr) == values.get(attr, default)
+
+    @pytest.mark.parametrize("values", [
+        {},
+        {"id": "1", "name": "Datum", "enumerators": [EnumDataType(61, "WGS84", "WGS84 datum")]},
+        {"id": "0", "name": "empty", "enumerators": []}])
+    class TestEnumDefinition:
+        """Tests for EnumDefinition."""
+        defaults = {
+            "id": "",
+            "name": "",
+            "enumerators": []
+        }
+        def test_construct(self, values: dict):
+            # Act
+            enum_def = EnumDefinition(**values)
+            # Assert
+            for attr, default in self.defaults.items():
+                assert getattr(enum_def, attr) == values.get(attr, default)
+
+        def test_set_direct(self, values: dict):
+            # Arrange
+            enum_def = EnumDefinition()
+            # Act
+            for attr, value in values.items():
+                setattr(enum_def, attr, value)
+            # Assert
+            for attr, default in self.defaults.items():
+                assert getattr(enum_def, attr) == values.get(attr, default)
+
+    class TestFieldDefinition:
+        """Tests for FieldDefinition (BaseField)."""
+
+        @pytest.mark.parametrize("values", [
+            {},
+            {"name": "field1", "type": FIELD_TYPE.SIMPLE, "conversion": "%d", "data_type": DATA_TYPE.INT},
+            {"name": "field2", "type": FIELD_TYPE.SIMPLE, "conversion": "%.3f", "data_type": DATA_TYPE.DOUBLE}])
+        class TestValues:
+            """Tests that values are set correctly."""
+            defaults = {
+                "name": "",
+                "type": FIELD_TYPE.UNKNOWN,
+                "conversion": "",
+                "data_type": DATA_TYPE.UNKNOWN
+            }
+            def test_construct(self, values: dict):
+                # Act
+                field = FieldDefinition(**values)
+                # Assert
+                for attr, default in self.defaults.items():
+                    assert getattr(field, attr) == values.get(attr, default)
+
+            def test_set_direct(self, values: dict):
+                # Arrange
+                field = FieldDefinition()
+                # Act
+                for attr, value in values.items():
+                    setattr(field, attr, value)
+                # Assert
+                for attr, default in self.defaults.items():
+                    assert getattr(field, attr) == values.get(attr, default)
+
+        @pytest.mark.parametrize("invalid_conversion", [
+            "",
+            "d",
+            "%q!",
+            "%5.2"])
+        def test_invalid_conversion_raises_attribute_error(self, invalid_conversion: str):
+            # Arrange
+            field = FieldDefinition()
+            # Act / Assert
+            with pytest.raises(AttributeError):
+                field.conversion = invalid_conversion
+
+    @pytest.mark.parametrize("values", [
+        {},
+        {"name": "field1", "type": FIELD_TYPE.SIMPLE, "conversion": "%d", "data_type": DATA_TYPE.ULONG, "enum_id": "42", "enumerators": [EnumDataType(1, "A", "first"), EnumDataType(2, "B", "second")]},
+        {"name": "field2"}])
+    class TestEnumFieldDefinition:
+        """Tests for EnumFieldDefinition."""
+        defaults = {
+            "name": "",
+            "type": FIELD_TYPE.ENUM,
+            "conversion": "",
+            "data_type": DATA_TYPE.UNKNOWN,
+            "enum_id": "",
+            "enumerators": [],
+        }
+        def test_construct(self, values: dict):
+            # Act
+            field = EnumFieldDefinition(**values)
+            # Assert
+            for attr, default in self.defaults.items():
+                assert getattr(field, attr) == values.get(attr, default)
+
+        def test_set_direct(self, values: dict):
+            # Arrange
+            field = EnumFieldDefinition()
+            # Act
+            for attr, value in values.items():
+                setattr(field, attr, value)
+            # Assert
+            for attr, default in self.defaults.items():
+                assert getattr(field, attr) == values.get(attr, default)
+
+    @pytest.mark.parametrize("values", [
+        {},
+        {"name": "arr1", "type": FIELD_TYPE.FIXED_LENGTH_ARRAY, "conversion": "%s", "data_type": DATA_TYPE.UCHAR, "array_length": 4},
+        {"name": "arr2", "array_length": 0}])
+    class TestArrayFieldDefinition:
+        """Tests for ArrayFieldDefinition."""
+        defaults = {
+            "name": "",
+            "type": FIELD_TYPE.UNKNOWN,
+            "conversion": "",
+            "data_type": DATA_TYPE.UNKNOWN,
+            "array_length": 0,
+        }
+        def test_construct(self, values: dict):
+            # Act
+            field = ArrayFieldDefinition(**values)
+            # Assert
+            for attr, default in self.defaults.items():
+                assert getattr(field, attr) == values.get(attr, default)
+
+        def test_set_direct(self, values: dict):
+            # Arrange
+            field = ArrayFieldDefinition()
+            # Act
+            for attr, value in values.items():
+                setattr(field, attr, value)
+            # Assert
+            for attr, default in self.defaults.items():
+                assert getattr(field, attr) == values.get(attr, default)
+
+    @pytest.mark.parametrize("values", [
+        {},
+        {"name": "fa1", "array_length": 4},
+        {"name": "fa2", "array_length": 0, "type": FIELD_TYPE.SIMPLE, "conversion": "%s", "data_type": DATA_TYPE.UNKNOWN},
+        {"name": "fa3", "array_length": 2, "fields": [
+            FieldDefinition(name="x", type=FIELD_TYPE.SIMPLE, data_type=DATA_TYPE.INT),
+            EnumFieldDefinition(name="kind", enum_id="42", enumerators=[EnumDataType(1, "A", "first")]),
+        ]}])
+    class TestFieldArrayFieldDefinition:
+        """Tests for FieldArrayFieldDefinition."""
+        defaults = {
+            "name": "",
+            "type": FIELD_TYPE.FIELD_ARRAY,
+            "conversion": "",
+            "data_type": DATA_TYPE.UNKNOWN,
+            "array_length": 0,
+            "fields": [],
+        }
+        def test_construct(self, values: dict):
+            # Act
+            field = FieldArrayFieldDefinition(**values)
+            # Assert
+            for attr, default in self.defaults.items():
+                assert getattr(field, attr) == values.get(attr, default)
+
+        def test_set_direct(self, values: dict):
+            # Arrange
+            field = FieldArrayFieldDefinition()
+            # Act
+            for attr, value in values.items():
+                setattr(field, attr, value)
+            # Assert
+            for attr, default in self.defaults.items():
+                assert getattr(field, attr) == values.get(attr, default)
+
+    @pytest.mark.parametrize("values", [
+        {},
+        {"id": "1", "log_id": 42, "name": "BESTPOS", "description": "best position log", "latest_message_crc": 1234},
+        {"id": "0", "log_id": 0, "name": "", "description": "", "latest_message_crc": 0}])
+    class TestMessageDefinition:
+        """Tests for MessageDefinition."""
+        defaults = {
+            "id": "",
+            "log_id": 0,
+            "name": "",
+            "description": "",
+            "latest_message_crc": 0,
+            "fields": {},
+        }
+        def test_construct(self, values: dict):
+            # Act
+            msg_def = MessageDefinition(**values)
+            # Assert
+            for attr, default in self.defaults.items():
+                assert getattr(msg_def, attr) == values.get(attr, default)
+
+        def test_set_direct(self, values: dict):
+            # Arrange
+            msg_def = MessageDefinition()
+            # Act
+            for attr, value in values.items():
+                setattr(msg_def, attr, value)
+            # Assert
+            for attr, default in self.defaults.items():
+                assert getattr(msg_def, attr) == values.get(attr, default)
+
+
 
 def test_message_db_enums(json_db):
     # Act

--- a/python/test/test_message_database.py
+++ b/python/test/test_message_database.py
@@ -22,6 +22,8 @@
 #
 ################################################################################=
 
+import logging
+
 import pytest
 
 from novatel_edie import MessageDatabase, UnsupportedException
@@ -306,18 +308,18 @@ class TestDatabaseActions:
             assert old_db.is_locked
             assert not new_db.is_locked
 
-        def test_clone_locking(self):
+        def test_fork_locking(self):
             # Arrange
             old_db = MessageDatabase()
             # Act
-            new_db = old_db.clone()
+            new_db = old_db.fork()
             # Assert
             assert old_db.is_locked
             assert not new_db.is_locked
 
         def test_pytype_access_locking(self, json_db: MessageDatabase):
             # Arrange
-            db = json_db.clone()
+            db = json_db.fork()
             # Act
             db.get_msg_type("BESTPOS")
             # Assert
@@ -327,7 +329,7 @@ class TestDatabaseActions:
                                                    Commander, RangeDecompressor, RxConfigHandler])
         def test_consumer_locking(self, consumer_cons, json_db: MessageDatabase):
             # Arrange
-            db = json_db.clone()
+            db = json_db.fork()
             # Act
             consumer_cons(db)
             # Assert
@@ -392,7 +394,7 @@ class TestDatabaseActions:
     def test_merge(self, json_db: MessageDatabase):
         """Tests that one databases messages can be merged into another."""
         # Arrange
-        oem_minus_bestpos_db = json_db.clone()
+        oem_minus_bestpos_db = json_db.fork()
         new_db_with_bestpos = MessageDatabase()
         bestpos_name = "BESTPOS"
         bestpos_msg_def = oem_minus_bestpos_db.get_msg_def(bestpos_name)
@@ -418,8 +420,8 @@ class TestDatabaseActions:
         assert oem_minus_bestpos_db.get_msg_def(other_msg_name) == other_msg_def
         assert oem_minus_bestpos_db.get_msg_type(other_msg_name) is other_msg_type
 
-    def test_clone(self, json_db: MessageDatabase):
-        """Tests that a cloned database exposes the same messages and types as the original."""
+    def test_fork(self, json_db: MessageDatabase):
+        """Tests that a forked database exposes the same messages and types as the original."""
         # Arrange
         bestpos_name = "BESTPOS"
         bestpos_def = json_db.get_msg_def(bestpos_name)
@@ -429,16 +431,35 @@ class TestDatabaseActions:
         range_type = json_db.get_msg_type(range_name)
 
         # Act
-        cloned_db = json_db.clone()
+        forked_db = json_db.fork()
 
         # Assert
-        assert cloned_db is not json_db
-        assert cloned_db.get_msg_def(bestpos_name) == bestpos_def
-        assert cloned_db.get_msg_type(bestpos_name) is bestpos_type
-        assert cloned_db.get_msg_def(range_name) == range_def
-        assert cloned_db.get_msg_type(range_name) is range_type
+        assert forked_db is not json_db
+        assert forked_db.get_msg_def(bestpos_name) == bestpos_def
+        assert forked_db.get_msg_type(bestpos_name) is bestpos_type
+        assert forked_db.get_msg_def(range_name) == range_def
+        assert forked_db.get_msg_type(range_name) is range_type
 
         assert json_db.get_msg_def(bestpos_name) == bestpos_def
         assert json_db.get_msg_type(bestpos_name) is bestpos_type
         assert json_db.get_msg_def(range_name) == range_def
         assert json_db.get_msg_type(range_name) is range_type
+
+    def test_clone_deprecated(self, json_db: MessageDatabase, caplog):
+        """Tests that the deprecated clone() alias warns but still behaves like fork()."""
+        # Act
+        with caplog.at_level(logging.WARNING, logger="novatel_edie.deprecation_warning"):
+            cloned_db = json_db.clone()
+
+        # Assert: clone() behaves like fork() (independent copy, source locked).
+        assert cloned_db is not json_db
+        assert json_db.is_locked
+        assert not cloned_db.is_locked
+
+        # Assert: a deprecation warning directing the user to fork() was logged.
+        deprecation_records = [
+            rec for rec in caplog.records if rec.name == "novatel_edie.deprecation_warning"
+        ]
+        assert len(deprecation_records) == 1
+        assert deprecation_records[0].levelno == logging.WARNING
+        assert "fork" in deprecation_records[0].message

--- a/python/test/test_message_database.py
+++ b/python/test/test_message_database.py
@@ -24,8 +24,8 @@
 
 import pytest
 
-from novatel_edie import MessageDatabase, FailureException
-from novatel_edie.oem import Decoder
+from novatel_edie import MessageDatabase, UnsupportedException
+from novatel_edie.oem import Decoder, Parser, FileParser, get_builtin_database
 from novatel_edie.oem.enums import Datum
 from novatel_edie import MessageDefinition, EnumFieldDefinition, EnumDefinition, EnumDataType
 from novatel_edie import FieldDefinition, ArrayFieldDefinition, FieldArrayFieldDefinition, FIELD_TYPE, DATA_TYPE
@@ -37,7 +37,7 @@ class TestDatabaseObjects:
     @pytest.mark.parametrize("values", [
         {},
         {"value": 2, "name": "val", "description": "a value of 2"},
-        {"value": 0, "name": "error", "description": "an error msg"}])
+        {"value": 0, "name": "error"}])
     class TestEnumDataType:
         """Tests for EnumDataType."""
         defaults = {
@@ -92,7 +92,6 @@ class TestDatabaseObjects:
 
     class TestFieldDefinition:
         """Tests for FieldDefinition (BaseField)."""
-
         @pytest.mark.parametrize("values", [
             {},
             {"name": "field1", "type": FIELD_TYPE.SIMPLE, "conversion": "%d", "data_type": DATA_TYPE.INT},
@@ -267,6 +266,72 @@ class TestDatabaseObjects:
 
 class TestDatabaseActions:
     """Tests for the effect of preforming actions on a database."""
+    class TestDatabaseLocking:
+        """Tests for the database's locking mechanism.
+
+        Any access to the database's immutable types or exposure of them to other
+        C++ objects should permenantly lock the database from further mutation.
+        """
+        def test_lock(self, json_db: MessageDatabase):
+            # Arrange
+            db = MessageDatabase()
+            # Act
+            db.lock()
+
+            # Assert
+            assert db.is_locked
+            with pytest.raises(UnsupportedException, match="locked"):
+                db.append_messages(MessageDefinition())
+            with pytest.raises(UnsupportedException, match="locked"):
+                db.append_enumerations(EnumDefinition())
+            with pytest.raises(UnsupportedException, match="locked"):
+                db.remove_message(0)
+            with pytest.raises(UnsupportedException, match="locked"):
+                db.remove_enumeration("Datum")
+            with pytest.raises(UnsupportedException, match="locked"):
+                db.merge(json_db)
+            with pytest.raises(UnsupportedException, match="locked"):
+                db.message_family = "OEM"
+
+        def test_global_lock(self):
+            assert get_builtin_database().is_locked
+
+        def test_merge_locking(self):
+            # Arrange
+            old_db = MessageDatabase()
+            new_db = MessageDatabase()
+            # Act
+            new_db.merge(old_db)
+            # Assert
+            assert old_db.is_locked
+            assert not new_db.is_locked
+
+        def test_clone_locking(self):
+            # Arrange
+            old_db = MessageDatabase()
+            # Act
+            new_db = old_db.clone()
+            # Assert
+            assert old_db.is_locked
+            assert not new_db.is_locked
+
+        def test_pytype_access_locking(self, json_db: MessageDatabase):
+            # Arrange
+            db = json_db.clone()
+            # Act
+            db.get_msg_type("BESTPOS")
+            # Assert
+            assert db.is_locked
+
+        @pytest.mark.parametrize("consumer_cons", [Decoder, Parser, lambda x: FileParser("", x)])
+        def test_consumer_locking(self, consumer_cons, json_db: MessageDatabase):
+            # Arrange
+            db = json_db.clone()
+            # Act
+            consumer_cons(db)
+            # Assert
+            assert db.is_locked
+
     def test_message_db_enums(self, json_db):
         # Act
         datum_enum = json_db.get_enum_type_by_name("Datum")
@@ -310,7 +375,6 @@ class TestDatabaseActions:
         range_id = 43
         range_def = json_db.get_msg_def(range_id)
         new_db.append_messages([bestpos_def, range_def])
-        new_range_type = new_db.get_msg_type("RANGE")
 
         # Act
         new_db.remove_message(bestpos_id)
@@ -322,7 +386,7 @@ class TestDatabaseActions:
         assert new_db.get_msg_def(bestpos_id) is None
         assert new_db.get_msg_type("BESTPOS") is None
         assert new_db.get_msg_def(range_id) == range_def
-        assert new_db.get_msg_type("RANGE") is new_range_type
+        assert new_db.get_msg_type("RANGE") is not None
 
     def test_merge(self, json_db: MessageDatabase):
         """Tests that one databases messages can be merged into another."""
@@ -332,7 +396,6 @@ class TestDatabaseActions:
         bestpos_name = "BESTPOS"
         bestpos_msg_def = oem_minus_bestpos_db.get_msg_def(bestpos_name)
         new_db_with_bestpos.append_messages([bestpos_msg_def])
-        bestpos_msg_type = new_db_with_bestpos.get_msg_type(bestpos_name)
         other_msg_name = "RANGE"
         other_msg_def = oem_minus_bestpos_db.get_msg_def(other_msg_name)
         oem_minus_bestpos_db.remove_message(bestpos_msg_def.log_id)
@@ -343,7 +406,7 @@ class TestDatabaseActions:
 
         # Assert
         assert new_db_with_bestpos.get_msg_def(bestpos_name) == bestpos_msg_def
-        assert new_db_with_bestpos.get_msg_type(bestpos_name) is bestpos_msg_type
+        assert new_db_with_bestpos.get_msg_type(bestpos_name) is not None
         assert new_db_with_bestpos.get_msg_def(other_msg_name) == other_msg_def
         assert new_db_with_bestpos.get_msg_type(other_msg_name) is not None
         assert new_db_with_bestpos.get_msg_type(other_msg_name) != other_msg_type

--- a/python/test/test_message_database.py
+++ b/python/test/test_message_database.py
@@ -25,7 +25,7 @@
 import pytest
 
 from novatel_edie import MessageDatabase, UnsupportedException
-from novatel_edie.oem import Decoder, Parser, FileParser, get_builtin_database
+from novatel_edie.oem import Decoder, Parser, FileParser, Commander, RangeDecompressor, RxConfigHandler, get_builtin_database
 from novatel_edie.oem.enums import Datum
 from novatel_edie import MessageDefinition, EnumFieldDefinition, EnumDefinition, EnumDataType
 from novatel_edie import FieldDefinition, ArrayFieldDefinition, FieldArrayFieldDefinition, FIELD_TYPE, DATA_TYPE
@@ -323,7 +323,8 @@ class TestDatabaseActions:
             # Assert
             assert db.is_locked
 
-        @pytest.mark.parametrize("consumer_cons", [Decoder, Parser, lambda x: FileParser("", x)])
+        @pytest.mark.parametrize("consumer_cons", [Decoder, Parser, lambda x: FileParser("", x),
+                                                   Commander, RangeDecompressor, RxConfigHandler])
         def test_consumer_locking(self, consumer_cons, json_db: MessageDatabase):
             # Arrange
             db = json_db.clone()

--- a/src/decoders/common/src/json_db_reader.cpp
+++ b/src/decoders/common/src/json_db_reader.cpp
@@ -38,7 +38,6 @@ using json = nlohmann::json;
 
 // Forward declaration of from_json
 void from_json(const json& j_, EnumDataType& f_);
-void from_json(const json& j_, BaseDataType& f_);
 void from_json(const json& j_, SimpleDataType& f_);
 void from_json(const json& j_, BaseField& f_);
 void from_json(const json& j_, EnumField& f_);
@@ -61,23 +60,12 @@ void from_json(const json& j_, EnumDataType& f_)
 }
 
 //-----------------------------------------------------------------------
-void from_json(const json& j_, BaseDataType& f_)
+void from_json(const json& j_, SimpleDataType& f_)
 {
     auto itrDataTypeMapping = DataTypeEnumLookup.find(j_.at("name"));
     f_.name = itrDataTypeMapping != DataTypeEnumLookup.end() ? itrDataTypeMapping->second : DATA_TYPE::UNKNOWN;
     f_.length = j_.at("length");
     f_.description = j_.at("description").is_null() ? "" : j_.at("description");
-}
-
-//-----------------------------------------------------------------------
-void from_json(const json& j_, SimpleDataType& f_)
-{
-    from_json(j_, static_cast<BaseDataType&>(f_));
-
-    if (j_.find("enum") != j_.end())
-    {
-        for (const auto& e : j_.at("enum")) { f_.enums[e.at("value")] = e; }
-    }
 }
 
 //-----------------------------------------------------------------------
@@ -188,7 +176,7 @@ uint32_t ParseFields(const json& j_, std::vector<BaseField::Ptr>& vFields_)
     for (const auto& field : j_)
     {
         const auto sFieldType = field.at("type").get<std::string_view>();
-        const auto stDataType = field.at("dataType").get<BaseDataType>();
+        const auto stDataType = field.at("dataType").get<SimpleDataType>();
 
         if (sFieldType == "SIMPLE")
         {

--- a/src/decoders/common/src/json_db_reader.cpp
+++ b/src/decoders/common/src/json_db_reader.cpp
@@ -126,7 +126,6 @@ void from_json(const json& j_, MessageDefinition& md_)
     md_.name = j_.at("name");
     md_.description = j_.at("description").is_null() ? "" : j_.at("description");
     md_.latestMessageCrc = std::stoul(j_.at("latestMsgDefCrc").get<std::string>());
-    md_.messageStyle = j_.contains("messageStyle") && !j_.at("messageStyle").is_null() ? j_.at("messageStyle") : "OEM4_MESSAGE_STYLE";
 
     for (const auto& fields : j_.at("fields").items())
     {

--- a/src/decoders/common/src/json_db_reader.cpp
+++ b/src/decoders/common/src/json_db_reader.cpp
@@ -185,9 +185,7 @@ uint32_t ParseFields(const json& j_, std::vector<BaseField::Ptr>& vFields_)
         }
         else if (sFieldType == "ENUM")
         {
-            auto pstField = std::make_shared<EnumField>(field);
-            pstField->length = stDataType.length;
-            vFields_.emplace_back(pstField);
+            vFields_.emplace_back(std::make_shared<EnumField>(field));
             uiFieldSize += stDataType.length;
         }
         else if (sFieldType == "FIXED_LENGTH_ARRAY" || sFieldType == "VARIABLE_LENGTH_ARRAY" || sFieldType == "STRING")

--- a/src/decoders/common/src/json_db_reader.cpp
+++ b/src/decoders/common/src/json_db_reader.cpp
@@ -138,24 +138,9 @@ void from_json(const json& j_, MessageDefinition& md_)
 //-----------------------------------------------------------------------
 void from_json(const json& j_, EnumDefinition& ed_)
 {
-    ed_._id = j_.at("_id");
-    ed_.name = j_.at("name");
-
-    // Parse enumerators into the vector
-    ParseEnumerators(j_.at("enumerators"), ed_.enumerators);
-
-    // Populate the lookup maps
-    uint32_t maxVal = 0;
-    for (const auto& enumerator : ed_.enumerators)
-    {
-        maxVal = std::max(maxVal, enumerator.value);
-        ed_.nameValue[enumerator.name] = enumerator.value;
-        ed_.valueName[enumerator.value] = enumerator.name;
-        ed_.descriptionValue[enumerator.description] = enumerator.value;
-    }
-    ed_.unknownValue = maxVal + 1;
-    assert(ed_.unknownValue > maxVal &&
-           "Overflow encountered when determining placeholder value. Enumerator values are expected to  be within [0, 2^31).");
+    std::vector<EnumDataType> enumerators;
+    ParseEnumerators(j_.at("enumerators"), enumerators);
+    ed_ = EnumDefinition(j_.at("_id"), j_.at("name"), std::move(enumerators));
 }
 
 //-----------------------------------------------------------------------

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -673,7 +673,7 @@ STATUS MessageDecoderBase::DecodeAscii(const std::vector<BaseField::Ptr>& vMsgDe
         case FIELD_TYPE::ENUM: {
             std::string_view sEnum(*ppcLogBuf_, tokenLength);
             const auto* enumField = dynamic_cast<EnumField*>(field.get());
-            switch (enumField->length)
+            switch (enumField->dataType.length)
             {
             case 1: vIntermediateFormat_.emplace_back(static_cast<uint8_t>(GetEnumValue(enumField->enumDef, sEnum)), field); break;
             case 2: vIntermediateFormat_.emplace_back(static_cast<uint16_t>(GetEnumValue(enumField->enumDef, sEnum)), field); break;

--- a/src/decoders/common/test/message_decoder_unit_test.cpp
+++ b/src/decoders/common/test/message_decoder_unit_test.cpp
@@ -73,7 +73,7 @@ class MessageDecoderTypesTest : public ::testing::Test
                 // there is an issue here in that some data types can have multiple conversion strings or sizes
                 // associated with them. In order to fix this, we may want these DataType functions to return a
                 // vector so we can iterate through every possible valid combination of a basefield
-                auto stMessageDataType = std::make_shared<const BaseField>("", FIELD_TYPE::SIMPLE, DataTypeConversion(D), DataTypeSize(D), D);
+                auto stMessageDataType = std::make_shared<const BaseField>("", FIELD_TYPE::SIMPLE, DataTypeConversion(D), D);
                 const char* tempStr = vstrTestInput[sz].c_str();
                 DecodeAsciiField(std::move(stMessageDataType), &tempStr, vstrTestInput[sz].length(), vIntermediateFormat_);
 
@@ -84,17 +84,6 @@ class MessageDecoderTypesTest : public ::testing::Test
                 }
                 else { ASSERT_EQ(std::get<T>(vIntermediateFormat_[0].fieldValue), vTargets[sz]); }
             }
-        }
-
-        template <typename T, DATA_TYPE D> void InvalidSizeSimpleASCIIHelper(std::string_view strTestInput)
-        {
-            std::vector<FieldContainer> vIntermediateFormat;
-            vIntermediateFormat.reserve(1);
-
-            auto stMessageDataType = std::make_shared<const BaseField>("", FIELD_TYPE::SIMPLE, DataTypeConversion(D), DataTypeSize(D) + 1, D);
-            const char* tempStr = strTestInput.data();
-            ASSERT_THROW(MessageDecoderBase::DecodeAsciiField(std::move(stMessageDataType), &tempStr, strTestInput.size(), vIntermediateFormat),
-                         std::runtime_error);
         }
 
         template <typename T, DATA_TYPE D> void ValidBinaryHelper(std::vector<std::vector<uint8_t>> vvucTestInput, std::vector<T> vTargets)
@@ -112,7 +101,7 @@ class MessageDecoderTypesTest : public ::testing::Test
                 // there is an issue here in that some data types can have multiple conversion strings or sizes
                 // associated with them. In order to fix this, we may want these DataType functions to return a
                 // vector so we can iterate through every possible valid combination of a basefield
-                auto stMessageDataType = std::make_shared<const BaseField>("", FIELD_TYPE::SIMPLE, DataTypeConversion(D), DataTypeSize(D), D);
+                auto stMessageDataType = std::make_shared<const BaseField>("", FIELD_TYPE::SIMPLE, DataTypeConversion(D), D);
                 // there should be a better way to do this
                 const uint8_t* pucTestInput = vvucTestInput[sz].data();
                 DecodeBinaryField(std::move(stMessageDataType), &pucTestInput, vIntermediateFormat_);
@@ -228,27 +217,9 @@ TEST_F(MessageDecoderTypesTest, ASCII_SIMPLE_VALID)
     pclMyDecoderTester->ValidSimpleASCIIHelper<double, DATA_TYPE::DOUBLE>({"2.2250738585072014e-308", "1.7976931348623157e+308", "0.0"}, {0.0});
 }
 
-TEST_F(MessageDecoderTypesTest, DISABLED_ASCII_SIMPLE_INVALID_SIZE)
-{
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<bool, DATA_TYPE::BOOL>("FALSE");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<uint8_t, DATA_TYPE::UCHAR>("#");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<int8_t, DATA_TYPE::CHAR>("#");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<uint8_t, DATA_TYPE::HEXBYTE>("0x00");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<uint16_t, DATA_TYPE::USHORT>("0");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<int16_t, DATA_TYPE::SHORT>("0");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<uint32_t, DATA_TYPE::UINT>("0");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<int32_t, DATA_TYPE::INT>("0");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<uint32_t, DATA_TYPE::ULONG>("0");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<int32_t, DATA_TYPE::LONG>("0");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<uint64_t, DATA_TYPE::ULONGLONG>("0");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<int64_t, DATA_TYPE::LONGLONG>("0");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<float, DATA_TYPE::FLOAT>("0.0");
-    pclMyDecoderTester->InvalidSizeSimpleASCIIHelper<double, DATA_TYPE::DOUBLE>("0.0");
-}
-
 TEST_F(MessageDecoderTypesTest, ASCII_CHAR_BYTE_INVALID_INPUT)
 {
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("CHAR_1", FIELD_TYPE::SIMPLE, "%c", 1, DATA_TYPE::CHAR));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("CHAR_1", FIELD_TYPE::SIMPLE, "%c", DATA_TYPE::CHAR));
     std::vector<FieldContainer> vIntermediateFormat_;
     vIntermediateFormat_.reserve(1);
 
@@ -260,7 +231,7 @@ TEST_F(MessageDecoderTypesTest, ASCII_CHAR_BYTE_INVALID_INPUT)
 
 TEST_F(MessageDecoderTypesTest, ASCII_BOOL_VALID_INPUT)
 {
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("B_True", FIELD_TYPE::SIMPLE, "%d", 4, DATA_TYPE::BOOL));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("B_True", FIELD_TYPE::SIMPLE, "%d", DATA_TYPE::BOOL));
     std::vector<FieldContainer> vIntermediateFormat_;
     vIntermediateFormat_.reserve(1);
 
@@ -295,7 +266,7 @@ TEST_F(MessageDecoderTypesTest, DISABLED_ASCII_ENUM_VALID)
 
 TEST_F(MessageDecoderTypesTest, ASCII_STRING_VALID)
 {
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("MESSAGE", FIELD_TYPE::STRING, "%s", 1, DATA_TYPE::UNKNOWN));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("MESSAGE", FIELD_TYPE::STRING, "%s", DATA_TYPE::UNKNOWN));
     std::vector<FieldContainer> vIntermediateFormat;
     vIntermediateFormat.reserve(1);
 
@@ -313,7 +284,7 @@ TEST_F(MessageDecoderTypesTest, ASCII_STRING_VALID)
 
 TEST_F(MessageDecoderTypesTest, ASCII_TYPE_INVALID)
 {
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::UNKNOWN, "%d", 1, DATA_TYPE::UNKNOWN));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::UNKNOWN, "%d", DATA_TYPE::UNKNOWN));
     std::vector<FieldContainer> vIntermediateFormat_;
     vIntermediateFormat_.reserve(1);
 
@@ -342,27 +313,27 @@ TEST_F(MessageDecoderTypesTest, BINARY_VALID)
 
 TEST_F(MessageDecoderTypesTest, BINARY_SIMPLE_TYPE_INVALID)
 {
-    ASSERT_THROW(MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%", 1, DATA_TYPE::UNKNOWN)), std::runtime_error);
+    ASSERT_THROW(MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%", DATA_TYPE::UNKNOWN)), std::runtime_error);
 }
 
 TEST_F(MessageDecoderTypesTest, BINARY_TYPE_INVALID)
 {
-    ASSERT_THROW(MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::UNKNOWN, "%", 1, DATA_TYPE::UNKNOWN)), std::runtime_error);
+    ASSERT_THROW(MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::UNKNOWN, "%", DATA_TYPE::UNKNOWN)), std::runtime_error);
 }
 
 TEST_F(MessageDecoderTypesTest, SIMPLE_FIELD_WIDTH_VALID)
 {
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%d", 4, DATA_TYPE::BOOL));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%hu", 2, DATA_TYPE::USHORT));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%hd", 2, DATA_TYPE::SHORT));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%u", 4, DATA_TYPE::UINT));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%lu", 4, DATA_TYPE::ULONG));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%d", 4, DATA_TYPE::INT));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%ld", 4, DATA_TYPE::LONG));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%llu", 8, DATA_TYPE::ULONGLONG));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%lld", 8, DATA_TYPE::LONGLONG));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%f", 4, DATA_TYPE::FLOAT));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%lf", 8, DATA_TYPE::DOUBLE));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%d", DATA_TYPE::BOOL));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%hu", DATA_TYPE::USHORT));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%hd", DATA_TYPE::SHORT));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%u", DATA_TYPE::UINT));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%lu", DATA_TYPE::ULONG));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%d", DATA_TYPE::INT));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%ld", DATA_TYPE::LONG));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%llu", DATA_TYPE::ULONGLONG));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%lld", DATA_TYPE::LONGLONG));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%f", DATA_TYPE::FLOAT));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%lf", DATA_TYPE::DOUBLE));
 
     std::vector<FieldContainer> vIntermediateFormat;
     vIntermediateFormat.reserve(MsgDefFields.size());

--- a/src/decoders/common/test/message_decoder_unit_test.cpp
+++ b/src/decoders/common/test/message_decoder_unit_test.cpp
@@ -295,7 +295,7 @@ TEST_F(MessageDecoderTypesTest, DISABLED_ASCII_ENUM_VALID)
 
 TEST_F(MessageDecoderTypesTest, ASCII_STRING_VALID)
 {
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("MESSAGE", FIELD_TYPE::STRING, "%", 1, DATA_TYPE::UNKNOWN));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("MESSAGE", FIELD_TYPE::STRING, "%s", 1, DATA_TYPE::UNKNOWN));
     std::vector<FieldContainer> vIntermediateFormat;
     vIntermediateFormat.reserve(1);
 
@@ -342,22 +342,12 @@ TEST_F(MessageDecoderTypesTest, BINARY_VALID)
 
 TEST_F(MessageDecoderTypesTest, BINARY_SIMPLE_TYPE_INVALID)
 {
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%", 1, DATA_TYPE::UNKNOWN));
-    std::vector<FieldContainer> vIntermediateFormat_;
-
-    const unsigned char* testInput = nullptr;
-
-    ASSERT_THROW(pclMyDecoderTester->TestDecodeBinary(MsgDefFields, &testInput, vIntermediateFormat_), std::runtime_error);
+    ASSERT_THROW(MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::SIMPLE, "%", 1, DATA_TYPE::UNKNOWN)), std::runtime_error);
 }
 
 TEST_F(MessageDecoderTypesTest, BINARY_TYPE_INVALID)
 {
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::UNKNOWN, "%", 1, DATA_TYPE::UNKNOWN));
-    std::vector<FieldContainer> vIntermediateFormat_;
-
-    const unsigned char* testInput = nullptr;
-
-    ASSERT_THROW(pclMyDecoderTester->TestDecodeBinary(MsgDefFields, &testInput, vIntermediateFormat_), std::runtime_error);
+    ASSERT_THROW(MsgDefFields.emplace_back(std::make_shared<BaseField>("", FIELD_TYPE::UNKNOWN, "%", 1, DATA_TYPE::UNKNOWN)), std::runtime_error);
 }
 
 TEST_F(MessageDecoderTypesTest, SIMPLE_FIELD_WIDTH_VALID)

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -4294,10 +4294,10 @@ class NovatelTypesTest : public ::testing::Test
 
 TEST_F(NovatelTypesTest, ASCII_GPSTIME_MSEC_VALID)
 {
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("Sec1", FIELD_TYPE::SIMPLE, "%T", 4, DATA_TYPE::ULONG));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("Sec2", FIELD_TYPE::SIMPLE, "%T", 4, DATA_TYPE::ULONG));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("Sec3", FIELD_TYPE::SIMPLE, "%T", 4, DATA_TYPE::ULONG));
-    MsgDefFields.emplace_back(std::make_shared<BaseField>("Sec4", FIELD_TYPE::SIMPLE, "%T", 4, DATA_TYPE::ULONG));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("Sec1", FIELD_TYPE::SIMPLE, "%T", DATA_TYPE::ULONG));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("Sec2", FIELD_TYPE::SIMPLE, "%T", DATA_TYPE::ULONG));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("Sec3", FIELD_TYPE::SIMPLE, "%T", DATA_TYPE::ULONG));
+    MsgDefFields.emplace_back(std::make_shared<BaseField>("Sec4", FIELD_TYPE::SIMPLE, "%T", DATA_TYPE::ULONG));
     std::vector<FieldContainer> vIntermediateFormat_;
     vIntermediateFormat_.reserve(4);
 


### PR DESCRIPTION
## Python Message Database + Message Definition Structs Refactor

This pull request has the following motivations:
1. **Improve the python interface for managing database contents:**
    - Allow users to construct a message definition and all its sub-components purely in python.
    - The underlying C++ structs contain fields which are used for caching derived values, not configuring a definition, the new interface encapsulates these from the python side.
    - All database methods now use copy semantics for passing definitions to and from python. This avoids the possibility of accidental mutation of a value. There was previously a footgun where appending message definitions from one database to another caused enum definitions to be overwritten. This approach makes issues like this impossible.
2. **Allow the owning database for a type to be resolved:**
    - `Message` subtypes such as `BESTPOS` now hold a pointer to the database which created them. This allows their constructors to lookup the information needed to create a proper object.
    - A database and all python types it creates will now share a lifetime. This means that it is always safe to construct an object. Management is outsourced to python's garbage collector.
    - Once a type has been retrieved from a database, either explicitly or via decoding a message, the database that owns it is guaranteed to be "locked".
3. **Clean up C++ message definition structs:**
    - Centralize initialization logic in constructors instead of relying on json parser.
    - Introduce explicit copy constructors and equality operators.
    - Clearly indicate which fields store cached values.
    - Delete completely dead or redundant code.


## Summary of changes

1. **Value-type rework** — `EnumDefinition`, `BaseField` and subclasses, and `MessageDefinition` got proper copy/move semantics, deep `clone()`, structural `operator==`, and explicit `// cached` annotations on derived fields rebuilt via `RebuildCaches()` / `ComputeStringFlags()`. Default-copy aliasing of nested `string_view`s and `shared_ptr<BaseField>`s is gone. Any communication between python and C++ layer now employs copying.
2. **Database lifetime + locking** — `PyMessageDatabase` is now constructed via a `Create()` factory that publishes the wrapper into nanobind's instance map before init runs. The DB supports `lock()` / `is_locked` and installs `tp_traverse` / `tp_clear` GC slots so the cycle between the DB and its dynamically-built Python types is collectable. `MessageDbSingleton::cleanup` is registered with `atexit` to release the built-in DB at interpreter teardown.
3. **Mutation hooks** — `append_messages`, `append_enumerations`, `remove_message`, `remove_enumeration`, `merge`, `clone`, and `message_family` all throw `UnsupportedException` once locked. Consumers (`Parser`, `FileParser`, `Decoder`, `Commander`, `RangeDecompressor`, `RxConfigHandler`, plus `get_msg_type` / `get_enum_type_*`) implicitly lock the DB on first use. `get_builtin_database()` returns a pre-locked DB.
4. **Definition objects in Python** — `EnumDataType`, `EnumDefinition`, `FieldDefinition`, `EnumFieldDefinition`, `ArrayFieldDefinition`, `FieldArrayFieldDefinition`, `MessageDefinition` are now default-constructible, fully mutable, equality-comparable, and have meaningful `__repr__`s.
5. **Reverse lookup: Python type → definition** — new per-DB `enum_type_lookup_` / `field_type_lookup_` / `message_type_lookup_` maps power `Message.__new__` / `Field.__new__`, so a user can construct an empty message instance of a Python type and have it bind back to the right `MessageDefinition` + CRC.
6. `BaseDataType` deleted (dead code), `SimpleDataType::enums` removed (dead code), `EnumField::length` removed (redundant), `MessageDefinition::messageStyle` removed (dead code).

## Interface breakage

### C++ API

| Symbol | Status | Migration |
| --- | --- | --- |
| `BaseDataType` | Removed | Use `SimpleDataType` (fields merged in). |
| `SimpleDataType::enums` | Removed | Was unused. |
| `EnumField::length` | Removed | Read `field.dataType.length`. |
| `MessageDefinition::messageStyle` | Removed | No replacement. JSON `messageStyle` keys are now ignored. |
| `BaseField::SetConversion("%")` / `"d"` / etc. | Now throws | Provide a valid format with an alpha specifier. |
| Default copy on `BaseField`/`EnumField`/`ArrayField`/`FieldArrayField`/`MessageDefinition`/`EnumDefinition` | Now deep | Code relying on the previous aliasing breaks (almost certainly was a UAF bug). |
| `FieldArrayField::fieldSize` | Auto-computed in constructor | Don't hand-set after construction. |

External code that builds on `BaseDataType`, reads `EnumField::length`, or touches `messageStyle` will not compile.

### Python API

| Symbol | Status | Migration |
| --- | --- | --- |
| `EnummeratorDefinition` | Aliased to `EnumDefinition` in `novatel_edie/__init__.py` | Imports from `novatel_edie.common_bindings.EnummeratorDefinition` will break — use `EnumDefinition`. |
| `EnumFieldDefinition(name=, enumerators=)` | Removed | New: `(name, type, conversion, data_type, enum_id)`. Add the `EnumDefinition` to the DB separately. |
| `EnumFieldDefinition.length` | Removed | Read `field.data_type`. |
| `EnumFieldDefinition.enum_def` | Read-only | It's a cache resolved by the DB. |
| `FieldDefinition(name, type, conversion, length, data_type)` | Removed | New: `(name, type, conversion, data_type)`; `length` derives from `data_type`. |
| `FieldDefinition.width` / `.precision` | Not bound | Caches recomputed by `SetConversion`. |
| `<enum_type>._name` / `<enum_type>._id` attrs on dynamically-created enum types | Removed | Was unused. |
| `BaseDataType` / `SimpleDataType` Python classes | Removed | `DATA_TYPE` enum is sufficient. |
| `FieldArrayFieldDefinition.field_size` | Removed | Cache; populated by the constructor. |
| `MessageDefinition.fields` setter | Newly available | Was read-only. |
| `MessageDatabase.get_msg_def(...)` | Returns a deep copy | Mutations to the result no longer affect the DB; identity checks against in-DB defs fail. |
| `MessageDatabase.clone()` | Locks the source | Mutate before cloning if you need the source mutable. |
| `MessageDatabase.get_msg_type(...)` / `get_enum_type_by_*(...)` | Implicitly lock the DB | Configure the DB before requesting any Python type. |
| `Parser(db)` / `FileParser(path, db)` / `Decoder(db)` / `Commander(db)` / `RangeDecompressor(db)` / `RxConfigHandler(db)` | Implicitly lock `db` | Same advice. |
| `get_builtin_database()` | Returns locked | Clone first if you need to extend the built-in DB. |
| `field.conversion = "bad"` | `AttributeError` | Was `RuntimeError`. |
| `FieldDefinition(conversion="bad")` etc. | `ValueError` | Constructor errors are now `ValueError`. |
| Mutating a locked DB | `UnsupportedException` | New exception class. |
| `MessageDatabase.lock()` / `.is_locked` | Newly available | New public API. |
| `__eq__` on `EnumDataType` / `BaseField` / `MessageDefinition` | Newly available | Structural equality. |
| `MessageDatabase.append_messages([def, ...])` | Defensively deep-clones each `def` | Source's field defs can no longer be mutated through a shared pointer. |

The current python API was il-defined enough that I suspect most of these changes will have no impact. The database locking is the only exception and is a quick fix with `db.clone()`.

## Test coverage

`python/test/test_message_database.py` — 64 tests (parametrized), all green:

- **Definition objects** — for each of the seven Python definition classes: construction with defaults, with mixed/full kwargs, and via `setattr` after default-construction. Plus `field.conversion = bad-string` → `AttributeError` parametrized over `""`, `"d"`, `"%q!"`, `"%5.2"`.
- **Locking** — six scenarios: explicit `lock()` blocks every mutator, `get_builtin_database()` returns locked, `merge` locks both DBs, `clone` locks the source, `get_msg_type` / `get_enum_type_by_name` lock the DB, and constructing each of `Decoder` / `Parser` / `FileParser` / `Commander` / `RangeDecompressor` / `RxConfigHandler` locks the passed DB.
- **Database actions** — built-in enum lookup, append/remove/merge/clone with bidirectional identity assertions across DBs.
