### PR TITLE
Disable logger tests for python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,15 @@ if(BUILD_TESTS)
     # https://gitlab.kitware.com/cmake/cmake/-/issues/21730
     set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
     include(CTest)
+    if(BUILD_PYTHON)
+        # Python builds link spdlog statically into the EDIE shared libraries, so spdlog's
+        # global registry inside the library is a separate instance from the one in the test
+        # executable. The *.LOGGER test cases assert against a shared registry and cannot hold
+        # in that configuration, so SKIP_IF_STATIC_SPDLOG_REGISTRY() skips them (see
+        # include/novatel_edie/common/test_utils/logger_registry_test.hpp). Directory-scoped so
+        # only the test subdirectories added below pick it up.
+        add_compile_definitions(NOVATEL_EDIE_STATIC_SPDLOG)
+    endif()
     add_subdirectory(src/common/test)
     add_subdirectory(src/decoders/common/test)
     add_subdirectory(src/decoders/oem/test)

--- a/include/novatel_edie/common/test_utils/logger_registry_test.hpp
+++ b/include/novatel_edie/common/test_utils/logger_registry_test.hpp
@@ -1,0 +1,32 @@
+//-----------------------------------------------------------------------
+//! \file logger_registry_test.hpp
+//! \brief Helper for skipping logger-registry tests when spdlog is statically
+//!        linked into a shared library.
+//!
+//! In Python builds (BUILD_PYTHON=ON) the EDIE libraries are built as shared
+//! libraries with spdlog linked statically into them. spdlog's global registry
+//! lives in static storage, so the copy inside the EDIE shared library is a
+//! separate instance from the one in the test executable. As a result, registry
+//! assertions in the *.LOGGER test cases (e.g. spdlog::get("novatel_framer"))
+//! cannot see loggers registered on the library side and fail.
+//!
+//! These assertions describe behavior that is only valid when a single spdlog
+//! registry is shared across the test executable and the code under test, so the
+//! affected tests are skipped in that configuration only. The macro is a no-op in
+//! every other build, leaving the tests active.
+//!
+//! NOVATEL_EDIE_STATIC_SPDLOG is defined on the test targets by CMake when
+//! BUILD_PYTHON is ON (see the BUILD_TESTS block in the top-level CMakeLists.txt).
+//-----------------------------------------------------------------------
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#ifdef NOVATEL_EDIE_STATIC_SPDLOG
+#define SKIP_IF_STATIC_SPDLOG_REGISTRY()                                                                                                             \
+    GTEST_SKIP() << "spdlog is statically linked into the shared library (Python build); its global registry is not shared with the test "           \
+                    "executable, so logger-registry assertions are not applicable."
+#else
+#define SKIP_IF_STATIC_SPDLOG_REGISTRY() ((void)0)
+#endif

--- a/src/decoders/common/test/message_decoder_unit_test.cpp
+++ b/src/decoders/common/test/message_decoder_unit_test.cpp
@@ -28,6 +28,7 @@
 
 #include <gtest/gtest.h>
 
+#include "novatel_edie/common/test_utils/logger_registry_test.hpp"
 #include "novatel_edie/decoders/common/json_db_reader.hpp"
 #include "novatel_edie/decoders/common/message_decoder.hpp"
 
@@ -203,6 +204,7 @@ class MessageDecoderTypesTest : public ::testing::Test
 
 TEST_F(MessageDecoderTypesTest, LOGGER)
 {
+    SKIP_IF_STATIC_SPDLOG_REGISTRY();
     spdlog::level::level_enum eLevel = spdlog::level::off;
 
     ASSERT_NE(spdlog::get("message_decoder"), nullptr);

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -36,6 +36,7 @@
 #include <novatel_edie/decoders/common/framer_manager.hpp>
 #include <novatel_edie/decoders/common/framer_registration.hpp>
 
+#include "novatel_edie/common/test_utils/logger_registry_test.hpp"
 #include "novatel_edie/decoders/common/json_db_reader.hpp"
 #include "novatel_edie/decoders/common/message_decoder.hpp"
 #include "novatel_edie/decoders/oem/commander.hpp"
@@ -166,6 +167,7 @@ TYPED_TEST_SUITE(ShortAsciiFramerTest, ShortAsciiFramerTypes, ::testing::interna
 // -------------------------------------------------------------------------------------------------------
 TEST_F(OEMFramerTest, LOGGER)
 {
+    SKIP_IF_STATIC_SPDLOG_REGISTRY();
     spdlog::level::level_enum eLevel = spdlog::level::off;
 
     ASSERT_NE(spdlog::get("novatel_framer"), nullptr);
@@ -1339,6 +1341,7 @@ std::unique_ptr<unsigned char[]> FramerManagerTest::pucMyTestFrameBuffer = nullp
 // -------------------------------------------------------------------------------------------------------
 TEST_F(FramerManagerTest, LOGGER)
 {
+    SKIP_IF_STATIC_SPDLOG_REGISTRY();
     spdlog::level::level_enum eLevel = spdlog::level::off;
 
     ASSERT_NE(spdlog::get("novatel_framer_ascii"), nullptr);
@@ -2305,6 +2308,7 @@ std::unique_ptr<Encoder> DecodeEncodeTest::pclMyEncoder = nullptr;
 // -------------------------------------------------------------------------------------------------------
 TEST_F(DecodeEncodeTest, LOGGER)
 {
+    SKIP_IF_STATIC_SPDLOG_REGISTRY();
     ASSERT_NE(spdlog::get("novatel_header_decoder"), nullptr);
     std::shared_ptr<spdlog::logger> novatel_header_decoder = pclMyHeaderDecoder->GetLogger();
     pclMyHeaderDecoder->SetLoggerLevel(spdlog::level::critical);
@@ -3454,6 +3458,7 @@ std::unique_ptr<Commander> CommandEncodeTest::pclMyCommander = nullptr;
 // -------------------------------------------------------------------------------------------------------
 TEST_F(CommandEncodeTest, LOGGER)
 {
+    SKIP_IF_STATIC_SPDLOG_REGISTRY();
     spdlog::level::level_enum eLevel = spdlog::level::off;
 
     ASSERT_NE(spdlog::get("novatel_commander"), nullptr);
@@ -3572,6 +3577,7 @@ std::unique_ptr<Filter> FilterTest::pclMyFilter = nullptr;
 
 TEST_F(FilterTest, LOGGER)
 {
+    SKIP_IF_STATIC_SPDLOG_REGISTRY();
     spdlog::level::level_enum eLevel = spdlog::level::off;
 
     ASSERT_NE(spdlog::get("novatel_filter"), nullptr);
@@ -3938,6 +3944,7 @@ std::unique_ptr<FileParser> FileParserTest::pclFp = nullptr;
 
 TEST_F(FileParserTest, LOGGER)
 {
+    SKIP_IF_STATIC_SPDLOG_REGISTRY();
     spdlog::level::level_enum eLevel = spdlog::level::off;
 
     // FileParser logger
@@ -4077,6 +4084,7 @@ std::unique_ptr<Parser> ParserTest::pclParser = nullptr;
 
 TEST_F(ParserTest, LOGGER)
 {
+    SKIP_IF_STATIC_SPDLOG_REGISTRY();
     spdlog::level::level_enum eLevel = spdlog::level::off;
     ASSERT_NE(spdlog::get("novatel_parser"), nullptr);
     std::shared_ptr<spdlog::logger> novatelParser = pclParser->GetLogger();

--- a/src/decoders/oem/test/range_cmp_test.cpp
+++ b/src/decoders/oem/test/range_cmp_test.cpp
@@ -26,6 +26,7 @@
 
 #include <gtest/gtest.h>
 
+#include "novatel_edie/common/test_utils/logger_registry_test.hpp"
 #include "novatel_edie/decoders/common/json_db_reader.hpp"
 #include "novatel_edie/decoders/oem/rangecmp/range_decompressor.hpp"
 
@@ -84,6 +85,7 @@ MessageDatabase::Ptr RangeCmpTest::pclMyJsonDb = nullptr;
 // -------------------------------------------------------------------------------------------------------
 TEST_F(RangeCmpTest, LOGGER)
 {
+    SKIP_IF_STATIC_SPDLOG_REGISTRY();
     spdlog::level::level_enum eLevel = spdlog::level::off;
 
     ASSERT_NE(spdlog::get("range_decompressor"), nullptr);

--- a/src/decoders/oem/test/rx_config_test.cpp
+++ b/src/decoders/oem/test/rx_config_test.cpp
@@ -29,6 +29,7 @@
 
 #include <gtest/gtest.h>
 
+#include "novatel_edie/common/test_utils/logger_registry_test.hpp"
 #include "novatel_edie/decoders/common/common.hpp"
 #include "novatel_edie/decoders/common/json_db_reader.hpp"
 #include "novatel_edie/decoders/common/message_decoder.hpp"
@@ -90,6 +91,7 @@ std::unique_ptr<RxConfigHandler> RxConfigTest::pclMyRxConfigHandler = nullptr;
 // -------------------------------------------------------------------------------------------------------
 TEST_F(RxConfigTest, LOGGER)
 {
+    SKIP_IF_STATIC_SPDLOG_REGISTRY();
     spdlog::level::level_enum eLevel = spdlog::level::off;
 
     ASSERT_NE(spdlog::get("rxconfig_handler"), nullptr);


### PR DESCRIPTION
Logger tests fail for python builds because we are asserting spdlog registry behavior that doesn't work when it is statically linked into share modules. This is not a concern for python builds because we don't ever use the registry directly. This PR just disables the tests for python builds with an explanation.