### PR TITLE
Drop nlohman json

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,4 +49,5 @@ HeaderFilterRegex: 'src/.*|examples/.*'
 
 WarningsAsErrors: '*'
 
-ExtraArgs: - -Wno-unknown-pragmas # TODO: remove this after switch to clang-tidy-18
+# Explictly allow exceptions, otherwise MSVC with clang-tidy runs into issues
+ExtraArgs: [-Wno-unknown-pragmas, -Xclang, -fcxx-exceptions]

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -188,13 +188,14 @@ jobs:
     - name: Run Tests
       run: cd out/build && ctest && cd ..
 
+    # Disable parse errors due to gcc bug that can cause negative code coverage
     - name: Generate HTML code coverage reports
       run: |
         mkdir out/build/code-coverage
-        gcovr -r ./src/ ./out/build/ --exclude='.*/test/.*' --exclude='.*/version.h' --html --html-details -o ./out/build/code-coverage/index.html
+        gcovr -r ./src/ ./out/build/ --exclude='.*/test/.*' --exclude='.*/version.h' --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --html --html-details -o ./out/build/code-coverage/index.html
 
     - name: Coverage visualization in pipeline summary
-      run: gcovr -r ./src/ ./out/build/ --exclude='.*/test/.*' --exclude='.*/version.h' --exclude-unreachable-branches --print-summary -o ./out/build/coverage.xml
+      run: gcovr -r ./src/ ./out/build/ --exclude='.*/test/.*' --exclude='.*/version.h' --exclude-unreachable-branches --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --print-summary -o ./out/build/coverage.xml
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4.3.0

--- a/cmake/novatel_edie-config.cmake.in
+++ b/cmake/novatel_edie-config.cmake.in
@@ -9,7 +9,7 @@ set_and_check(novatel_edie_DATA_DIR "@PACKAGE_CMAKE_INSTALL_DATADIR@")
 set(novatel_edie_LIBRARIES novatel_edie::novatel_edie)
 check_required_components(novatel_edie)
 
-find_dependency(nlohmann_json)
+find_dependency(simdjson)
 find_dependency(spdlog)
 
 if(@spdlog_setup_VENDORED@)

--- a/conanfile.py
+++ b/conanfile.py
@@ -95,7 +95,6 @@ class NovatelEdieConan(ConanFile):
 
     def requirements(self):
         self.requires("simdjson/3.10.1", transitive_headers=True, transitive_libs=True, force=True)
-        self.requires("nlohmann_json/[>=3.11 <3.12]", transitive_headers=True)
         self.requires("spdlog/[>=1.15 <1.16]", transitive_headers=True, transitive_libs=True, force=True)
         self.requires("gegles-spdlog_setup/[>=1.1 <2]", transitive_headers=True)
         self.requires("fmt/[>=12.0.0 <13]", force=True)

--- a/include/novatel_edie/decoders/common/json_db_reader.hpp
+++ b/include/novatel_edie/decoders/common/json_db_reader.hpp
@@ -30,8 +30,6 @@
 #include <filesystem>
 #include <sstream>
 
-#include <nlohmann/json.hpp>
-
 #include "novatel_edie/decoders/common/message_database.hpp"
 
 namespace novatel::edie {

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -241,15 +241,12 @@ class MessageDecoderBase
         static_assert(!std::is_same_v<IntermediateType, void>, "Unsupported type for PushElement");
 
         IntermediateType intermediateValue;
-        if (clJsonField_.get(intermediateValue) == simdjson::SUCCESS)
+        if (clJsonField_.get(intermediateValue) != simdjson::SUCCESS)
         {
-            T value = static_cast<T>(intermediateValue);
-            vIntermediate_.emplace_back(value, std::move(pstMessageDataType_));
+            throw std::runtime_error("Failed to decode JSON field '" + pstMessageDataType_->name + "'");
         }
-        else
-        {
-            // Handle error (e.g., log a warning or throw an exception)
-        }
+        T value = static_cast<T>(intermediateValue);
+        vIntermediate_.emplace_back(value, std::move(pstMessageDataType_));
     }
 
     // -------------------------------------------------------------------------------------------------------

--- a/include/novatel_edie/decoders/oem/common.hpp
+++ b/include/novatel_edie/decoders/oem/common.hpp
@@ -131,7 +131,6 @@ struct MetaDataStruct : public MetaDataBase
 {
     uint8_t ucSiblingId{NULL_SIBLING_ID};
     TIME_STATUS eTimeStatus{TIME_STATUS::UNKNOWN};
-    CONSTELLATION constellation{CONSTELLATION::UNKNOWN};
 
     // NOTE: C++20 automatically generates a generic operator== for this struct.
     bool operator==(const MetaDataStruct& other_) const

--- a/src/decoders/common/CMakeLists.txt
+++ b/src/decoders/common/CMakeLists.txt
@@ -11,11 +11,9 @@ target_include_directories(${TARGET_NAME} PUBLIC
 )
 target_compile_features(${TARGET_NAME} PUBLIC cxx_std_17)
 
-find_package(nlohmann_json REQUIRED CONFIG)
 find_package(simdjson REQUIRED CONFIG)
 target_link_libraries(${TARGET_NAME} PUBLIC
     common
-    nlohmann_json::nlohmann_json
     simdjson::simdjson
 )
 

--- a/src/decoders/common/src/json_db_reader.cpp
+++ b/src/decoders/common/src/json_db_reader.cpp
@@ -193,10 +193,6 @@ void ParseMessageDefinition(element j_, MessageDefinition& md_)
     md_.description = AsStringOrEmpty(Member(j_, "description"));
     md_.latestMessageCrc = std::stoul(AsString(Member(j_, "latestMsgDefCrc")));
 
-    element messageStyle;
-    md_.messageStyle =
-        j_["messageStyle"].get(messageStyle) == simdjson::SUCCESS && !messageStyle.is_null() ? AsString(messageStyle) : "OEM4_MESSAGE_STYLE";
-
     object fields;
     if (Member(j_, "fields").get(fields) != simdjson::SUCCESS) { throw std::runtime_error("Expected 'fields' to be a JSON object"); }
     for (auto field : fields)

--- a/src/decoders/common/src/json_db_reader.cpp
+++ b/src/decoders/common/src/json_db_reader.cpp
@@ -26,208 +26,323 @@
 
 #include "novatel_edie/decoders/common/json_db_reader.hpp"
 
+#include <algorithm>
+#include <cassert>
 #include <future>
+#include <stdexcept>
+#include <string>
 
-#include <nlohmann/json.hpp>
+#include <simdjson.h>
 
 #include "novatel_edie/decoders/common/common.hpp"
 
 namespace novatel::edie {
 
-using json = nlohmann::json;
+namespace {
 
-// Forward declaration of from_json
-void from_json(const json& j_, EnumDataType& f_);
-void from_json(const json& j_, SimpleDataType& f_);
-void from_json(const json& j_, BaseField& f_);
-void from_json(const json& j_, EnumField& f_);
-void from_json(const json& j_, ArrayField& fd_);
-void from_json(const json& j_, FieldArrayField& fd_);
-void from_json(const json& j_, MessageDefinition& md_);
-void from_json(const json& j_, EnumDefinition& ed_);
-void from_json(const json& j_, DbMetadata& dbm_);
-
-// Forward declaration of parse_fields and parse_enumerators
-uint32_t ParseFields(const json& j_, std::vector<BaseField::Ptr>& vFields_);
-void ParseEnumerators(const json& j_, std::vector<EnumDataType>& vEnumerators_);
+using simdjson::dom::array;
+using simdjson::dom::element;
+using simdjson::dom::object;
 
 //-----------------------------------------------------------------------
-void from_json(const json& j_, EnumDataType& f_)
+// Small helpers providing required-member, optional-member and null-aware
+// access semantics on top of the simdjson DOM API.
+//-----------------------------------------------------------------------
+
+//! Resolve a required object member. Throws if the key is absent.
+element Member(element obj_, std::string_view key_)
 {
-    f_.value = j_.at("value");
-    f_.name = j_.at("name");
-    f_.description = j_.at("description").is_null() ? "" : j_.at("description");
+    element out;
+    if (obj_[key_].get(out) != simdjson::SUCCESS) { throw std::runtime_error("Missing required JSON field: " + std::string(key_)); }
+    return out;
+}
+
+//! Read an element as a string view. Throws if it is not a string.
+std::string_view AsStringView(element el_)
+{
+    std::string_view sv;
+    if (el_.get(sv) != simdjson::SUCCESS) { throw std::runtime_error("Expected a JSON string value"); }
+    return sv;
+}
+
+//! Read an element as an owned string. Throws if it is not a string.
+std::string AsString(element el_) { return std::string(AsStringView(el_)); }
+
+//! Read an element as a string, mapping a JSON null to an empty string.
+std::string AsStringOrEmpty(element el_) { return el_.is_null() ? std::string() : AsString(el_); }
+
+//! Read a JSON integer known to be unsigned, accepting either simdjson tag.
+//! simdjson stores a number that fits in int64 as INT64 and a larger one as UINT64, and get<T>()
+//! is strict about that tag, so both cases must be tried. Throws if the value is not an integer or is negative.
+uint64_t AsUint(element el_)
+{
+    uint64_t u;
+    if (el_.get(u) == simdjson::SUCCESS) { return u; }
+    int64_t i;
+    if (el_.get(i) == simdjson::SUCCESS && i >= 0) { return static_cast<uint64_t>(i); }
+    throw std::runtime_error("Expected an unsigned JSON integer value");
+}
+
+//! Read an optional string member, returning the default if the key is absent.
+std::string StringOr(element obj_, std::string_view key_, std::string_view default_)
+{
+    element el;
+    if (obj_[key_].get(el) != simdjson::SUCCESS) { return std::string(default_); }
+    return AsString(el);
+}
+
+// Forward declarations (parse functions are mutually recursive via field arrays).
+void ParseEnumDataType(element j_, EnumDataType& f_);
+void ParseSimpleDataType(element j_, SimpleDataType& f_);
+void ParseBaseField(element j_, BaseField& f_);
+void ParseEnumField(element j_, EnumField& f_);
+void ParseArrayField(element j_, ArrayField& fd_);
+void ParseFieldArrayField(element j_, FieldArrayField& fd_);
+void ParseMessageDefinition(element j_, MessageDefinition& md_);
+void ParseEnumDefinition(element j_, EnumDefinition& ed_);
+void ParseDbMetadata(element j_, DbMetadata& dbm_);
+uint32_t ParseFields(element j_, std::vector<BaseField::Ptr>& vFields_);
+void ParseEnumerators(element j_, std::vector<EnumDataType>& vEnumerators_);
+
+//-----------------------------------------------------------------------
+void ParseEnumDataType(element j_, EnumDataType& f_)
+{
+    f_.value = static_cast<uint32_t>(AsUint(Member(j_, "value")));
+    f_.name = AsString(Member(j_, "name"));
+    f_.description = AsStringOrEmpty(Member(j_, "description"));
 }
 
 //-----------------------------------------------------------------------
-void from_json(const json& j_, SimpleDataType& f_)
+void ParseSimpleDataType(element j_, SimpleDataType& f_)
 {
-    auto itrDataTypeMapping = DataTypeEnumLookup.find(j_.at("name"));
+    const auto itrDataTypeMapping = DataTypeEnumLookup.find(std::string(AsStringView(Member(j_, "name"))));
     f_.name = itrDataTypeMapping != DataTypeEnumLookup.end() ? itrDataTypeMapping->second : DATA_TYPE::UNKNOWN;
-    f_.length = j_.at("length");
-    f_.description = j_.at("description").is_null() ? "" : j_.at("description");
+    f_.length = static_cast<uint16_t>(AsUint(Member(j_, "length")));
+    f_.description = AsStringOrEmpty(Member(j_, "description"));
 }
 
 //-----------------------------------------------------------------------
-void from_json(const json& j_, BaseField& f_)
+void ParseBaseField(element j_, BaseField& f_)
 {
-    f_.name = j_.at("name");
-    f_.description = j_.at("description").is_null() ? "" : j_.at("description");
+    f_.name = AsString(Member(j_, "name"));
+    f_.description = AsStringOrEmpty(Member(j_, "description"));
 
-    const auto itrFieldTypeMapping = FieldTypeEnumLookup.find(j_.at("type"));
+    const auto itrFieldTypeMapping = FieldTypeEnumLookup.find(std::string(AsStringView(Member(j_, "type"))));
     f_.type = itrFieldTypeMapping != FieldTypeEnumLookup.end() ? itrFieldTypeMapping->second : FIELD_TYPE::UNKNOWN;
 
-    if (j_.find("conversionString") != j_.end())
+    element conversionString;
+    if (j_["conversionString"].get(conversionString) == simdjson::SUCCESS)
     {
-        if (j_.at("conversionString").is_null()) { f_.conversion = ""; }
-        else { f_.SetConversion(j_.at("conversionString")); }
+        if (conversionString.is_null()) { f_.conversion = ""; }
+        else { f_.SetConversion(std::string(AsStringView(conversionString))); }
     }
 
-    f_.dataType = j_.at("dataType");
+    ParseSimpleDataType(Member(j_, "dataType"), f_.dataType);
 }
 
 //-----------------------------------------------------------------------
-void from_json(const json& j_, EnumField& f_)
+void ParseEnumField(element j_, EnumField& f_)
 {
-    from_json(j_, static_cast<BaseField&>(f_));
+    ParseBaseField(j_, f_);
 
-    if (j_.at("enumID").is_null()) { throw std::runtime_error("Invalid enum ID - cannot be NULL. JsonDB file is likely corrupted."); }
+    element enumId = Member(j_, "enumID");
+    if (enumId.is_null()) { throw std::runtime_error("Invalid enum ID - cannot be NULL. JsonDB file is likely corrupted."); }
 
-    f_.enumId = j_.at("enumID");
+    f_.enumId = AsString(enumId);
 }
 
 //-----------------------------------------------------------------------
-void from_json(const json& j_, ArrayField& fd_)
+void ParseArrayField(element j_, ArrayField& fd_)
 {
-    from_json(j_, static_cast<BaseField&>(fd_));
+    ParseBaseField(j_, fd_);
 
-    fd_.arrayLength = j_.at("arrayLength");
-    fd_.arrayLengthFieldSize = j_.value("arrayLengthFieldSize", 4);
-    fd_.dataType = j_.at("dataType");
-    if (j_.find("arrayLengthRef") != j_.end()) { fd_.arrayLengthRef = j_.at("arrayLengthRef").is_null() ? "" : j_.at("arrayLengthRef"); }
+    fd_.arrayLength = static_cast<uint32_t>(AsUint(Member(j_, "arrayLength")));
+
+    element arrayLengthFieldSize;
+    fd_.arrayLengthFieldSize =
+        j_["arrayLengthFieldSize"].get(arrayLengthFieldSize) == simdjson::SUCCESS ? static_cast<uint8_t>(AsUint(arrayLengthFieldSize)) : 4;
+
+    element arrayLengthRef;
+    if (j_["arrayLengthRef"].get(arrayLengthRef) == simdjson::SUCCESS) { fd_.arrayLengthRef = AsStringOrEmpty(arrayLengthRef); }
 }
 
 //-----------------------------------------------------------------------
-void from_json(const json& j_, FieldArrayField& fd_)
+void ParseFieldArrayField(element j_, FieldArrayField& fd_)
 {
-    from_json(j_, static_cast<BaseField&>(fd_));
+    ParseBaseField(j_, fd_);
 
-    fd_.arrayLength = j_.at("arrayLength").is_null() ? 0 : static_cast<uint32_t>(j_.at("arrayLength"));
-    fd_.arrayLengthFieldSize = j_.value("arrayLengthFieldSize", 4);
-    fd_.fieldSize = fd_.arrayLength * ParseFields(j_.at("fields"), fd_.fields);
-    if (j_.find("arrayLengthRef") != j_.end()) { fd_.arrayLengthRef = j_.at("arrayLengthRef").is_null() ? "" : j_.at("arrayLengthRef"); }
+    element arrayLength = Member(j_, "arrayLength");
+    fd_.arrayLength = arrayLength.is_null() ? 0 : static_cast<uint32_t>(AsUint(arrayLength));
+
+    element arrayLengthFieldSize;
+    fd_.arrayLengthFieldSize =
+        j_["arrayLengthFieldSize"].get(arrayLengthFieldSize) == simdjson::SUCCESS ? static_cast<uint8_t>(AsUint(arrayLengthFieldSize)) : 4;
+
+    fd_.fieldSize = fd_.arrayLength * ParseFields(Member(j_, "fields"), fd_.fields);
+
+    element arrayLengthRef;
+    if (j_["arrayLengthRef"].get(arrayLengthRef) == simdjson::SUCCESS) { fd_.arrayLengthRef = AsStringOrEmpty(arrayLengthRef); }
 }
 
 //-----------------------------------------------------------------------
-void from_json(const json& j_, MessageDefinition& md_)
+void ParseMessageDefinition(element j_, MessageDefinition& md_)
 {
-    md_._id = j_.at("_id");
-    md_.logID = j_.at("messageID"); // this was "logID"
-    md_.name = j_.at("name");
-    md_.description = j_.at("description").is_null() ? "" : j_.at("description");
-    md_.latestMessageCrc = std::stoul(j_.at("latestMsgDefCrc").get<std::string>());
+    md_._id = AsString(Member(j_, "_id"));
+    md_.logID = static_cast<uint32_t>(AsUint(Member(j_, "messageID"))); // this was "logID"
+    md_.name = AsString(Member(j_, "name"));
+    md_.description = AsStringOrEmpty(Member(j_, "description"));
+    md_.latestMessageCrc = std::stoul(AsString(Member(j_, "latestMsgDefCrc")));
 
-    for (const auto& fields : j_.at("fields").items())
+    element messageStyle;
+    md_.messageStyle =
+        j_["messageStyle"].get(messageStyle) == simdjson::SUCCESS && !messageStyle.is_null() ? AsString(messageStyle) : "OEM4_MESSAGE_STYLE";
+
+    object fields;
+    if (Member(j_, "fields").get(fields) != simdjson::SUCCESS) { throw std::runtime_error("Expected 'fields' to be a JSON object"); }
+    for (auto field : fields)
     {
-        uint32_t defCrc = std::stoul(fields.key());
-        md_.fields[defCrc];
-        ParseFields(fields.value(), md_.fields[defCrc]);
+        uint32_t defCrc = std::stoul(std::string(field.key));
+        ParseFields(field.value, md_.fields[defCrc]);
     }
 }
 
 //-----------------------------------------------------------------------
-void from_json(const json& j_, EnumDefinition& ed_)
+void ParseEnumDefinition(element j_, EnumDefinition& ed_)
 {
     std::vector<EnumDataType> enumerators;
-    ParseEnumerators(j_.at("enumerators"), enumerators);
-    ed_ = EnumDefinition(j_.at("_id"), j_.at("name"), std::move(enumerators));
+    ParseEnumerators(Member(j_, "enumerators"), enumerators);
+    ed_ = EnumDefinition(AsString(Member(j_, "_id")), AsString(Member(j_, "name")), std::move(enumerators));
 }
 
 //-----------------------------------------------------------------------
-void from_json(const json& j_, DbMetadata& dbm_)
+void ParseDbMetadata(element j_, DbMetadata& dbm_)
 {
-    dbm_.subset = j_.value("subset", "");
-    dbm_.version = j_.value("version", "0.0.0");
-    dbm_.messageFamily = j_.value("messageFamily", "");
+    dbm_.subset = StringOr(j_, "subset", "");
+    dbm_.version = StringOr(j_, "version", "0.0.0");
+    dbm_.messageFamily = StringOr(j_, "messageFamily", "");
 }
 
 //-----------------------------------------------------------------------
-uint32_t ParseFields(const json& j_, std::vector<BaseField::Ptr>& vFields_)
+uint32_t ParseFields(element j_, std::vector<BaseField::Ptr>& vFields_)
 {
     uint32_t uiFieldSize = 0;
-    vFields_.reserve(j_.size());
 
-    for (const auto& field : j_)
+    array fields;
+    if (j_.get(fields) != simdjson::SUCCESS) { throw std::runtime_error("Expected 'fields' to be a JSON array"); }
+    vFields_.reserve(fields.size());
+
+    for (element field : fields)
     {
-        const auto sFieldType = field.at("type").get<std::string_view>();
-        const auto stDataType = field.at("dataType").get<SimpleDataType>();
+        const auto sFieldType = AsStringView(Member(field, "type"));
+
+        SimpleDataType stDataType;
+        ParseSimpleDataType(Member(field, "dataType"), stDataType);
 
         if (sFieldType == "SIMPLE")
         {
-            vFields_.emplace_back(std::make_shared<BaseField>(field));
+            auto pstField = std::make_shared<BaseField>();
+            ParseBaseField(field, *pstField);
+            vFields_.emplace_back(std::move(pstField));
             uiFieldSize += stDataType.length;
         }
         else if (sFieldType == "ENUM")
         {
-            vFields_.emplace_back(std::make_shared<EnumField>(field));
+            auto pstField = std::make_shared<EnumField>();
+            ParseEnumField(field, *pstField);
+            vFields_.emplace_back(std::move(pstField));
             uiFieldSize += stDataType.length;
         }
         else if (sFieldType == "FIXED_LENGTH_ARRAY" || sFieldType == "VARIABLE_LENGTH_ARRAY" || sFieldType == "STRING")
         {
-            vFields_.emplace_back(std::make_shared<ArrayField>(field));
-            uint32_t uiArrayLength = field.at("arrayLength").get<uint32_t>();
+            auto pstField = std::make_shared<ArrayField>();
+            ParseArrayField(field, *pstField);
+            auto uiArrayLength = static_cast<uint32_t>(AsUint(Member(field, "arrayLength")));
+            vFields_.emplace_back(std::move(pstField));
             uiFieldSize += stDataType.length * uiArrayLength;
         }
-        else if (sFieldType == "FIELD_ARRAY") { vFields_.emplace_back(std::make_shared<FieldArrayField>(field)); }
+        else if (sFieldType == "FIELD_ARRAY")
+        {
+            auto pstField = std::make_shared<FieldArrayField>();
+            ParseFieldArrayField(field, *pstField);
+            vFields_.emplace_back(std::move(pstField));
+        }
         else { throw std::runtime_error("Could not find field type"); }
     }
     return uiFieldSize;
 }
 
 //-----------------------------------------------------------------------
-void ParseEnumerators(const json& j_, std::vector<EnumDataType>& vEnumerators_)
+void ParseEnumerators(element j_, std::vector<EnumDataType>& vEnumerators_)
 {
-    vEnumerators_.reserve(j_.size());
-    for (const auto& enumerator : j_) { vEnumerators_.emplace_back(enumerator); }
+    array enumerators;
+    if (j_.get(enumerators) != simdjson::SUCCESS) { throw std::runtime_error("Expected 'enumerators' to be a JSON array"); }
+    vEnumerators_.reserve(enumerators.size());
+    for (element enumerator : enumerators)
+    {
+        EnumDataType enumDataType;
+        ParseEnumDataType(enumerator, enumDataType);
+        vEnumerators_.emplace_back(std::move(enumDataType));
+    }
 }
 
 //-----------------------------------------------------------------------
-std::vector<MessageDefinition::ConstPtr> ProcessMessageDefinitions(const json& jArray)
+std::vector<MessageDefinition::ConstPtr> ProcessMessageDefinitions(element jRoot_)
 {
-    const auto& data = jArray["messages"];
+    array data;
+    if (Member(jRoot_, "messages").get(data) != simdjson::SUCCESS) { throw std::runtime_error("Expected 'messages' to be a JSON array"); }
+
     std::vector<MessageDefinition::ConstPtr> res;
     res.reserve(data.size());
 
-    for (const auto& it : data) { res.emplace_back(std::make_shared<MessageDefinition>(it)); }
+    for (element it : data)
+    {
+        auto md = std::make_shared<MessageDefinition>();
+        ParseMessageDefinition(it, *md);
+        res.emplace_back(std::move(md));
+    }
 
     return res;
 }
 
 //-----------------------------------------------------------------------
-std::vector<EnumDefinition::ConstPtr> ProcessEnumDefinitions(const json& jArray)
+std::vector<EnumDefinition::ConstPtr> ProcessEnumDefinitions(element jRoot_)
 {
-    const auto& data = jArray["enums"];
+    array data;
+    if (Member(jRoot_, "enums").get(data) != simdjson::SUCCESS) { throw std::runtime_error("Expected 'enums' to be a JSON array"); }
+
     std::vector<EnumDefinition::ConstPtr> res;
     res.reserve(data.size());
 
-    for (const auto& it : data) { res.emplace_back(std::make_shared<EnumDefinition>(it)); }
+    for (element it : data)
+    {
+        auto ed = std::make_shared<EnumDefinition>();
+        ParseEnumDefinition(it, *ed);
+        res.emplace_back(std::move(ed));
+    }
 
     return res;
 }
 
 //-----------------------------------------------------------------------
-namespace {
-template <typename T> MessageDatabase::Ptr ParseJsonDbImpl(T&& source, std::string_view errorContext)
+MessageDatabase::Ptr ParseJsonDbImpl(simdjson::padded_string source, std::string_view errorContext)
 {
     try
     {
-        auto json = json::parse(std::forward<T>(source));
+        simdjson::dom::parser parser;
+        element root;
+        if (parser.parse(source).get(root) != simdjson::SUCCESS) { throw std::runtime_error("Failed to parse JSON database"); }
 
-        auto messageFuture = std::async(std::launch::async, ProcessMessageDefinitions, std::cref(json));
-        auto enumFuture = std::async(std::launch::async, ProcessEnumDefinitions, std::cref(json));
+        // The parsed DOM is immutable; the message and enum subtrees can be read concurrently.
+        auto messageFuture = std::async(std::launch::async, ProcessMessageDefinitions, root);
+        auto enumFuture = std::async(std::launch::async, ProcessEnumDefinitions, root);
 
         DbMetadata::Ptr dbMeta;
-        if (json.contains("meta")) { dbMeta = std::make_shared<DbMetadata>(json.at("meta").template get<DbMetadata>()); }
+        element meta;
+        if (root["meta"].get(meta) == simdjson::SUCCESS)
+        {
+            dbMeta = std::make_shared<DbMetadata>();
+            ParseDbMetadata(meta, *dbMeta);
+        }
 
         return std::make_shared<MessageDatabase>(messageFuture.get(), enumFuture.get(), dbMeta);
     }
@@ -239,9 +354,18 @@ template <typename T> MessageDatabase::Ptr ParseJsonDbImpl(T&& source, std::stri
 } // namespace
 
 //-----------------------------------------------------------------------
-MessageDatabase::Ptr LoadJsonDbFile(const std::filesystem::path& filePath_) { return ParseJsonDbImpl(std::ifstream(filePath_), filePath_.string()); }
+MessageDatabase::Ptr LoadJsonDbFile(const std::filesystem::path& filePath_)
+{
+    simdjson::padded_string source;
+    const auto error = simdjson::padded_string::load(filePath_.string()).get(source);
+    if (error) { throw JsonDbReaderFailure(__func__, __FILE__, __LINE__, filePath_, simdjson::error_message(error)); }
+    return ParseJsonDbImpl(std::move(source), filePath_.string());
+}
 
 //-----------------------------------------------------------------------
-MessageDatabase::Ptr ParseJsonDb(std::string_view strJsonData_) { return ParseJsonDbImpl(strJsonData_, strJsonData_); }
+MessageDatabase::Ptr ParseJsonDb(std::string_view strJsonData_)
+{
+    return ParseJsonDbImpl(simdjson::padded_string(strJsonData_.data(), strJsonData_.size()), strJsonData_);
+}
 
 } // namespace novatel::edie

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -853,7 +853,17 @@ STATUS MessageDecoderBase::DecodeJson(const std::vector<BaseField::Ptr>& vMsgDef
 
         switch (field->type)
         {
-        case FIELD_TYPE::SIMPLE: DecodeJsonField(field, clField, vIntermediateFormat_); break;
+        case FIELD_TYPE::SIMPLE:
+            try
+            {
+                DecodeJsonField(field, clField, vIntermediateFormat_);
+            }
+            catch (const std::runtime_error&)
+            {
+                SPDLOG_LOGGER_CRITICAL(pclMyLogger, "DecodeJsonField(): Exception when decoding field. Malformed Input\n");
+                return STATUS::MALFORMED_INPUT;
+            }
+            break;
 
         case FIELD_TYPE::ENUM: {
             std::string_view enumValue;

--- a/src/decoders/oem/src/message_decoder.cpp
+++ b/src/decoders/oem/src/message_decoder.cpp
@@ -30,11 +30,9 @@
 #include <charconv>
 #include <cmath>
 
-#include <nlohmann/json.hpp>
+#include <simdjson.h>
 
 using namespace novatel::edie::oem;
-
-using json = nlohmann::json;
 
 // -------------------------------------------------------------------------------------------------------
 MessageDecoder::MessageDecoder(const MessageDatabase::Ptr& pclMessageDb_) : MessageDecoderBase("OEM", pclMessageDb_) { InitOemFieldMaps(); }
@@ -118,25 +116,42 @@ void MessageDecoder::InitOemFieldMaps()
     jsonFieldMap[CalculateBlockCrc32("lk")] = SimpleJsonMapEntry<double>();
 
     jsonFieldMap[CalculateBlockCrc32("ucb")] = [](std::vector<FieldContainer>& vIntermediateFormat_, BaseField::ConstPtr&& pstMessageDataType_,
-                                                  const json& clJsonField_, [[maybe_unused]] MessageDatabase& pclMsgDb_) {
-        vIntermediateFormat_.emplace_back(static_cast<uint32_t>(std::bitset<8>(clJsonField_.get<std::string>().c_str()).to_ulong()),
-                                          std::move(pstMessageDataType_));
+                                                  simdjson::dom::element clJsonField_, [[maybe_unused]] MessageDatabase& pclMsgDb_) {
+        std::string_view sValue;
+        if (clJsonField_.get(sValue) != simdjson::SUCCESS)
+        {
+            throw std::runtime_error("Failed to decode JSON field '" + pstMessageDataType_->name + "'");
+        }
+        vIntermediateFormat_.emplace_back(static_cast<uint32_t>(std::bitset<8>(std::string(sValue)).to_ulong()), std::move(pstMessageDataType_));
     };
 
     jsonFieldMap[CalculateBlockCrc32("m")] = [](std::vector<FieldContainer>& vIntermediateFormat_, BaseField::ConstPtr&& pstMessageDataType_,
-                                                const json& clJsonField_, [[maybe_unused]] MessageDatabase& pclMsgDb_) {
-        vIntermediateFormat_.emplace_back(pclMsgDb_.MsgNameToMsgId(clJsonField_.get<std::string>()), std::move(pstMessageDataType_));
+                                                simdjson::dom::element clJsonField_, [[maybe_unused]] MessageDatabase& pclMsgDb_) {
+        std::string_view sValue;
+        if (clJsonField_.get(sValue) != simdjson::SUCCESS)
+        {
+            throw std::runtime_error("Failed to decode JSON field '" + pstMessageDataType_->name + "'");
+        }
+        vIntermediateFormat_.emplace_back(pclMsgDb_.MsgNameToMsgId(std::string(sValue)), std::move(pstMessageDataType_));
     };
 
     jsonFieldMap[CalculateBlockCrc32("T")] = [](std::vector<FieldContainer>& vIntermediateFormat_, BaseField::ConstPtr&& pstMessageDataType_,
-                                                const json& clJsonField_, [[maybe_unused]] MessageDatabase& pclMsgDb_) {
-        vIntermediateFormat_.emplace_back(static_cast<uint32_t>(std::llround(clJsonField_.get<double>() * SEC_TO_MILLI_SEC)),
-                                          std::move(pstMessageDataType_));
+                                                simdjson::dom::element clJsonField_, [[maybe_unused]] MessageDatabase& pclMsgDb_) {
+        double dValue;
+        if (clJsonField_.get(dValue) != simdjson::SUCCESS)
+        {
+            throw std::runtime_error("Failed to decode JSON field '" + pstMessageDataType_->name + "'");
+        }
+        vIntermediateFormat_.emplace_back(static_cast<uint32_t>(std::llround(dValue * SEC_TO_MILLI_SEC)), std::move(pstMessageDataType_));
     };
 
     jsonFieldMap[CalculateBlockCrc32("id")] = [](std::vector<FieldContainer>& vIntermediateFormat_, BaseField::ConstPtr&& pstMessageDataType_,
-                                                 const json& clJsonField_, [[maybe_unused]] MessageDatabase& pclMsgDb_) {
-        std::string_view sTemp = clJsonField_.get<std::string_view>();
+                                                 simdjson::dom::element clJsonField_, [[maybe_unused]] MessageDatabase& pclMsgDb_) {
+        std::string_view sTemp;
+        if (clJsonField_.get(sTemp) != simdjson::SUCCESS)
+        {
+            throw std::runtime_error("Failed to decode JSON field '" + pstMessageDataType_->name + "'");
+        }
         size_t sDelimiter = sTemp.find_last_of('+');
         if (sDelimiter == std::string_view::npos) { sDelimiter = sTemp.find_last_of('-'); }
 
@@ -179,8 +194,13 @@ void MessageDecoder::InitOemFieldMaps()
     };
 
     jsonFieldMap[CalculateBlockCrc32("R")] = [](std::vector<FieldContainer>& vIntermediateFormat_, BaseField::ConstPtr&& pstMessageDataType_,
-                                                const json& clJsonField_, [[maybe_unused]] MessageDatabase& pclMsgDb_) {
-        MessageDefinition::ConstPtr pclMessageDef = pclMsgDb_.GetMsgDef(clJsonField_.get<std::string_view>());
+                                                simdjson::dom::element clJsonField_, [[maybe_unused]] MessageDatabase& pclMsgDb_) {
+        std::string_view sValue;
+        if (clJsonField_.get(sValue) != simdjson::SUCCESS)
+        {
+            throw std::runtime_error("Failed to decode JSON field '" + pstMessageDataType_->name + "'");
+        }
+        MessageDefinition::ConstPtr pclMessageDef = pclMsgDb_.GetMsgDef(sValue);
         vIntermediateFormat_.emplace_back(pclMessageDef != nullptr ? CreateMsgId(pclMessageDef->logID, 0, 1, 0) : 0, std::move(pstMessageDataType_));
     };
 }


### PR DESCRIPTION
# Drop nlohmann-json in favour of simdjson

Replaces the nlohmann/json dependency with simdjson across the JSON message decoder and the JSON message-database reader. Decoding was meant to have been swapped already but a couple places hadn't been fully updated. 

Note: As cleanup the unused `constellation` from `MetaDataBase` is also being removed.

## Decoder changes

OEM JSON decode functions migrated from `nlohmann::json` to `simdjson::dom::element`. Previously this code was broken.

- **`oem/src/message_decoder.cpp`** — All `jsonFieldMap` lambdas now take `simdjson::dom::element` instead of `const json&`. Reads go through `.get(out)` with an explicit `throw std::runtime_error("Failed to decode JSON field '...'")` on failure, replacing nlohmann's `.get<T>()` (which threw internally). 
- **`common/message_decoder.hpp`** — `PushElement<T>` now throws on a failed `.get()` instead of silently doing nothing. `SimpleJsonMapEntry<T>` and related signatures updated to `simdjson::dom::element`.
- **`common/src/message_decoder.cpp`** — Added a `try`/`catch (const std::runtime_error&)` around the `FIELD_TYPE::SIMPLE` decode that converts a decode exception into `STATUS::MALFORMED_INPUT` (with a `CRITICAL` log) rather than letting it escape. This matches ascii decoding.

## Reader changes (JSON DB reader)

Database loading now uses simdjson.

- **New helpers** (anonymous namespace) for accessing data out of simdjson: `Member` (required key, throws if absent), `AsStringView` / `AsString`, `AsStringOrEmpty` (null → `""`), `AsUint`, and `StringOr` (optional key with default).
- **Explicit parse functions** — the `from_json(const json&, T&)` overloads are replaced with named `ParseEnumDataType` / `ParseSimpleDataType` / `ParseBaseField` / `ParseEnumField` / `ParseArrayField` / `ParseFieldArrayField` / `ParseMessageDefinition` / `ParseEnumDefinition` / `ParseDbMetadata` / `ParseFields` / `ParseEnumerators`, each taking a `simdjson::dom::element`. These functions are all essentially the same as the old ones but just use the new helpers instead of nholman_json's accessors.



## Build / tooling / dependency changes

- Drop all references to nlohman_json from conan and cmake.
- **`.github/workflows/build_cpp.yml`** — add `--gcov-ignore-parse-errors=negative_hits.warn_once_per_file` to the `gcovr` coverage steps to work around a gcc bug producing negative hit counts. simdjson trips this issue.
