### PR TITLE
Range decompressor bug fixes

### DIFF
--- a/include/novatel_edie/decoders/oem/rangecmp/common.hpp
+++ b/include/novatel_edie/decoders/oem/rangecmp/common.hpp
@@ -330,6 +330,14 @@ constexpr std::array<uint32_t, 2> RBLK_DOPPLER_BITS = {26, 14};
 constexpr std::array<uint32_t, 2> RBLK_DOPPLER_SIGNEXT_MASK = {0xFC000000, 0xFFFFC000};
 constexpr std::array<int64_t, 2> RBLK_INVALID_PSR = {137438953471, -524288};
 
+constexpr uint32_t SIG_DBLK_PRIMARY_BITS = SIG_BLK_PARITY_FLAG_BITS + SIG_BLK_HALF_CYCLE_BITS + SIG_BLK_CNO_BITS + SIG_BLK_LOCK_TIME_BITS +
+                                           SIG_BLK_PSR_STDDEV_BITS + SIG_BLK_ADR_STDDEV_BITS + SIG_DBLK_PSR_BITS + SIG_DBLK_PHR_BITS +
+                                           DBLK_DOPPLER_BITS[0];
+
+constexpr uint32_t SIG_DBLK_SECONDARY_BITS = SIG_BLK_PARITY_FLAG_BITS + SIG_BLK_HALF_CYCLE_BITS + SIG_BLK_CNO_BITS + SIG_BLK_LOCK_TIME_BITS +
+                                             SIG_BLK_PSR_STDDEV_BITS + SIG_BLK_ADR_STDDEV_BITS + SIG_DBLK_PSR_BITS + SIG_DBLK_PHR_BITS +
+                                             DBLK_DOPPLER_BITS[1];
+
 } // namespace rangecmp4
 
 namespace rangecmp5 {

--- a/src/decoders/oem/src/rangecmp/range_decompressor.cpp
+++ b/src/decoders/oem/src/rangecmp/range_decompressor.cpp
@@ -173,8 +173,8 @@ double RangeDecompressor::GetRangeCmp4LockTime(const MetaDataStruct& stMetaData_
     // Is the lock time relative and has a bitfield change been found?
     if (!stLockTimeInfo.bAbsolute && ucLockTimeBits_ != stLockTimeInfo.ucBits)
     {
-        // Set lock time as absolute if bits are 0 or transitioning from relative to absolute.
-        if (ucLockTimeBits_ == 0 || (stLockTimeInfo.ucBits != 0xFF && ucLockTimeBits_ > stLockTimeInfo.ucBits))
+        // Set lock time as absolute if bits are 0 or if bits have changed since previous observation.
+        if (ucLockTimeBits_ == 0 || ucLockTimeBits_ > stLockTimeInfo.ucBits)
         {
             stLockTimeInfo.bAbsolute = true;
 
@@ -201,14 +201,12 @@ double RangeDecompressor::GetRangeCmp4LockTime(const MetaDataStruct& stMetaData_
         pclMyLogger->warn("Detected a lock time slip (perhaps caused by an outage) of {}ms at time {}w, {}ms.",
                           stLockTimeInfo.dMilliseconds - lockTime[stLockTimeInfo.ucBits], stMetaData_.usWeek, stMetaData_.dMilliseconds);
     }
-    else
+    // If the lock time is absolute and the bitfield hasn't changed within the expected time, reset the last change time
+    else if (stLockTimeInfo.bAbsolute && ucLockTimeBits_ < 15 &&
+             stMetaData_.dMilliseconds - stLockTimeInfo.dLastBitfieldChangeMilliseconds > lockTime[ucLockTimeBits_ + 1])
     {
-        // If the lock time is absolute and the bitfield hasn't changed within the expected time, reset the last change time
-        if (stMetaData_.dMilliseconds - stLockTimeInfo.dLastBitfieldChangeMilliseconds > 2 * lockTime[ucLockTimeBits_])
-        {
-            stLockTimeInfo.dLastBitfieldChangeMilliseconds = stMetaData_.dMilliseconds;
-            pclMyLogger->warn("Expected a bit change much sooner at time {}w, {}ms.", stMetaData_.usWeek, stMetaData_.dMilliseconds);
-        }
+        stLockTimeInfo.dLastBitfieldChangeMilliseconds = stMetaData_.dMilliseconds;
+        pclMyLogger->warn("Expected a bit change much sooner at time {}w, {}ms.", stMetaData_.usWeek, stMetaData_.dMilliseconds);
     }
     stLockTimeInfo.dMilliseconds = stMetaData_.dMilliseconds - stLockTimeInfo.dLastBitfieldChangeMilliseconds + lockTime[stLockTimeInfo.ucBits];
     return stLockTimeInfo.dMilliseconds / SEC_TO_MILLI_SEC;
@@ -503,6 +501,17 @@ void RangeDecompressor::RangeCmp4ToRange(unsigned char* pucData_, Range& stRange
 
     auto systems = ExtractBitfield<uint16_t, SATELLITE_SYSTEMS_BITS>(&pucData_, uiBytesLeft, uiBitOffset);
 
+    // Function to skip a differential block when reference data is not available. This is needed to keep the
+    // bit offset (uiBitOffset) and byte pointer (pucData_) in the correct position so that subsequent blocks
+    // can be read correctly.
+    const auto skipDBlock = [&uiBytesLeft, &uiBitOffset, &pucData_](bool& primary) {
+        const uint32_t uiBitsToSkip = primary ? SIG_DBLK_PRIMARY_BITS : SIG_DBLK_SECONDARY_BITS;
+        uiBytesLeft -= (uiBitsToSkip + uiBitOffset) / 8;
+        pucData_ += (uiBitsToSkip + uiBitOffset) / 8;
+        uiBitOffset = (uiBitsToSkip + uiBitOffset) % 8;
+        primary = false;
+    };
+
     while (systems)
     {
         auto system = static_cast<SYSTEM>(PopLsb(systems));
@@ -552,9 +561,16 @@ void RangeDecompressor::RangeCmp4ToRange(unsigned char* pucData_, Range& stRange
 
                 if (stMbHeader.bIsDifferentialData) // This is a differential block.
                 {
-                    try
+                    const auto& it = mMyReferenceBlocks.find(key);
+                    if (it == mMyReferenceBlocks.end())
                     {
-                        const std::pair<MeasurementBlockHeader, MeasurementSignalBlock>& stRb = mMyReferenceBlocks.at(key);
+                        pclMyLogger->warn("No reference data exists for SYSTEM {}, SIGNAL {}, PRN {}, ID {}", static_cast<int32_t>(system),
+                                          static_cast<int32_t>(signal), prn, stMbHeader.ucReferenceId);
+                        skipDBlock(bPrimaryBlock);
+                    }
+                    else
+                    {
+                        const auto& stRb = it->second;
 
                         if (stMbHeader.ucReferenceId == stRb.first.ucReferenceId)
                         {
@@ -572,12 +588,8 @@ void RangeDecompressor::RangeCmp4ToRange(unsigned char* pucData_, Range& stRange
                         else
                         {
                             pclMyLogger->warn("Invalid reference data: Diff ID {} != Ref ID {}", stMbHeader.ucReferenceId, stRb.first.ucReferenceId);
+                            skipDBlock(bPrimaryBlock);
                         }
-                    }
-                    catch (...)
-                    {
-                        pclMyLogger->warn("No reference data exists for SYSTEM {}, SIGNAL {}, PRN {}, ID {}", static_cast<int32_t>(system),
-                                          static_cast<int32_t>(signal), prn, stMbHeader.ucReferenceId);
                     }
                 }
                 else // This is a reference block.

--- a/src/decoders/oem/src/rangecmp/range_decompressor.cpp
+++ b/src/decoders/oem/src/rangecmp/range_decompressor.cpp
@@ -496,7 +496,8 @@ void RangeDecompressor::RangeCmp4ToRange(unsigned char* pucData_, Range& stRange
 
     stRangeMessage_.uiNumberOfObservations = 0;
     uint32_t uiBitOffset = 0;
-    uint32_t uiBytesLeft = *reinterpret_cast<uint32_t*>(pucData_);
+    uint32_t uiBytesLeft;
+    memcpy(&uiBytesLeft, pucData_, sizeof(uint32_t));
     pucData_ += sizeof(uint32_t);
 
     auto systems = ExtractBitfield<uint16_t, SATELLITE_SYSTEMS_BITS>(&pucData_, uiBytesLeft, uiBitOffset);


### PR DESCRIPTION
This PR contains several bug fixes for RANGECMP4 decompression and RANGECMP4/5 lock time tracking.

### RANGECMP4 decompression

- Previously, when a differential block was skipped due to missing reference data, the decompressor moved on to the next signal without decoding the differential block. But the bit offset/buffer pointer still pointed at the "discarded" differential block, meaning that the remaining signals in the log could not be decoded. To fix this, I've added code that advances the buffer pointer and bit offset to skip over the discarded differential block.
- Missing reference data also used to throw/catch an exception because the map lookup was done using `at()`; I've changed this to  `find()` + check, which should be significantly faster when reference data is frequently missing.

### RANGECMP4/5 lock time tracking

- Previous code expected the accumulated lock time not to exceed `2 * lockTime[ucLockTimeBits_]`. Since `lockTime[0] = 0.0`, this check would always fail when the lock time bits were 0 (causing a bunch of "Expected a bit change much sooner" warnings to be emitted).
- This check would continue to be performed when the lock time index had reached its maximum value of 15, meaning that the warning would be emitted every 262144ms as long as lock was maintained.
- I've changed this so that the check is only performed when in absolute mode and when the lock time index is < 15. The condition now checks that the accumulated lock time is no larger than `lockTime[ucLockTimeBits_ + 1]` (since table entries are consecutive powers of 2 this is essentially the same as before except when `ucLockTimeBits_` is 0 or 15)