### PR TITLE
Add QZSS L1C/B support for RANGECMP logs

### DIFF
--- a/include/novatel_edie/decoders/oem/rangecmp/channel_tracking_status.hpp
+++ b/include/novatel_edie/decoders/oem/rangecmp/channel_tracking_status.hpp
@@ -188,6 +188,7 @@ class ChannelTrackingStatus
         QZSS_L5Q = 14,
         QZSS_L1CP = 16,
         QZSS_L2CM = 17,
+        QZSS_L1CB = 24,
         QZSS_L6P = 27,
         QZSS_L6D = 28,
         // SBAS

--- a/include/novatel_edie/decoders/oem/rangecmp/common.hpp
+++ b/include/novatel_edie/decoders/oem/rangecmp/common.hpp
@@ -521,6 +521,7 @@ enum class SIGNAL_TYPE
     GALILEO_E6B = 12,
     // QZSS
     QZSS_L1CA = 1,
+    QZSS_L1CB = 2,
     QZSS_L2CM = 3,
     QZSS_L5Q = 4,
     QZSS_L1C = 8,
@@ -616,6 +617,7 @@ constexpr double SignalScaling(SYSTEM system, SIGNAL_TYPE signal)
         switch (signal)
         {
         case SIGNAL_TYPE::QZSS_L1C: [[fallthrough]];
+        case SIGNAL_TYPE::QZSS_L1CB: [[fallthrough]];
         case SIGNAL_TYPE::QZSS_L1CA: return 1.0;
         case SIGNAL_TYPE::QZSS_L2CM: return 154.0 / 120.0;
         case SIGNAL_TYPE::QZSS_L5Q: return 154.0 / 115.0;
@@ -687,6 +689,7 @@ enum class SIGNAL_TYPE
     BEIDOU_B2BI = 11,
     // QZSS
     QZSS_L1CA = 1,
+    QZSS_L1CB = 2,
     QZSS_L2C = 3,
     QZSS_L5Q = 4,
     QZSS_L1C = 8,

--- a/src/decoders/oem/src/rangecmp/channel_tracking_status.cpp
+++ b/src/decoders/oem/src/rangecmp/channel_tracking_status.cpp
@@ -114,7 +114,8 @@ ChannelTrackingStatus::ChannelTrackingStatus(const SYSTEM eSystem_, const rangec
     if (eSignalType_ == rangecmp4::SIGNAL_TYPE::GPS_L1CA || eSignalType_ == rangecmp4::SIGNAL_TYPE::GLONASS_L1CA ||
         eSignalType_ == rangecmp4::SIGNAL_TYPE::SBAS_L1CA || eSignalType_ == rangecmp4::SIGNAL_TYPE::GALILEO_E1 ||
         eSignalType_ == rangecmp4::SIGNAL_TYPE::BEIDOU_B1I || eSignalType_ == rangecmp4::SIGNAL_TYPE::QZSS_L1CA ||
-        (eSatelliteSystem == CTS_SYSTEM::BEIDOU && eSignalType_ == rangecmp4::SIGNAL_TYPE::BEIDOU_B1GEO))
+        (eSatelliteSystem == CTS_SYSTEM::BEIDOU && eSignalType_ == rangecmp4::SIGNAL_TYPE::BEIDOU_B1GEO) ||
+        (eSatelliteSystem == CTS_SYSTEM::QZSS && eSignalType_ == rangecmp4::SIGNAL_TYPE::QZSS_L1CB))
     {
         bPrimaryL1Channel = true;
         eTrackingState = TRACKING_STATE::PHASE_LOCK_LOOP;
@@ -148,7 +149,8 @@ ChannelTrackingStatus::ChannelTrackingStatus(const SYSTEM eSystem_, const rangec
     if (eSignalType_ == rangecmp4::SIGNAL_TYPE::GPS_L1CA || eSignalType_ == rangecmp4::SIGNAL_TYPE::GLONASS_L1CA ||
         eSignalType_ == rangecmp4::SIGNAL_TYPE::SBAS_L1CA || eSignalType_ == rangecmp4::SIGNAL_TYPE::GALILEO_E1 ||
         eSignalType_ == rangecmp4::SIGNAL_TYPE::BEIDOU_B1I || eSignalType_ == rangecmp4::SIGNAL_TYPE::QZSS_L1CA ||
-        (eSatelliteSystem == CTS_SYSTEM::BEIDOU && eSignalType_ == rangecmp4::SIGNAL_TYPE::BEIDOU_B1GEO))
+        (eSatelliteSystem == CTS_SYSTEM::BEIDOU && eSignalType_ == rangecmp4::SIGNAL_TYPE::BEIDOU_B1GEO) ||
+        (eSatelliteSystem == CTS_SYSTEM::QZSS && eSignalType_ == rangecmp4::SIGNAL_TYPE::QZSS_L1CB))
     {
         bPrimaryL1Channel = true;
         eTrackingState = TRACKING_STATE::PHASE_LOCK_LOOP;
@@ -217,6 +219,7 @@ ChannelTrackingStatus::CTS_SIGNAL ChannelTrackingStatus::RangeCmp2SignalTypeToSi
         switch (eSignalType_)
         {
         case SIGNAL_TYPE::QZSS_L1CA: return CTS_SIGNAL::QZSS_L1CA;
+        case SIGNAL_TYPE::QZSS_L1CB: return CTS_SIGNAL::QZSS_L1CB;
         case SIGNAL_TYPE::QZSS_L2CM: return CTS_SIGNAL::QZSS_L2CM;
         case SIGNAL_TYPE::QZSS_L5Q: return CTS_SIGNAL::QZSS_L5Q;
         case SIGNAL_TYPE::QZSS_L1C: return CTS_SIGNAL::QZSS_L1CP;
@@ -304,6 +307,7 @@ ChannelTrackingStatus::CTS_SIGNAL ChannelTrackingStatus::RangeCmp4SignalTypeToSi
         switch (eSignalType_)
         {
         case SIGNAL_TYPE::QZSS_L1CA: return CTS_SIGNAL::QZSS_L1CA;
+        case SIGNAL_TYPE::QZSS_L1CB: return CTS_SIGNAL::QZSS_L1CB;
         case SIGNAL_TYPE::QZSS_L2C: return CTS_SIGNAL::QZSS_L2CM;
         case SIGNAL_TYPE::QZSS_L5Q: return CTS_SIGNAL::QZSS_L5Q;
         case SIGNAL_TYPE::QZSS_L1C: return CTS_SIGNAL::QZSS_L1CP;
@@ -438,6 +442,7 @@ double ChannelTrackingStatus::GetSignalWavelength(const int16_t sGLONASSFrequenc
         switch (eSignalType)
         {
         case CTS_SIGNAL::QZSS_L1CA: [[fallthrough]];
+        case CTS_SIGNAL::QZSS_L1CB: [[fallthrough]];
         case CTS_SIGNAL::QZSS_L1CP: return wavelengthGpsL1;
         case CTS_SIGNAL::QZSS_L2CM: return wavelengthGpsL2;
         case CTS_SIGNAL::QZSS_L5Q: return wavelengthGpsL5;


### PR DESCRIPTION
Adds the QZSS L1C/B signal type for RANGECMP decompression.