### PR TITLE
Check for minimum size of NMEA framed data to prevent uint underflow

### DIFF
--- a/include/novatel_edie/decoders/common/common.hpp
+++ b/include/novatel_edie/decoders/common/common.hpp
@@ -427,5 +427,7 @@ constexpr uint32_t MAX_ABB_ASCII_RESPONSE_LENGTH = MESSAGE_SIZE_MAX;
 //!< NovAtel Docs - NMEA Standard Logs: Explicitly states that the maximum allowable is 82 chars.
 //!< Numerous internal logs break that standard, so we will use 256here as a safety measure.
 constexpr uint32_t MAX_NMEA_MESSAGE_LENGTH = 256; //(82)
+//!< The minimum length of a NMEA message should be 11 bytes. $GPGGA*hh<CR><LF>
+constexpr uint32_t MIN_NMEA_MESSAGE_LENGTH = 11;
 
 #endif

--- a/src/decoders/oem/src/framer.cpp
+++ b/src/decoders/oem/src/framer.cpp
@@ -513,6 +513,13 @@ Framer::GetFrame(unsigned char* pucFrameBuffer_, uint32_t uiFrameBufferSize_, Me
         case NovAtelFrameState::WAITING_FOR_NMEA_CRC: {
             if (ucDataByte == '\n')
             {
+                if (uiMyByteCount <= MIN_NMEA_MESSAGE_LENGTH) // Handling the case where the message is too short. e.g. $*<CR> will incorrectly frame.
+                {
+                    uiMyByteCount = NMEA_SYNC_LENGTH;
+                    uiMyExpectedPayloadLength = 0;
+                    ResetState();
+                    continue;
+                }
                 char acCrc[NMEA_CRC_LENGTH + 1];
                 const size_t crcStartIndexInBuffer = uiMyByteCount - NMEA_CRC_LENGTH - 2;
                 for (int32_t i = 0; i < NMEA_CRC_LENGTH; ++i) { acCrc[i] = clInternalFrameBuffer[crcStartIndexInBuffer + i]; }


### PR DESCRIPTION
Found a underflow case in unknown bytes that accidently matched.

Specifically this pattern: `$*.` = `24 2a 0a`
The Framer start tracking it as NMEA data and then immediately see the `*` and `\r`. So we compute the index just before the CRC with `const size_t crcStartIndexInBuffer = uiMyByteCount - NMEA_CRC_LENGTH - 2;` = u3 - 2 -2 = 4294967295. This underflow causes a crash when used in a array index. 
 