### PR TITLE
Fix image windows-latest migrating to VS2026 and breaking Actions

### DIFF
--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         platform:
-          - [windows, windows-latest, msvc, Debug, msvc, AMD64]
-          - [windows, windows-latest, msvc, Release, msvc, AMD64]
-          - [windows, windows-latest, gnu, Debug, gnu, AMD64]
-          - [windows, windows-latest, gnu, Release, gnu, AMD64]
+          - [windows, windows-2022, msvc, Debug, msvc, AMD64]
+          - [windows, windows-2022, msvc, Release, msvc, AMD64]
+          - [windows, windows-2022, gnu, Debug, gnu, AMD64]
+          - [windows, windows-2022, gnu, Release, gnu, AMD64]
           #- [windows, windows-latest, clang-cl, Debug, clang, AMD64]
           #- [windows, windows-latest, clang-cl, Release, clang, AMD64]
           - [linux, ubuntu-latest, gnu, Debug, gnu, x86_64]


### PR DESCRIPTION
As per: https://github.com/actions/runner-images/issues/14017
The windows-latest image is now using Window 2025 & VS 2026. Lock down to 2022 as we haven't upgraded to VS 2026 yet.