### PR TITLE
Remove all unsafe reinterpret casts

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ This will generate a header file called `novatel_message_definitions.hpp` in you
 **⚠️ Disadvantages:**
 - Only works with the flattened binary format
 - Requires running Python script to generate structs
-- Uses `reinterpret_cast` (undefined behaviour if you cast to the wrong type)
+- No feedback if you copy data into the wrong message type
 
 **Example:**
 
@@ -355,7 +355,8 @@ if (eDecoderStatus == STATUS::SUCCESS)
     pucFrameBuffer += stMetaData.uiHeaderLength;
 
     if (stMetaData.usMessageId == 42/*BESTPOS*/) {
-        auto bestposLog = reinterpret_cast<struct BESTPOS*>(pucFrameBuffer);
+        struct BESTPOS bestposLog;
+        std::memcpy(&bestposLog, pucFrameBuffer, sizeof(struct BESTPOS));
         latitude = bestposLog->latitude;
     }
 }

--- a/examples/novatel/rxconfig_handler/rxconfig_handler.cpp
+++ b/examples/novatel/rxconfig_handler/rxconfig_handler.cpp
@@ -132,9 +132,10 @@ int main(int argc, char* argv[])
                 else if (eEncodeFormat == ENCODE_FORMAT::BINARY)
                 {
                     // Flip the CRC at the end of the embedded message, so it becomes a valid command.
-                    auto* puiCrcBegin = reinterpret_cast<uint32_t*>((stEmbeddedMessageData.pucMessage + stEmbeddedMessageData.uiMessageLength) -
-                                                                    OEM4_BINARY_CRC_LENGTH);
-                    *puiCrcBegin ^= 0xFFFFFFFF;
+                    for (uint32_t uiIndex = 0; uiIndex < OEM4_BINARY_CRC_LENGTH; uiIndex++)
+                    {
+                        stEmbeddedMessageData.pucMessage[stEmbeddedMessageData.uiMessageLength - OEM4_BINARY_CRC_LENGTH + uiIndex] ^= 0xFF;
+                    }
                     strippedOfs.write(reinterpret_cast<char*>(stEmbeddedMessageData.pucMessage), stEmbeddedMessageData.uiMessageLength);
                 }
                 else if (eEncodeFormat == ENCODE_FORMAT::JSON)

--- a/include/novatel_edie/decoders/common/common.hpp
+++ b/include/novatel_edie/decoders/common/common.hpp
@@ -41,6 +41,19 @@
 
 namespace novatel::edie {
 
+//-----------------------------------------------------------------------
+//! \brief Helper function for safely loading a value of type T from a buffer.
+//-----------------------------------------------------------------------
+template <typename T, typename BufferType> inline T LoadValueFromBuffer(const BufferType* logBuf_)
+{
+    static_assert(std::is_same_v<BufferType, char> || std::is_same_v<BufferType, unsigned char> || std::is_same_v<BufferType, std::byte> ||
+                      std::is_same_v<BufferType, int8_t> || std::is_same_v<BufferType, uint8_t>,
+                  "BufferType must be char, unsigned char, std::byte, int8_t, or uint8_t");
+    T value;
+    std::memcpy(&value, logBuf_, sizeof(T));
+    return value;
+}
+
 inline void ValidateMessageDatabaseFamily(MessageDatabase::ConstPtr pclMessageDb_, std::string_view expectedFamily,
                                           const std::shared_ptr<spdlog::logger>& logger)
 {

--- a/include/novatel_edie/decoders/common/encoder.hpp
+++ b/include/novatel_edie/decoders/common/encoder.hpp
@@ -67,20 +67,19 @@ template <typename T> inline std::chars_format FloatingPointFormat(const FieldCo
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> [[nodiscard]] bool WriteIntToBuffer(unsigned char** ppucBuffer_, uint32_t& uiBytesLeft_, T&& arg)
+template <typename T> [[nodiscard]] bool WriteIntToBuffer(char** ppcBuffer_, uint32_t& uiBytesLeft_, T&& arg)
 {
     static_assert(std::is_integral_v<std::decay_t<T>>, "Argument must be integral type.");
-    auto* ppcBuffer = reinterpret_cast<char*>(*ppucBuffer_);
-    auto [end, ec] = std::to_chars(ppcBuffer, ppcBuffer + uiBytesLeft_, arg);
+    auto [end, ec] = std::to_chars(*ppcBuffer_, *ppcBuffer_ + uiBytesLeft_, arg);
     if (ec != std::errc{}) { return false; }
-    const auto written = static_cast<uint32_t>(end - ppcBuffer);
-    *ppucBuffer_ = reinterpret_cast<unsigned char*>(end);
+    const auto written = static_cast<uint32_t>(end - *ppcBuffer_);
+    *ppcBuffer_ = end;
     uiBytesLeft_ -= written;
     return true;
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> [[nodiscard]] bool WriteHexToBuffer(unsigned char** ppucBuffer_, uint32_t& uiBytesLeft_, T&& arg, uint32_t width)
+template <typename T> [[nodiscard]] bool WriteHexToBuffer(char** ppcBuffer_, uint32_t& uiBytesLeft_, T&& arg, uint32_t width)
 {
     static_assert(std::is_integral_v<std::decay_t<T>>, "Argument must be integral type.");
 
@@ -89,29 +88,28 @@ template <typename T> [[nodiscard]] bool WriteHexToBuffer(unsigned char** ppucBu
 
     if (uiBytesLeft_ < requiredSpace) { return false; }
 
-    auto* ppcBuffer = reinterpret_cast<char*>(*ppucBuffer_);
-    auto [end, ec] = std::to_chars(ppcBuffer, ppcBuffer + uiBytesLeft_, arg, 16);
+    auto [end, ec] = std::to_chars(*ppcBuffer_, *ppcBuffer_ + uiBytesLeft_, arg, 16);
 
     if (ec != std::errc{}) { return false; }
 
-    const auto num_digits = static_cast<uint32_t>(end - ppcBuffer);
+    const auto num_digits = static_cast<uint32_t>(end - *ppcBuffer_);
 
     if (num_digits < width)
     {
         const uint32_t pad_chars = width - num_digits;
-        std::memmove(*ppucBuffer_ + pad_chars, *ppucBuffer_, num_digits);
-        std::fill_n(*ppucBuffer_, pad_chars, '0');
+        std::memmove(*ppcBuffer_ + pad_chars, *ppcBuffer_, num_digits);
+        std::fill_n(*ppcBuffer_, pad_chars, '0');
         end += pad_chars;
     }
 
-    uiBytesLeft_ -= static_cast<uint32_t>(end - ppcBuffer);
-    *ppucBuffer_ = reinterpret_cast<unsigned char*>(end);
+    uiBytesLeft_ -= static_cast<uint32_t>(end - *ppcBuffer_);
+    *ppcBuffer_ = end;
     return true;
 }
 
 // -------------------------------------------------------------------------------------------------------
 template <typename T>
-[[nodiscard]] bool WriteFloatToBuffer(unsigned char** ppucBuffer_, uint32_t& uiBytesLeft_, T value, std::chars_format format, std::optional<int> precision)
+[[nodiscard]] bool WriteFloatToBuffer(char** ppcBuffer_, uint32_t& uiBytesLeft_, T value, std::chars_format format, std::optional<int> precision)
 {
     static_assert(std::is_floating_point_v<T>, "WriteFloatToBuffer requires float/double.");
 
@@ -123,13 +121,12 @@ template <typename T>
     }
     else if (format == std::chars_format::fixed || format == std::chars_format::scientific) { precision_arg = 6; }
 
-    auto* ppcBuffer = reinterpret_cast<char*>(*ppucBuffer_);
-    auto [end, ec] = std::to_chars(ppcBuffer, ppcBuffer + uiBytesLeft_, value, format, precision_arg);
+    auto [end, ec] = std::to_chars(*ppcBuffer_, *ppcBuffer_ + uiBytesLeft_, value, format, precision_arg);
 
     if (ec != std::errc{}) { return false; }
 
-    uiBytesLeft_ -= static_cast<uint32_t>(end - ppcBuffer);
-    *ppucBuffer_ = reinterpret_cast<unsigned char*>(end);
+    uiBytesLeft_ -= static_cast<uint32_t>(end - *ppcBuffer_);
+    *ppcBuffer_ = end;
     return true;
 }
 
@@ -209,38 +206,44 @@ template <typename T, template <typename> class Template> struct is_specializati
 
 template <typename T, template <typename> class Template> inline constexpr bool is_specialization_of_v = is_specialization_of<T, Template>::value;
 
-namespace {
-using FieldMapEntry = std::function<bool(const FieldContainer&, unsigned char**, uint32_t&, const MessageDatabase&)>;
-} // namespace
-
 // -------------------------------------------------------------------------------------------------------
-template <typename... Args> [[nodiscard]] bool CopyAllToBuffer(unsigned char** ppucBuffer_, uint32_t& uiBytesLeft_, Args&&... args_)
+template <typename BufferType, typename... Args> [[nodiscard]] bool CopyAllToBuffer(BufferType* buffer_, uint32_t& uiBytesLeft_, Args&&... args_)
 {
+    static_assert(std::is_same_v<BufferType, char*> || std::is_same_v<BufferType, unsigned char*>, "BufferType must be char* or unsigned char*.");
     return ([&](auto&& arg) {
         using Decayed = std::decay_t<decltype(arg)>;
-        if constexpr (std::is_integral_v<Decayed> && !std::is_same_v<Decayed, char>) { return WriteIntToBuffer(ppucBuffer_, uiBytesLeft_, arg); }
-        if constexpr (is_specialization_of_v<Decayed, FloatValue>)
+        auto* ppcBuffer = reinterpret_cast<char*>(*buffer_);
+        if constexpr (std::is_integral_v<Decayed> && !std::is_same_v<Decayed, char>)
         {
-            return WriteFloatToBuffer(ppucBuffer_, uiBytesLeft_, arg.value, arg.format, arg.precision);
+            if (!WriteIntToBuffer(&ppcBuffer, uiBytesLeft_, arg)) { return false; }
         }
-        if constexpr (is_specialization_of_v<Decayed, HexValue>) { return WriteHexToBuffer(ppucBuffer_, uiBytesLeft_, arg.value, arg.width); }
-        return CopyToBuffer(ppucBuffer_, uiBytesLeft_, arg);
+        else if constexpr (is_specialization_of_v<Decayed, FloatValue>)
+        {
+            if (!WriteFloatToBuffer(&ppcBuffer, uiBytesLeft_, arg.value, arg.format, arg.precision)) { return false; }
+        }
+        else if constexpr (is_specialization_of_v<Decayed, HexValue>)
+        {
+            if (!WriteHexToBuffer(&ppcBuffer, uiBytesLeft_, arg.value, arg.width)) { return false; }
+        }
+        else { return CopyToBuffer(buffer_, uiBytesLeft_, arg); }
+        *buffer_ = reinterpret_cast<BufferType>(ppcBuffer);
+        return true;
     }(args_) &&
             ...);
 }
 
 // -------------------------------------------------------------------------------------------------------
 template <typename BufferType, typename... Args>
-[[nodiscard]] bool CopyAllToBufferSeparated(BufferType* ppucBuffer_, uint32_t& uiBytesLeft_, const char cSeparator_, Args&&... args_)
+[[nodiscard]] bool CopyAllToBufferSeparated(BufferType* buffer_, uint32_t& uiBytesLeft_, const char cSeparator_, Args&&... args_)
 {
     bool success = true;
     size_t i = 0;
     (
         [&](auto&& arg) {
             if (!success) { return; }
-            success &= CopyAllToBuffer(ppucBuffer_, uiBytesLeft_, arg);
+            success &= CopyAllToBuffer(buffer_, uiBytesLeft_, arg);
             // Copy the separator to the buffer for every item except the last.
-            if (success && (i++ < sizeof...(Args) - 1)) { success &= CopyToBuffer(ppucBuffer_, uiBytesLeft_, cSeparator_); }
+            if (success && (i++ < sizeof...(Args) - 1)) { success &= CopyToBuffer(buffer_, uiBytesLeft_, cSeparator_); }
         }(std::forward<Args>(args_)),
         ...);
 
@@ -248,25 +251,25 @@ template <typename BufferType, typename... Args>
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> FieldMapEntry BasicMapEntry(const char* pcF_)
+template <typename T> std::function<bool(const FieldContainer&, char**, uint32_t&, const MessageDatabase&)> BasicMapEntry(const char* pcF_)
 {
-    return [pcF_](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
+    return [pcF_](const FieldContainer& fc_, char** ppucOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         return WriteFormattedToBuffer(ppucOutBuf_, uiBytesLeft_, pcF_, std::get<T>(fc_.fieldValue));
     };
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> FieldMapEntry BasicIntMapEntry()
+template <typename T> std::function<bool(const FieldContainer&, char**, uint32_t&, const MessageDatabase&)> BasicIntMapEntry()
 {
-    return [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
+    return [](const FieldContainer& fc_, char** ppucOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<T>(fc_.fieldValue));
     };
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> FieldMapEntry BasicHexMapEntry(uint32_t width)
+template <typename T> std::function<bool(const FieldContainer&, char**, uint32_t&, const MessageDatabase&)> BasicHexMapEntry(uint32_t width)
 {
-    return [width](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
+    return [width](const FieldContainer& fc_, char** ppucOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         return WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<T>(fc_.fieldValue), width);
     };
 }
@@ -289,8 +292,8 @@ template <typename Derived> class EncoderBase
     EnumDefinition::ConstPtr vMyGpsTimeStatusDefinitions{nullptr};
 
     // TODO: ASCII and JSON could probably share the same map.
-    std::unordered_map<uint64_t, FieldMapEntry> asciiFieldMap;
-    std::unordered_map<uint64_t, FieldMapEntry> jsonFieldMap;
+    std::unordered_map<uint64_t, std::function<bool(const FieldContainer&, char**, uint32_t&, const MessageDatabase&)>> asciiFieldMap;
+    std::unordered_map<uint64_t, std::function<bool(const FieldContainer&, char**, uint32_t&, const MessageDatabase&)>> jsonFieldMap;
 
     template <bool Flatten, bool Align>
     [[nodiscard]] bool EncodeBinaryBody(const std::vector<FieldContainer>& stInterMessage_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
@@ -437,7 +440,7 @@ template <typename Derived> class EncoderBase
     }
 
     template <bool Abbreviated>
-    [[nodiscard]] bool EncodeAsciiBody(const std::vector<FieldContainer>& vIntermediateFormat_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    [[nodiscard]] bool EncodeAsciiBody(const std::vector<FieldContainer>& vIntermediateFormat_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                        const uint32_t uiIndents_ = 1) const
     {
         constexpr char separator = Abbreviated ? Derived::separatorAbbAscii : Derived::separatorAscii;
@@ -446,8 +449,8 @@ template <typename Derived> class EncoderBase
 
         if constexpr (Abbreviated)
         {
-            if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, '<') ||
-                !SetInBuffer(ppucOutBuf_, uiBytesLeft_, ' ', uiIndents_ * Derived::indentLengthAbbAscii))
+            if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, '<') ||
+                !SetInBuffer(ppcOutBuf_, uiBytesLeft_, ' ', uiIndents_ * Derived::indentLengthAbbAscii))
             {
                 return false;
             }
@@ -459,8 +462,8 @@ template <typename Derived> class EncoderBase
             {
                 if (newIndentLine)
                 {
-                    if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\r\n<") ||
-                        !SetInBuffer(ppucOutBuf_, uiBytesLeft_, ' ', uiIndents_ * Derived::indentLengthAbbAscii))
+                    if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\r\n<") ||
+                        !SetInBuffer(ppcOutBuf_, uiBytesLeft_, ' ', uiIndents_ * Derived::indentLengthAbbAscii))
                     {
                         return false;
                     }
@@ -475,8 +478,8 @@ template <typename Derived> class EncoderBase
                 // FIELD_ARRAY types contain several classes and so will use a recursive call
                 if (field.fieldDef->type == FIELD_TYPE::FIELD_ARRAY)
                 {
-                    if (!WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, vFcCurrentVectorField.size()) ||
-                        !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator))
+                    if (!WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, vFcCurrentVectorField.size()) ||
+                        !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))
                     {
                         return false;
                     }
@@ -488,8 +491,8 @@ template <typename Derived> class EncoderBase
                         // Abbrev ascii will output a blank line for a 0 length array, nice
                         if (vCurrentFieldArrayField.empty())
                         {
-                            if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\r\n<") ||
-                                !SetInBuffer(ppucOutBuf_, uiBytesLeft_, ' ', (uiIndents_ + 1) * Derived::indentLengthAbbAscii))
+                            if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\r\n<") ||
+                                !SetInBuffer(ppcOutBuf_, uiBytesLeft_, ' ', (uiIndents_ + 1) * Derived::indentLengthAbbAscii))
                             {
                                 return false;
                             }
@@ -500,8 +503,8 @@ template <typename Derived> class EncoderBase
                         {
                             for (const auto& clFieldArray : vCurrentFieldArrayField)
                             {
-                                if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\r\n") ||
-                                    !EncodeAsciiBody<true>(std::get<std::vector<FieldContainer>>(clFieldArray.fieldValue), ppucOutBuf_, uiBytesLeft_,
+                                if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\r\n") ||
+                                    !EncodeAsciiBody<true>(std::get<std::vector<FieldContainer>>(clFieldArray.fieldValue), ppcOutBuf_, uiBytesLeft_,
                                                            uiIndents_ + 1))
                                 {
                                     return false;
@@ -514,7 +517,7 @@ template <typename Derived> class EncoderBase
                     {
                         for (const auto& clFieldArray : vCurrentFieldArrayField)
                         {
-                            if (!EncodeAsciiBody<false>(std::get<std::vector<FieldContainer>>(clFieldArray.fieldValue), ppucOutBuf_, uiBytesLeft_))
+                            if (!EncodeAsciiBody<false>(std::get<std::vector<FieldContainer>>(clFieldArray.fieldValue), ppcOutBuf_, uiBytesLeft_))
                             {
                                 return false;
                             }
@@ -525,9 +528,9 @@ template <typename Derived> class EncoderBase
                 {
                     // if the field is a variable array, print the size first
                     if ((field.fieldDef->type == FIELD_TYPE::VARIABLE_LENGTH_ARRAY &&
-                         (!WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, vFcCurrentVectorField.size()) ||
-                          !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator))) ||
-                        (field.fieldDef->isString && !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, '"')))
+                         (!WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, vFcCurrentVectorField.size()) ||
+                          !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))) ||
+                        (field.fieldDef->isString && !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, '"')))
                     {
                         return false;
                     }
@@ -543,8 +546,8 @@ template <typename Derived> class EncoderBase
                             break;
                         }
 
-                        if (!FieldToAscii(arrayField, ppucOutBuf_, uiBytesLeft_) ||
-                            (field.fieldDef->isCsv && !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator)))
+                        if (!FieldToAscii(arrayField, ppcOutBuf_, uiBytesLeft_) ||
+                            (field.fieldDef->isCsv && !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator)))
                         {
                             return false;
                         }
@@ -552,10 +555,10 @@ template <typename Derived> class EncoderBase
                     // Quoted elements need a trailing comma
                     if (field.fieldDef->isString)
                     {
-                        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, '"') || !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator)) { return false; }
+                        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, '"') || !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator)) { return false; }
                     }
                     // Non-quoted, non-internally-separated elements also need a trailing comma
-                    else if (!field.fieldDef->isCsv && !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator)) { return false; }
+                    else if (!field.fieldDef->isCsv && !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator)) { return false; }
                 }
             }
             else
@@ -563,8 +566,8 @@ template <typename Derived> class EncoderBase
                 switch (field.fieldDef->type)
                 {
                 case FIELD_TYPE::STRING: // STRING types can be handled all at once because they are a single element and have a null terminator
-                    if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::get<std::string>(field.fieldValue), '"') ||
-                        !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator))
+                    if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::get<std::string>(field.fieldValue), '"') ||
+                        !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))
                     {
                         return false;
                     }
@@ -581,14 +584,14 @@ template <typename Derived> class EncoderBase
                     }
                     else if (enumField->dataType.length == 2)
                     {
-                        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, GetEnumString(enumField->enumDef, std::get<int16_t>(field.fieldValue))) ||
-                            !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator))
+                        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, GetEnumString(enumField->enumDef, std::get<int16_t>(field.fieldValue))) ||
+                            !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))
                         {
                             return false;
                         }
                     }
-                    else if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, GetEnumString(enumField->enumDef, std::get<int32_t>(field.fieldValue))) ||
-                             !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator))
+                    else if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, GetEnumString(enumField->enumDef, std::get<int32_t>(field.fieldValue))) ||
+                             !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))
                     {
                         return false;
                     }
@@ -596,14 +599,14 @@ template <typename Derived> class EncoderBase
                 }
                 case FIELD_TYPE::RESPONSE_ID: break; // Do nothing, ascii logs don't output this field
                 case FIELD_TYPE::RESPONSE_STR:
-                    if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<std::string>(field.fieldValue)) ||
-                        !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator))
+                    if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<std::string>(field.fieldValue)) ||
+                        !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))
                     {
                         return false;
                     }
                     break;
                 case FIELD_TYPE::SIMPLE:
-                    if (!FieldToAscii(field, ppucOutBuf_, uiBytesLeft_) || !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator)) { return false; }
+                    if (!FieldToAscii(field, ppcOutBuf_, uiBytesLeft_) || !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator)) { return false; }
                     break;
                 default: return false;
                 }
@@ -612,68 +615,68 @@ template <typename Derived> class EncoderBase
         return true;
     }
 
-    [[nodiscard]] bool FieldToAscii(const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
+    [[nodiscard]] bool FieldToAscii(const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
     {
         auto it = asciiFieldMap.find(fc_.fieldDef->conversionHash);
-        if (it != asciiFieldMap.end()) { return it->second(fc_, ppucOutBuf_, uiBytesLeft_, *pclMyMsgDb); }
+        if (it != asciiFieldMap.end()) { return it->second(fc_, ppcOutBuf_, uiBytesLeft_, *pclMyMsgDb); }
 
         switch (fc_.fieldDef->dataType.name)
         {
-        case DATA_TYPE::BOOL: return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, std::string_view(std::get<bool>(fc_.fieldValue) ? "TRUE" : "FALSE"));
-        case DATA_TYPE::HEXBYTE: return WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue), 2);
-        case DATA_TYPE::UCHAR: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue));
-        case DATA_TYPE::CHAR: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int8_t>(fc_.fieldValue));
-        case DATA_TYPE::USHORT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint16_t>(fc_.fieldValue));
-        case DATA_TYPE::SHORT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int16_t>(fc_.fieldValue));
-        case DATA_TYPE::UINT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
-        case DATA_TYPE::INT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
-        case DATA_TYPE::ULONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
-        case DATA_TYPE::ULONGLONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint64_t>(fc_.fieldValue));
-        case DATA_TYPE::LONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
-        case DATA_TYPE::LONGLONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int64_t>(fc_.fieldValue));
+        case DATA_TYPE::BOOL: return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, std::string_view(std::get<bool>(fc_.fieldValue) ? "TRUE" : "FALSE"));
+        case DATA_TYPE::HEXBYTE: return WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue), 2);
+        case DATA_TYPE::UCHAR: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue));
+        case DATA_TYPE::CHAR: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int8_t>(fc_.fieldValue));
+        case DATA_TYPE::USHORT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint16_t>(fc_.fieldValue));
+        case DATA_TYPE::SHORT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int16_t>(fc_.fieldValue));
+        case DATA_TYPE::UINT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
+        case DATA_TYPE::INT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
+        case DATA_TYPE::ULONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
+        case DATA_TYPE::ULONGLONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint64_t>(fc_.fieldValue));
+        case DATA_TYPE::LONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
+        case DATA_TYPE::LONGLONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int64_t>(fc_.fieldValue));
         case DATA_TYPE::FLOAT:
-            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
                                       fc_.fieldDef->precision);
         case DATA_TYPE::DOUBLE:
-            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
                                       fc_.fieldDef->precision);
         default: SPDLOG_LOGGER_CRITICAL(pclMyLogger, "FieldToAscii(): unknown type."); throw std::runtime_error("FieldToAscii(): unknown type.");
         }
     }
 
     // TODO: Delete this and use FieldToAscii
-    [[nodiscard]] bool FieldToJson(const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
+    [[nodiscard]] bool FieldToJson(const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
     {
         auto it = jsonFieldMap.find(fc_.fieldDef->conversionHash);
-        if (it != jsonFieldMap.end()) { return it->second(fc_, ppucOutBuf_, uiBytesLeft_, *pclMyMsgDb); }
+        if (it != jsonFieldMap.end()) { return it->second(fc_, ppcOutBuf_, uiBytesLeft_, *pclMyMsgDb); }
 
         switch (fc_.fieldDef->dataType.name)
         {
-        case DATA_TYPE::BOOL: return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, std::string_view(std::get<bool>(fc_.fieldValue) ? "true" : "false"));
+        case DATA_TYPE::BOOL: return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, std::string_view(std::get<bool>(fc_.fieldValue) ? "true" : "false"));
         case DATA_TYPE::HEXBYTE: [[fallthrough]];
-        case DATA_TYPE::UCHAR: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue));
-        case DATA_TYPE::CHAR: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int8_t>(fc_.fieldValue));
-        case DATA_TYPE::USHORT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint16_t>(fc_.fieldValue));
-        case DATA_TYPE::SHORT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int16_t>(fc_.fieldValue));
-        case DATA_TYPE::UINT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
-        case DATA_TYPE::INT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
-        case DATA_TYPE::ULONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
-        case DATA_TYPE::LONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
-        case DATA_TYPE::ULONGLONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint64_t>(fc_.fieldValue));
-        case DATA_TYPE::LONGLONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int64_t>(fc_.fieldValue));
+        case DATA_TYPE::UCHAR: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue));
+        case DATA_TYPE::CHAR: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int8_t>(fc_.fieldValue));
+        case DATA_TYPE::USHORT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint16_t>(fc_.fieldValue));
+        case DATA_TYPE::SHORT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int16_t>(fc_.fieldValue));
+        case DATA_TYPE::UINT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
+        case DATA_TYPE::INT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
+        case DATA_TYPE::ULONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
+        case DATA_TYPE::LONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
+        case DATA_TYPE::ULONGLONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint64_t>(fc_.fieldValue));
+        case DATA_TYPE::LONGLONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int64_t>(fc_.fieldValue));
         case DATA_TYPE::FLOAT:
-            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
                                       fc_.fieldDef->precision);
         case DATA_TYPE::DOUBLE:
-            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
                                       fc_.fieldDef->precision);
         default: SPDLOG_LOGGER_CRITICAL(pclMyLogger, "FieldToJson(): unknown type."); throw std::runtime_error("FieldToJson(): unknown type.");
         }
     }
 
-    [[nodiscard]] bool EncodeJsonBody(const std::vector<FieldContainer>& vIntermediateFormat_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
+    [[nodiscard]] bool EncodeJsonBody(const std::vector<FieldContainer>& vIntermediateFormat_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
     {
-        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, '{')) { return false; }
+        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, '{')) { return false; }
 
         for (const auto& field : vIntermediateFormat_)
         {
@@ -684,35 +687,35 @@ template <typename Derived> class EncoderBase
                 // FIELD_ARRAY types contain several classes and so will use a recursive call
                 if (field.fieldDef->type == FIELD_TYPE::FIELD_ARRAY)
                 {
-                    if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), R"(": [)")) { return false; }
+                    if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), R"(": [)")) { return false; }
                     const auto& vCurrentFieldArrayField = std::get<std::vector<FieldContainer>>(field.fieldValue);
                     if (vCurrentFieldArrayField.empty())
                     {
-                        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "],")) { return false; }
+                        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "],")) { return false; }
                     }
                     else
                     {
                         for (const auto& clFieldArray : vCurrentFieldArrayField)
                         {
-                            if (!EncodeJsonBody(std::get<std::vector<FieldContainer>>(clFieldArray.fieldValue), ppucOutBuf_, uiBytesLeft_) ||
-                                !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, ','))
+                            if (!EncodeJsonBody(std::get<std::vector<FieldContainer>>(clFieldArray.fieldValue), ppcOutBuf_, uiBytesLeft_) ||
+                                !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, ','))
                             {
                                 return false;
                             }
                         }
-                        *(*ppucOutBuf_ - 1) = ']';
-                        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, ',')) { return false; }
+                        *(*ppcOutBuf_ - 1) = ']';
+                        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, ',')) { return false; }
                     }
                 }
                 else
                 {
                     if (field.fieldDef->isString)
                     {
-                        if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), R"(": ")")) { return false; }
+                        if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), R"(": ")")) { return false; }
                     }
                     // This is an array of simple elements
-                    else if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), R"(": [)") ||
-                             (vFcCurrentVectorField.empty() && !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, ']')))
+                    else if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), R"(": [)") ||
+                             (vFcCurrentVectorField.empty() && !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, ']')))
                     {
                         return false;
                     }
@@ -727,8 +730,8 @@ template <typename Derived> class EncoderBase
                             break;
                         }
 
-                        if (!FieldToJson(arrayField, ppucOutBuf_, uiBytesLeft_) ||
-                            (!field.fieldDef->isString && !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, ',')))
+                        if (!FieldToJson(arrayField, ppcOutBuf_, uiBytesLeft_) ||
+                            (!field.fieldDef->isString && !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, ',')))
                         {
                             return false;
                         }
@@ -737,13 +740,13 @@ template <typename Derived> class EncoderBase
                     // Quoted elements need a trailing comma
                     if (field.fieldDef->isString)
                     {
-                        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\",")) { return false; }
+                        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\",")) { return false; }
                     }
                     // Non-quoted, non-internally-separated elements also need a trailing comma
                     else
                     {
-                        *(*ppucOutBuf_ - 1) = ']';
-                        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, ',')) { return false; }
+                        *(*ppcOutBuf_ - 1) = ']';
+                        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, ',')) { return false; }
                     }
                 }
             }
@@ -752,7 +755,7 @@ template <typename Derived> class EncoderBase
                 switch (field.fieldDef->type)
                 {
                 case FIELD_TYPE::STRING: // STRING types can be handled all at once because they are a single element and have a null terminator
-                    if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": \"",
+                    if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": \"",
                                          std::get<std::string>(field.fieldValue), "\","))
                     {
                         return false;
@@ -761,7 +764,7 @@ template <typename Derived> class EncoderBase
 
                 case FIELD_TYPE::ENUM:
                     if (!CopyAllToBuffer(
-                            ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": \"",
+                            ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": \"",
                             GetEnumString(dynamic_cast<const EnumField*>(field.fieldDef.get())->enumDef, std::get<int32_t>(field.fieldValue)), "\","))
                     {
                         return false;
@@ -769,7 +772,7 @@ template <typename Derived> class EncoderBase
                     break;
 
                 case FIELD_TYPE::RESPONSE_ID:
-                    if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name),
+                    if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name),
                                          "\": ", std::get<int32_t>(field.fieldValue), ','))
                     {
                         return false;
@@ -777,7 +780,7 @@ template <typename Derived> class EncoderBase
                     break;
 
                 case FIELD_TYPE::RESPONSE_STR:
-                    if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": \"",
+                    if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": \"",
                                          std::get<std::string>(field.fieldValue), "\","))
                     {
                         return false;
@@ -785,8 +788,8 @@ template <typename Derived> class EncoderBase
                     break;
 
                 case FIELD_TYPE::SIMPLE:
-                    if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": ") ||
-                        !FieldToJson(field, ppucOutBuf_, uiBytesLeft_) || !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, ','))
+                    if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": ") ||
+                        !FieldToJson(field, ppcOutBuf_, uiBytesLeft_) || !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, ','))
                     {
                         return false;
                     }
@@ -796,7 +799,7 @@ template <typename Derived> class EncoderBase
             }
         }
 
-        *(*ppucOutBuf_ - 1) = '}';
+        *(*ppcOutBuf_ - 1) = '}';
         return true;
     }
 

--- a/include/novatel_edie/decoders/common/encoder.hpp
+++ b/include/novatel_edie/decoders/common/encoder.hpp
@@ -67,19 +67,20 @@ template <typename T> inline std::chars_format FloatingPointFormat(const FieldCo
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> [[nodiscard]] bool WriteIntToBuffer(char** ppcBuffer_, uint32_t& uiBytesLeft_, T&& arg)
+template <typename T> [[nodiscard]] bool WriteIntToBuffer(unsigned char** ppucBuffer_, uint32_t& uiBytesLeft_, T&& arg)
 {
     static_assert(std::is_integral_v<std::decay_t<T>>, "Argument must be integral type.");
-    auto [end, ec] = std::to_chars(*ppcBuffer_, *ppcBuffer_ + uiBytesLeft_, arg);
+    auto* ppcBuffer = reinterpret_cast<char*>(*ppucBuffer_);
+    auto [end, ec] = std::to_chars(ppcBuffer, ppcBuffer + uiBytesLeft_, arg);
     if (ec != std::errc{}) { return false; }
-    const auto written = static_cast<uint32_t>(end - *ppcBuffer_);
-    *ppcBuffer_ = end;
+    const auto written = static_cast<uint32_t>(end - ppcBuffer);
+    *ppucBuffer_ = reinterpret_cast<unsigned char*>(end);
     uiBytesLeft_ -= written;
     return true;
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> [[nodiscard]] bool WriteHexToBuffer(char** ppcBuffer_, uint32_t& uiBytesLeft_, T&& arg, uint32_t width)
+template <typename T> [[nodiscard]] bool WriteHexToBuffer(unsigned char** ppucBuffer_, uint32_t& uiBytesLeft_, T&& arg, uint32_t width)
 {
     static_assert(std::is_integral_v<std::decay_t<T>>, "Argument must be integral type.");
 
@@ -88,28 +89,29 @@ template <typename T> [[nodiscard]] bool WriteHexToBuffer(char** ppcBuffer_, uin
 
     if (uiBytesLeft_ < requiredSpace) { return false; }
 
-    auto [end, ec] = std::to_chars(*ppcBuffer_, *ppcBuffer_ + uiBytesLeft_, arg, 16);
+    auto* ppcBuffer = reinterpret_cast<char*>(*ppucBuffer_);
+    auto [end, ec] = std::to_chars(ppcBuffer, ppcBuffer + uiBytesLeft_, arg, 16);
 
     if (ec != std::errc{}) { return false; }
 
-    const auto num_digits = static_cast<uint32_t>(end - *ppcBuffer_);
+    const auto num_digits = static_cast<uint32_t>(end - ppcBuffer);
 
     if (num_digits < width)
     {
         const uint32_t pad_chars = width - num_digits;
-        std::memmove(*ppcBuffer_ + pad_chars, *ppcBuffer_, num_digits);
-        std::fill_n(*ppcBuffer_, pad_chars, '0');
+        std::memmove(*ppucBuffer_ + pad_chars, *ppucBuffer_, num_digits);
+        std::fill_n(*ppucBuffer_, pad_chars, '0');
         end += pad_chars;
     }
 
-    uiBytesLeft_ -= static_cast<uint32_t>(end - *ppcBuffer_);
-    *ppcBuffer_ = end;
+    uiBytesLeft_ -= static_cast<uint32_t>(end - ppcBuffer);
+    *ppucBuffer_ = reinterpret_cast<unsigned char*>(end);
     return true;
 }
 
 // -------------------------------------------------------------------------------------------------------
 template <typename T>
-[[nodiscard]] bool WriteFloatToBuffer(char** ppcBuffer_, uint32_t& uiBytesLeft_, T value, std::chars_format format, std::optional<int> precision)
+[[nodiscard]] bool WriteFloatToBuffer(unsigned char** ppucBuffer_, uint32_t& uiBytesLeft_, T value, std::chars_format format, std::optional<int> precision)
 {
     static_assert(std::is_floating_point_v<T>, "WriteFloatToBuffer requires float/double.");
 
@@ -121,12 +123,13 @@ template <typename T>
     }
     else if (format == std::chars_format::fixed || format == std::chars_format::scientific) { precision_arg = 6; }
 
-    auto [end, ec] = std::to_chars(*ppcBuffer_, *ppcBuffer_ + uiBytesLeft_, value, format, precision_arg);
+    auto* ppcBuffer = reinterpret_cast<char*>(*ppucBuffer_);
+    auto [end, ec] = std::to_chars(ppcBuffer, ppcBuffer + uiBytesLeft_, value, format, precision_arg);
 
     if (ec != std::errc{}) { return false; }
 
-    uiBytesLeft_ -= static_cast<uint32_t>(end - *ppcBuffer_);
-    *ppcBuffer_ = end;
+    uiBytesLeft_ -= static_cast<uint32_t>(end - ppcBuffer);
+    *ppucBuffer_ = reinterpret_cast<unsigned char*>(end);
     return true;
 }
 
@@ -135,7 +138,7 @@ template <typename BufferType>
 [[nodiscard]] inline bool SetInBuffer(BufferType* ppucBuffer_, uint32_t& uiBytesLeft_, const unsigned char iItem_, const uint32_t uiItemSize_)
 {
     if (uiBytesLeft_ < uiItemSize_) { return false; }
-    memset(*ppucBuffer_, iItem_, uiItemSize_);
+    std::memset(*ppucBuffer_, iItem_, uiItemSize_);
     *ppucBuffer_ += uiItemSize_;
     uiBytesLeft_ -= uiItemSize_;
     return true;
@@ -206,8 +209,12 @@ template <typename T, template <typename> class Template> struct is_specializati
 
 template <typename T, template <typename> class Template> inline constexpr bool is_specialization_of_v = is_specialization_of<T, Template>::value;
 
+namespace {
+using FieldMapEntry = std::function<bool(const FieldContainer&, unsigned char**, uint32_t&, const MessageDatabase&)>;
+} // namespace
+
 // -------------------------------------------------------------------------------------------------------
-template <typename... Args> [[nodiscard]] bool CopyAllToBuffer(char** ppucBuffer_, uint32_t& uiBytesLeft_, Args&&... args_)
+template <typename... Args> [[nodiscard]] bool CopyAllToBuffer(unsigned char** ppucBuffer_, uint32_t& uiBytesLeft_, Args&&... args_)
 {
     return ([&](auto&& arg) {
         using Decayed = std::decay_t<decltype(arg)>;
@@ -241,26 +248,26 @@ template <typename BufferType, typename... Args>
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> std::function<bool(const FieldContainer&, char**, uint32_t&, const MessageDatabase&)> BasicMapEntry(const char* pcF_)
+template <typename T> FieldMapEntry BasicMapEntry(const char* pcF_)
 {
-    return [pcF_](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFormattedToBuffer(ppcOutBuf_, uiBytesLeft_, pcF_, std::get<T>(fc_.fieldValue));
+    return [pcF_](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
+        return WriteFormattedToBuffer(ppucOutBuf_, uiBytesLeft_, pcF_, std::get<T>(fc_.fieldValue));
     };
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> std::function<bool(const FieldContainer&, char**, uint32_t&, const MessageDatabase&)> BasicIntMapEntry()
+template <typename T> FieldMapEntry BasicIntMapEntry()
 {
-    return [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<T>(fc_.fieldValue));
+    return [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
+        return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<T>(fc_.fieldValue));
     };
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> std::function<bool(const FieldContainer&, char**, uint32_t&, const MessageDatabase&)> BasicHexMapEntry(uint32_t width)
+template <typename T> FieldMapEntry BasicHexMapEntry(uint32_t width)
 {
-    return [width](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<T>(fc_.fieldValue), width);
+    return [width](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
+        return WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<T>(fc_.fieldValue), width);
     };
 }
 
@@ -282,9 +289,8 @@ template <typename Derived> class EncoderBase
     EnumDefinition::ConstPtr vMyGpsTimeStatusDefinitions{nullptr};
 
     // TODO: ASCII and JSON could probably share the same map.
-    std::unordered_map<uint64_t, std::function<bool(const FieldContainer&, char**, uint32_t&, [[maybe_unused]] const MessageDatabase&)>>
-        asciiFieldMap;
-    std::unordered_map<uint64_t, std::function<bool(const FieldContainer&, char**, uint32_t&, [[maybe_unused]] const MessageDatabase&)>> jsonFieldMap;
+    std::unordered_map<uint64_t, FieldMapEntry> asciiFieldMap;
+    std::unordered_map<uint64_t, FieldMapEntry> jsonFieldMap;
 
     template <bool Flatten, bool Align>
     [[nodiscard]] bool EncodeBinaryBody(const std::vector<FieldContainer>& stInterMessage_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
@@ -297,7 +303,7 @@ template <typename Derived> class EncoderBase
         // decoder for consistency.
         const auto alignBufferPtr = [&ppucOutBuf_, &uiBytesLeft_](uint8_t alignment) {
             const auto uiAlign = std::min(static_cast<uint8_t>(4U), alignment);
-            const auto ullRem = reinterpret_cast<uint64_t>(*ppucOutBuf_) % uiAlign;
+            const auto ullRem = reinterpret_cast<uintptr_t>(*ppucOutBuf_) % uiAlign;
             return (ullRem == 0) || SetInBuffer(ppucOutBuf_, uiBytesLeft_, 0, uiAlign - ullRem);
         };
 
@@ -396,7 +402,7 @@ template <typename Derived> class EncoderBase
                         const uint32_t maxSize = dynamic_cast<const ArrayField*>(field.fieldDef.get())->arrayLength * field.fieldDef->dataType.length;
                         if (diff < maxSize && !SetInBuffer(ppucOutBuf_, uiBytesLeft_, '\0', maxSize - diff)) { return false; }
                     }
-                    else if (!SetInBuffer(ppucOutBuf_, uiBytesLeft_, '\0', 4 - (reinterpret_cast<uint64_t>(*ppucOutBuf_) % 4))) { return false; }
+                    else if (!SetInBuffer(ppucOutBuf_, uiBytesLeft_, '\0', 4 - (reinterpret_cast<uintptr_t>(*ppucOutBuf_) % 4))) { return false; }
                     break;
                 }
                 case FIELD_TYPE::ENUM:
@@ -431,7 +437,7 @@ template <typename Derived> class EncoderBase
     }
 
     template <bool Abbreviated>
-    [[nodiscard]] bool EncodeAsciiBody(const std::vector<FieldContainer>& vIntermediateFormat_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    [[nodiscard]] bool EncodeAsciiBody(const std::vector<FieldContainer>& vIntermediateFormat_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                        const uint32_t uiIndents_ = 1) const
     {
         constexpr char separator = Abbreviated ? Derived::separatorAbbAscii : Derived::separatorAscii;
@@ -440,8 +446,8 @@ template <typename Derived> class EncoderBase
 
         if constexpr (Abbreviated)
         {
-            if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, '<') ||
-                !SetInBuffer(ppcOutBuf_, uiBytesLeft_, ' ', uiIndents_ * Derived::indentLengthAbbAscii))
+            if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, '<') ||
+                !SetInBuffer(ppucOutBuf_, uiBytesLeft_, ' ', uiIndents_ * Derived::indentLengthAbbAscii))
             {
                 return false;
             }
@@ -453,8 +459,8 @@ template <typename Derived> class EncoderBase
             {
                 if (newIndentLine)
                 {
-                    if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\r\n<") ||
-                        !SetInBuffer(ppcOutBuf_, uiBytesLeft_, ' ', uiIndents_ * Derived::indentLengthAbbAscii))
+                    if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\r\n<") ||
+                        !SetInBuffer(ppucOutBuf_, uiBytesLeft_, ' ', uiIndents_ * Derived::indentLengthAbbAscii))
                     {
                         return false;
                     }
@@ -469,8 +475,8 @@ template <typename Derived> class EncoderBase
                 // FIELD_ARRAY types contain several classes and so will use a recursive call
                 if (field.fieldDef->type == FIELD_TYPE::FIELD_ARRAY)
                 {
-                    if (!WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, vFcCurrentVectorField.size()) ||
-                        !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))
+                    if (!WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, vFcCurrentVectorField.size()) ||
+                        !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator))
                     {
                         return false;
                     }
@@ -482,8 +488,8 @@ template <typename Derived> class EncoderBase
                         // Abbrev ascii will output a blank line for a 0 length array, nice
                         if (vCurrentFieldArrayField.empty())
                         {
-                            if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\r\n<") ||
-                                !SetInBuffer(ppcOutBuf_, uiBytesLeft_, ' ', (uiIndents_ + 1) * Derived::indentLengthAbbAscii))
+                            if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\r\n<") ||
+                                !SetInBuffer(ppucOutBuf_, uiBytesLeft_, ' ', (uiIndents_ + 1) * Derived::indentLengthAbbAscii))
                             {
                                 return false;
                             }
@@ -494,8 +500,8 @@ template <typename Derived> class EncoderBase
                         {
                             for (const auto& clFieldArray : vCurrentFieldArrayField)
                             {
-                                if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\r\n") ||
-                                    !EncodeAsciiBody<true>(std::get<std::vector<FieldContainer>>(clFieldArray.fieldValue), ppcOutBuf_, uiBytesLeft_,
+                                if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\r\n") ||
+                                    !EncodeAsciiBody<true>(std::get<std::vector<FieldContainer>>(clFieldArray.fieldValue), ppucOutBuf_, uiBytesLeft_,
                                                            uiIndents_ + 1))
                                 {
                                     return false;
@@ -508,7 +514,7 @@ template <typename Derived> class EncoderBase
                     {
                         for (const auto& clFieldArray : vCurrentFieldArrayField)
                         {
-                            if (!EncodeAsciiBody<false>(std::get<std::vector<FieldContainer>>(clFieldArray.fieldValue), ppcOutBuf_, uiBytesLeft_))
+                            if (!EncodeAsciiBody<false>(std::get<std::vector<FieldContainer>>(clFieldArray.fieldValue), ppucOutBuf_, uiBytesLeft_))
                             {
                                 return false;
                             }
@@ -519,9 +525,9 @@ template <typename Derived> class EncoderBase
                 {
                     // if the field is a variable array, print the size first
                     if ((field.fieldDef->type == FIELD_TYPE::VARIABLE_LENGTH_ARRAY &&
-                         (!WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, vFcCurrentVectorField.size()) ||
-                          !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))) ||
-                        (field.fieldDef->isString && !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, '"')))
+                         (!WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, vFcCurrentVectorField.size()) ||
+                          !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator))) ||
+                        (field.fieldDef->isString && !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, '"')))
                     {
                         return false;
                     }
@@ -537,8 +543,8 @@ template <typename Derived> class EncoderBase
                             break;
                         }
 
-                        if (!FieldToAscii(arrayField, ppcOutBuf_, uiBytesLeft_) ||
-                            (field.fieldDef->isCsv && !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator)))
+                        if (!FieldToAscii(arrayField, ppucOutBuf_, uiBytesLeft_) ||
+                            (field.fieldDef->isCsv && !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator)))
                         {
                             return false;
                         }
@@ -546,10 +552,10 @@ template <typename Derived> class EncoderBase
                     // Quoted elements need a trailing comma
                     if (field.fieldDef->isString)
                     {
-                        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, '"') || !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator)) { return false; }
+                        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, '"') || !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator)) { return false; }
                     }
                     // Non-quoted, non-internally-separated elements also need a trailing comma
-                    else if (!field.fieldDef->isCsv && !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator)) { return false; }
+                    else if (!field.fieldDef->isCsv && !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator)) { return false; }
                 }
             }
             else
@@ -557,8 +563,8 @@ template <typename Derived> class EncoderBase
                 switch (field.fieldDef->type)
                 {
                 case FIELD_TYPE::STRING: // STRING types can be handled all at once because they are a single element and have a null terminator
-                    if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::get<std::string>(field.fieldValue), '"') ||
-                        !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))
+                    if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::get<std::string>(field.fieldValue), '"') ||
+                        !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator))
                     {
                         return false;
                     }
@@ -575,14 +581,14 @@ template <typename Derived> class EncoderBase
                     }
                     else if (enumField->dataType.length == 2)
                     {
-                        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, GetEnumString(enumField->enumDef, std::get<int16_t>(field.fieldValue))) ||
-                            !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))
+                        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, GetEnumString(enumField->enumDef, std::get<int16_t>(field.fieldValue))) ||
+                            !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator))
                         {
                             return false;
                         }
                     }
-                    else if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, GetEnumString(enumField->enumDef, std::get<int32_t>(field.fieldValue))) ||
-                             !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))
+                    else if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, GetEnumString(enumField->enumDef, std::get<int32_t>(field.fieldValue))) ||
+                             !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator))
                     {
                         return false;
                     }
@@ -590,14 +596,14 @@ template <typename Derived> class EncoderBase
                 }
                 case FIELD_TYPE::RESPONSE_ID: break; // Do nothing, ascii logs don't output this field
                 case FIELD_TYPE::RESPONSE_STR:
-                    if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<std::string>(field.fieldValue)) ||
-                        !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator))
+                    if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<std::string>(field.fieldValue)) ||
+                        !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator))
                     {
                         return false;
                     }
                     break;
                 case FIELD_TYPE::SIMPLE:
-                    if (!FieldToAscii(field, ppcOutBuf_, uiBytesLeft_) || !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, separator)) { return false; }
+                    if (!FieldToAscii(field, ppucOutBuf_, uiBytesLeft_) || !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, separator)) { return false; }
                     break;
                 default: return false;
                 }
@@ -606,68 +612,68 @@ template <typename Derived> class EncoderBase
         return true;
     }
 
-    [[nodiscard]] bool FieldToAscii(const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
+    [[nodiscard]] bool FieldToAscii(const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
     {
         auto it = asciiFieldMap.find(fc_.fieldDef->conversionHash);
-        if (it != asciiFieldMap.end()) { return it->second(fc_, ppcOutBuf_, uiBytesLeft_, *pclMyMsgDb); }
+        if (it != asciiFieldMap.end()) { return it->second(fc_, ppucOutBuf_, uiBytesLeft_, *pclMyMsgDb); }
 
         switch (fc_.fieldDef->dataType.name)
         {
-        case DATA_TYPE::BOOL: return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, std::string_view(std::get<bool>(fc_.fieldValue) ? "TRUE" : "FALSE"));
-        case DATA_TYPE::HEXBYTE: return WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue), 2);
-        case DATA_TYPE::UCHAR: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue));
-        case DATA_TYPE::CHAR: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int8_t>(fc_.fieldValue));
-        case DATA_TYPE::USHORT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint16_t>(fc_.fieldValue));
-        case DATA_TYPE::SHORT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int16_t>(fc_.fieldValue));
-        case DATA_TYPE::UINT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
-        case DATA_TYPE::INT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
-        case DATA_TYPE::ULONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
-        case DATA_TYPE::ULONGLONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint64_t>(fc_.fieldValue));
-        case DATA_TYPE::LONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
-        case DATA_TYPE::LONGLONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int64_t>(fc_.fieldValue));
+        case DATA_TYPE::BOOL: return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, std::string_view(std::get<bool>(fc_.fieldValue) ? "TRUE" : "FALSE"));
+        case DATA_TYPE::HEXBYTE: return WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue), 2);
+        case DATA_TYPE::UCHAR: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue));
+        case DATA_TYPE::CHAR: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int8_t>(fc_.fieldValue));
+        case DATA_TYPE::USHORT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint16_t>(fc_.fieldValue));
+        case DATA_TYPE::SHORT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int16_t>(fc_.fieldValue));
+        case DATA_TYPE::UINT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
+        case DATA_TYPE::INT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
+        case DATA_TYPE::ULONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
+        case DATA_TYPE::ULONGLONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint64_t>(fc_.fieldValue));
+        case DATA_TYPE::LONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
+        case DATA_TYPE::LONGLONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int64_t>(fc_.fieldValue));
         case DATA_TYPE::FLOAT:
-            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
+            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
                                       fc_.fieldDef->precision);
         case DATA_TYPE::DOUBLE:
-            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
+            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
                                       fc_.fieldDef->precision);
         default: SPDLOG_LOGGER_CRITICAL(pclMyLogger, "FieldToAscii(): unknown type."); throw std::runtime_error("FieldToAscii(): unknown type.");
         }
     }
 
     // TODO: Delete this and use FieldToAscii
-    [[nodiscard]] bool FieldToJson(const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
+    [[nodiscard]] bool FieldToJson(const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
     {
         auto it = jsonFieldMap.find(fc_.fieldDef->conversionHash);
-        if (it != jsonFieldMap.end()) { return it->second(fc_, ppcOutBuf_, uiBytesLeft_, *pclMyMsgDb); }
+        if (it != jsonFieldMap.end()) { return it->second(fc_, ppucOutBuf_, uiBytesLeft_, *pclMyMsgDb); }
 
         switch (fc_.fieldDef->dataType.name)
         {
-        case DATA_TYPE::BOOL: return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, std::string_view(std::get<bool>(fc_.fieldValue) ? "true" : "false"));
+        case DATA_TYPE::BOOL: return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, std::string_view(std::get<bool>(fc_.fieldValue) ? "true" : "false"));
         case DATA_TYPE::HEXBYTE: [[fallthrough]];
-        case DATA_TYPE::UCHAR: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue));
-        case DATA_TYPE::CHAR: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int8_t>(fc_.fieldValue));
-        case DATA_TYPE::USHORT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint16_t>(fc_.fieldValue));
-        case DATA_TYPE::SHORT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int16_t>(fc_.fieldValue));
-        case DATA_TYPE::UINT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
-        case DATA_TYPE::INT: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
-        case DATA_TYPE::ULONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
-        case DATA_TYPE::LONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
-        case DATA_TYPE::ULONGLONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint64_t>(fc_.fieldValue));
-        case DATA_TYPE::LONGLONG: return WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<int64_t>(fc_.fieldValue));
+        case DATA_TYPE::UCHAR: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue));
+        case DATA_TYPE::CHAR: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int8_t>(fc_.fieldValue));
+        case DATA_TYPE::USHORT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint16_t>(fc_.fieldValue));
+        case DATA_TYPE::SHORT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int16_t>(fc_.fieldValue));
+        case DATA_TYPE::UINT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
+        case DATA_TYPE::INT: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
+        case DATA_TYPE::ULONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue));
+        case DATA_TYPE::LONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int32_t>(fc_.fieldValue));
+        case DATA_TYPE::ULONGLONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint64_t>(fc_.fieldValue));
+        case DATA_TYPE::LONGLONG: return WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<int64_t>(fc_.fieldValue));
         case DATA_TYPE::FLOAT:
-            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
+            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
                                       fc_.fieldDef->precision);
         case DATA_TYPE::DOUBLE:
-            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
+            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
                                       fc_.fieldDef->precision);
         default: SPDLOG_LOGGER_CRITICAL(pclMyLogger, "FieldToJson(): unknown type."); throw std::runtime_error("FieldToJson(): unknown type.");
         }
     }
 
-    [[nodiscard]] bool EncodeJsonBody(const std::vector<FieldContainer>& vIntermediateFormat_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
+    [[nodiscard]] bool EncodeJsonBody(const std::vector<FieldContainer>& vIntermediateFormat_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
     {
-        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, '{')) { return false; }
+        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, '{')) { return false; }
 
         for (const auto& field : vIntermediateFormat_)
         {
@@ -678,35 +684,35 @@ template <typename Derived> class EncoderBase
                 // FIELD_ARRAY types contain several classes and so will use a recursive call
                 if (field.fieldDef->type == FIELD_TYPE::FIELD_ARRAY)
                 {
-                    if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), R"(": [)")) { return false; }
+                    if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), R"(": [)")) { return false; }
                     const auto& vCurrentFieldArrayField = std::get<std::vector<FieldContainer>>(field.fieldValue);
                     if (vCurrentFieldArrayField.empty())
                     {
-                        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "],")) { return false; }
+                        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "],")) { return false; }
                     }
                     else
                     {
                         for (const auto& clFieldArray : vCurrentFieldArrayField)
                         {
-                            if (!EncodeJsonBody(std::get<std::vector<FieldContainer>>(clFieldArray.fieldValue), ppcOutBuf_, uiBytesLeft_) ||
-                                !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, ','))
+                            if (!EncodeJsonBody(std::get<std::vector<FieldContainer>>(clFieldArray.fieldValue), ppucOutBuf_, uiBytesLeft_) ||
+                                !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, ','))
                             {
                                 return false;
                             }
                         }
-                        *(*ppcOutBuf_ - 1) = ']';
-                        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, ',')) { return false; }
+                        *(*ppucOutBuf_ - 1) = ']';
+                        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, ',')) { return false; }
                     }
                 }
                 else
                 {
                     if (field.fieldDef->isString)
                     {
-                        if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), R"(": ")")) { return false; }
+                        if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), R"(": ")")) { return false; }
                     }
                     // This is an array of simple elements
-                    else if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), R"(": [)") ||
-                             (vFcCurrentVectorField.empty() && !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, ']')))
+                    else if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), R"(": [)") ||
+                             (vFcCurrentVectorField.empty() && !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, ']')))
                     {
                         return false;
                     }
@@ -721,8 +727,8 @@ template <typename Derived> class EncoderBase
                             break;
                         }
 
-                        if (!FieldToJson(arrayField, ppcOutBuf_, uiBytesLeft_) ||
-                            (!field.fieldDef->isString && !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, ',')))
+                        if (!FieldToJson(arrayField, ppucOutBuf_, uiBytesLeft_) ||
+                            (!field.fieldDef->isString && !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, ',')))
                         {
                             return false;
                         }
@@ -731,13 +737,13 @@ template <typename Derived> class EncoderBase
                     // Quoted elements need a trailing comma
                     if (field.fieldDef->isString)
                     {
-                        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\",")) { return false; }
+                        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\",")) { return false; }
                     }
                     // Non-quoted, non-internally-separated elements also need a trailing comma
                     else
                     {
-                        *(*ppcOutBuf_ - 1) = ']';
-                        if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, ',')) { return false; }
+                        *(*ppucOutBuf_ - 1) = ']';
+                        if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, ',')) { return false; }
                     }
                 }
             }
@@ -746,7 +752,7 @@ template <typename Derived> class EncoderBase
                 switch (field.fieldDef->type)
                 {
                 case FIELD_TYPE::STRING: // STRING types can be handled all at once because they are a single element and have a null terminator
-                    if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": \"",
+                    if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": \"",
                                          std::get<std::string>(field.fieldValue), "\","))
                     {
                         return false;
@@ -755,7 +761,7 @@ template <typename Derived> class EncoderBase
 
                 case FIELD_TYPE::ENUM:
                     if (!CopyAllToBuffer(
-                            ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": \"",
+                            ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": \"",
                             GetEnumString(dynamic_cast<const EnumField*>(field.fieldDef.get())->enumDef, std::get<int32_t>(field.fieldValue)), "\","))
                     {
                         return false;
@@ -763,7 +769,7 @@ template <typename Derived> class EncoderBase
                     break;
 
                 case FIELD_TYPE::RESPONSE_ID:
-                    if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name),
+                    if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name),
                                          "\": ", std::get<int32_t>(field.fieldValue), ','))
                     {
                         return false;
@@ -771,7 +777,7 @@ template <typename Derived> class EncoderBase
                     break;
 
                 case FIELD_TYPE::RESPONSE_STR:
-                    if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": \"",
+                    if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": \"",
                                          std::get<std::string>(field.fieldValue), "\","))
                     {
                         return false;
@@ -779,8 +785,8 @@ template <typename Derived> class EncoderBase
                     break;
 
                 case FIELD_TYPE::SIMPLE:
-                    if (!CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": ") ||
-                        !FieldToJson(field, ppcOutBuf_, uiBytesLeft_) || !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, ','))
+                    if (!CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(field.fieldDef->name), "\": ") ||
+                        !FieldToJson(field, ppucOutBuf_, uiBytesLeft_) || !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, ','))
                     {
                         return false;
                     }
@@ -790,7 +796,7 @@ template <typename Derived> class EncoderBase
             }
         }
 
-        *(*ppcOutBuf_ - 1) = '}';
+        *(*ppucOutBuf_ - 1) = '}';
         return true;
     }
 

--- a/include/novatel_edie/decoders/common/encoder.hpp
+++ b/include/novatel_edie/decoders/common/encoder.hpp
@@ -38,6 +38,46 @@
 
 namespace novatel::edie {
 
+template <typename T, template <typename> class Template> struct is_specialization_of : std::false_type
+{
+};
+template <typename T, template <typename> class Template> struct is_specialization_of<Template<T>, Template> : std::true_type
+{
+};
+template <typename T, template <typename> class Template> inline constexpr bool is_specialization_of_v = is_specialization_of<T, Template>::value;
+
+template <typename T> struct is_byte_buffer : std::false_type
+{
+};
+template <> struct is_byte_buffer<char*> : std::true_type
+{
+};
+template <> struct is_byte_buffer<unsigned char*> : std::true_type
+{
+};
+template <> struct is_byte_buffer<std::byte*> : std::true_type
+{
+};
+template <typename T> inline constexpr bool is_byte_buffer_v = is_byte_buffer<T>::value;
+
+template <typename BufferType> constexpr void AssertWritableByteBuffer()
+{
+    static_assert(is_byte_buffer_v<std::decay_t<BufferType>>, "BufferType must be char*, unsigned char*, or std::byte*.");
+}
+
+template <typename T> struct FloatValue
+{
+    T value;
+    std::chars_format format;
+    std::optional<int> precision;
+};
+
+template <typename T> struct HexValue
+{
+    T value;
+    uint32_t width;
+};
+
 constexpr auto powLookup = [] {
     std::array<double, 16> arr{};
     arr[0] = 1.0;
@@ -67,20 +107,22 @@ template <typename T> inline std::chars_format FloatingPointFormat(const FieldCo
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> [[nodiscard]] bool WriteIntToBuffer(char** ppcBuffer_, uint32_t& uiBytesLeft_, T&& arg)
+template <typename BufferType, typename T> [[nodiscard]] bool WriteIntToBuffer(BufferType* buffer_, uint32_t& uiBytesLeft_, T&& arg)
 {
+    AssertWritableByteBuffer<BufferType>();
     static_assert(std::is_integral_v<std::decay_t<T>>, "Argument must be integral type.");
-    auto [end, ec] = std::to_chars(*ppcBuffer_, *ppcBuffer_ + uiBytesLeft_, arg);
+    auto [end, ec] = std::to_chars(*buffer_, *buffer_ + uiBytesLeft_, arg);
     if (ec != std::errc{}) { return false; }
-    const auto written = static_cast<uint32_t>(end - *ppcBuffer_);
-    *ppcBuffer_ = end;
+    const auto written = static_cast<uint32_t>(end - *buffer_);
+    *buffer_ = end;
     uiBytesLeft_ -= written;
     return true;
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> [[nodiscard]] bool WriteHexToBuffer(char** ppcBuffer_, uint32_t& uiBytesLeft_, T&& arg, uint32_t width)
+template <typename BufferType, typename T> [[nodiscard]] bool WriteHexToBuffer(BufferType* buffer_, uint32_t& uiBytesLeft_, T&& arg, uint32_t width)
 {
+    AssertWritableByteBuffer<BufferType>();
     static_assert(std::is_integral_v<std::decay_t<T>>, "Argument must be integral type.");
 
     constexpr uint32_t maxDigits = sizeof(T) * 2;
@@ -88,29 +130,30 @@ template <typename T> [[nodiscard]] bool WriteHexToBuffer(char** ppcBuffer_, uin
 
     if (uiBytesLeft_ < requiredSpace) { return false; }
 
-    auto [end, ec] = std::to_chars(*ppcBuffer_, *ppcBuffer_ + uiBytesLeft_, arg, 16);
+    auto [end, ec] = std::to_chars(*buffer_, *buffer_ + uiBytesLeft_, arg, 16);
 
     if (ec != std::errc{}) { return false; }
 
-    const auto num_digits = static_cast<uint32_t>(end - *ppcBuffer_);
+    const auto num_digits = static_cast<uint32_t>(end - *buffer_);
 
     if (num_digits < width)
     {
         const uint32_t pad_chars = width - num_digits;
-        std::memmove(*ppcBuffer_ + pad_chars, *ppcBuffer_, num_digits);
-        std::fill_n(*ppcBuffer_, pad_chars, '0');
+        std::memmove(*buffer_ + pad_chars, *buffer_, num_digits);
+        std::fill_n(*buffer_, pad_chars, '0');
         end += pad_chars;
     }
 
-    uiBytesLeft_ -= static_cast<uint32_t>(end - *ppcBuffer_);
-    *ppcBuffer_ = end;
+    uiBytesLeft_ -= static_cast<uint32_t>(end - *buffer_);
+    *buffer_ = end;
     return true;
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T>
-[[nodiscard]] bool WriteFloatToBuffer(char** ppcBuffer_, uint32_t& uiBytesLeft_, T value, std::chars_format format, std::optional<int> precision)
+template <typename BufferType, typename T>
+[[nodiscard]] bool WriteFloatToBuffer(BufferType* buffer_, uint32_t& uiBytesLeft_, T value, std::chars_format format, std::optional<int> precision)
 {
+    AssertWritableByteBuffer<BufferType>();
     static_assert(std::is_floating_point_v<T>, "WriteFloatToBuffer requires float/double.");
 
     int precision_arg = -1;
@@ -121,95 +164,77 @@ template <typename T>
     }
     else if (format == std::chars_format::fixed || format == std::chars_format::scientific) { precision_arg = 6; }
 
-    auto [end, ec] = std::to_chars(*ppcBuffer_, *ppcBuffer_ + uiBytesLeft_, value, format, precision_arg);
+    auto [end, ec] = std::to_chars(*buffer_, *buffer_ + uiBytesLeft_, value, format, precision_arg);
 
     if (ec != std::errc{}) { return false; }
 
-    uiBytesLeft_ -= static_cast<uint32_t>(end - *ppcBuffer_);
-    *ppcBuffer_ = end;
+    uiBytesLeft_ -= static_cast<uint32_t>(end - *buffer_);
+    *buffer_ = end;
     return true;
 }
 
 // -------------------------------------------------------------------------------------------------------
 template <typename BufferType>
-[[nodiscard]] inline bool SetInBuffer(BufferType* ppucBuffer_, uint32_t& uiBytesLeft_, const unsigned char iItem_, const uint32_t uiItemSize_)
+[[nodiscard]] inline bool SetInBuffer(BufferType* buffer_, uint32_t& uiBytesLeft_, const unsigned char iItem_, const uint32_t uiItemSize_)
 {
+    AssertWritableByteBuffer<BufferType>();
     if (uiBytesLeft_ < uiItemSize_) { return false; }
-    std::memset(*ppucBuffer_, iItem_, uiItemSize_);
-    *ppucBuffer_ += uiItemSize_;
+    std::memset(*buffer_, iItem_, uiItemSize_);
+    *buffer_ += uiItemSize_;
     uiBytesLeft_ -= uiItemSize_;
     return true;
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename BufferType, typename T> [[nodiscard]] bool CopyToBuffer(BufferType* ppucBuffer_, uint32_t& uiBytesLeft_, const T& item)
+template <typename BufferType, typename T> [[nodiscard]] bool CopyToBuffer(BufferType* buffer_, uint32_t& uiBytesLeft_, const T& item)
 {
+    AssertWritableByteBuffer<BufferType>();
     static_assert(!std::is_pointer_v<T>, "Pointers not allowed.");
     if (uiBytesLeft_ < sizeof(T)) { return false; }
-    std::memcpy(*ppucBuffer_, &item, sizeof(T));
-    *ppucBuffer_ += sizeof(T);
+    std::memcpy(*buffer_, &item, sizeof(T));
+    *buffer_ += sizeof(T);
     uiBytesLeft_ -= sizeof(T);
     return true;
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename BufferType> [[nodiscard]] bool CopyToBuffer(BufferType* ppucBuffer_, uint32_t& uiBytesLeft_, const char* ptItem_)
+template <typename BufferType> [[nodiscard]] bool CopyToBuffer(BufferType* buffer_, uint32_t& uiBytesLeft_, const char* ptItem_)
 {
+    AssertWritableByteBuffer<BufferType>();
     auto uiItemSize = static_cast<uint32_t>(std::strlen(ptItem_));
     if (uiBytesLeft_ < uiItemSize) { return false; }
-    std::memcpy(*ppucBuffer_, ptItem_, uiItemSize);
-    *ppucBuffer_ += uiItemSize;
+    std::memcpy(*buffer_, ptItem_, uiItemSize);
+    *buffer_ += uiItemSize;
     uiBytesLeft_ -= uiItemSize;
     return true;
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename BufferType> [[nodiscard]] inline bool CopyToBuffer(BufferType* ppucBuffer_, uint32_t& uiBytesLeft_, std::string_view sv)
+template <typename BufferType> [[nodiscard]] inline bool CopyToBuffer(BufferType* buffer_, uint32_t& uiBytesLeft_, std::string_view sv)
 {
+    AssertWritableByteBuffer<BufferType>();
     if (uiBytesLeft_ < sv.size()) { return false; }
-    std::memcpy(*ppucBuffer_, sv.data(), sv.size());
-    *ppucBuffer_ += sv.size();
+    std::memcpy(*buffer_, sv.data(), sv.size());
+    *buffer_ += sv.size();
     uiBytesLeft_ -= static_cast<uint32_t>(sv.size());
     return true;
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename BufferType> [[nodiscard]] inline bool CopyToBuffer(BufferType* ppucBuffer_, uint32_t& uiBytesLeft_, const std::string& str)
+template <typename BufferType> [[nodiscard]] inline bool CopyToBuffer(BufferType* buffer_, uint32_t& uiBytesLeft_, const std::string& str)
 {
+    AssertWritableByteBuffer<BufferType>();
     if (uiBytesLeft_ < str.size()) { return false; }
-    std::memcpy(*ppucBuffer_, str.data(), str.size());
-    *ppucBuffer_ += str.size();
+    std::memcpy(*buffer_, str.data(), str.size());
+    *buffer_ += str.size();
     uiBytesLeft_ -= static_cast<uint32_t>(str.size());
     return true;
 }
 
-template <typename T> struct FloatValue
-{
-    T value;
-    std::chars_format format;
-    std::optional<int> precision;
-};
-
-template <typename T> struct HexValue
-{
-    T value;
-    uint32_t width;
-};
-
-template <typename T, template <typename> class Template> struct is_specialization_of : std::false_type
-{
-};
-
-template <typename T, template <typename> class Template> struct is_specialization_of<Template<T>, Template> : std::true_type
-{
-};
-
-template <typename T, template <typename> class Template> inline constexpr bool is_specialization_of_v = is_specialization_of<T, Template>::value;
-
 // -------------------------------------------------------------------------------------------------------
 template <typename BufferType, typename... Args> [[nodiscard]] bool CopyAllToBuffer(BufferType* buffer_, uint32_t& uiBytesLeft_, Args&&... args_)
 {
-    static_assert(std::is_same_v<BufferType, char*> || std::is_same_v<BufferType, unsigned char*>, "BufferType must be char* or unsigned char*.");
+    AssertWritableByteBuffer<BufferType>();
     return ([&](auto&& arg) {
         using Decayed = std::decay_t<decltype(arg)>;
         auto* ppcBuffer = reinterpret_cast<char*>(*buffer_);
@@ -236,6 +261,7 @@ template <typename BufferType, typename... Args> [[nodiscard]] bool CopyAllToBuf
 template <typename BufferType, typename... Args>
 [[nodiscard]] bool CopyAllToBufferSeparated(BufferType* buffer_, uint32_t& uiBytesLeft_, const char cSeparator_, Args&&... args_)
 {
+    AssertWritableByteBuffer<BufferType>();
     bool success = true;
     size_t i = 0;
     (
@@ -248,14 +274,6 @@ template <typename BufferType, typename... Args>
         ...);
 
     return success;
-}
-
-// -------------------------------------------------------------------------------------------------------
-template <typename T> std::function<bool(const FieldContainer&, char**, uint32_t&, const MessageDatabase&)> BasicMapEntry(const char* pcF_)
-{
-    return [pcF_](const FieldContainer& fc_, char** ppucOutBuf_, uint32_t& uiBytesLeft_, [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFormattedToBuffer(ppucOutBuf_, uiBytesLeft_, pcF_, std::get<T>(fc_.fieldValue));
-    };
 }
 
 // -------------------------------------------------------------------------------------------------------

--- a/include/novatel_edie/decoders/oem/encoder.hpp
+++ b/include/novatel_edie/decoders/oem/encoder.hpp
@@ -59,15 +59,15 @@ class Encoder : public EncoderBase<Encoder>
     [[nodiscard]] static bool EncodeBinaryShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_);
 
     // Encode ascii
-    [[nodiscard]] bool EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
-    [[nodiscard]] bool EncodeAsciiShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
-    [[nodiscard]] bool EncodeAbbrevAsciiHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    [[nodiscard]] bool EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
+    [[nodiscard]] bool EncodeAsciiShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
+    [[nodiscard]] bool EncodeAbbrevAsciiHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                bool bIsEmbedded_ = false) const;
-    [[nodiscard]] bool EncodeAbbrevAsciiShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
+    [[nodiscard]] bool EncodeAbbrevAsciiShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
 
     // Encode JSON
-    [[nodiscard]] bool EncodeJsonHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
-    [[nodiscard]] bool EncodeJsonShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
+    [[nodiscard]] bool EncodeJsonHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
+    [[nodiscard]] bool EncodeJsonShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
 
   public:
     //----------------------------------------------------------------------------

--- a/include/novatel_edie/decoders/oem/encoder.hpp
+++ b/include/novatel_edie/decoders/oem/encoder.hpp
@@ -59,15 +59,15 @@ class Encoder : public EncoderBase<Encoder>
     [[nodiscard]] static bool EncodeBinaryShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_);
 
     // Encode ascii
-    [[nodiscard]] bool EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
-    [[nodiscard]] bool EncodeAsciiShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
-    [[nodiscard]] bool EncodeAbbrevAsciiHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    [[nodiscard]] bool EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
+    [[nodiscard]] bool EncodeAsciiShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
+    [[nodiscard]] bool EncodeAbbrevAsciiHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                bool bIsEmbedded_ = false) const;
-    [[nodiscard]] bool EncodeAbbrevAsciiShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
+    [[nodiscard]] bool EncodeAbbrevAsciiShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
 
     // Encode JSON
-    [[nodiscard]] bool EncodeJsonHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
-    [[nodiscard]] bool EncodeJsonShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
+    [[nodiscard]] bool EncodeJsonHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
+    [[nodiscard]] bool EncodeJsonShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;
 
   public:
     //----------------------------------------------------------------------------
@@ -105,7 +105,7 @@ class Encoder : public EncoderBase<Encoder>
     //!   UNSUPPORTED: eFormat_ contains a format that is not supported for
     //! encoding.
     //----------------------------------------------------------------------------
-    [[nodiscard]] STATUS Encode(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+    [[nodiscard]] STATUS Encode(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                 const std::vector<FieldContainer>& stMessage_, MessageDataStruct& stMessageData_, HEADER_FORMAT eHeaderFormat_,
                                 ENCODE_FORMAT eFormat_) const;
 
@@ -136,7 +136,7 @@ class Encoder : public EncoderBase<Encoder>
     //!   UNSUPPORTED: eEncodeFormat_ contains a format that is not supported for
     //! encoding.
     //----------------------------------------------------------------------------
-    [[nodiscard]] STATUS EncodeHeader(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+    [[nodiscard]] STATUS EncodeHeader(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                       MessageDataStruct& stMessageData_, HEADER_FORMAT eHeaderFormat_, ENCODE_FORMAT eFormat_,
                                       bool bIsEmbeddedHeader_ = false) const;
 
@@ -165,7 +165,7 @@ class Encoder : public EncoderBase<Encoder>
     //!   UNSUPPORTED: eEncodeFormat_ contains a format that is not supported for
     //! encoding.
     //----------------------------------------------------------------------------
-    [[nodiscard]] STATUS EncodeBody(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const std::vector<FieldContainer>& stMessage_,
+    [[nodiscard]] STATUS EncodeBody(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const std::vector<FieldContainer>& stMessage_,
                                     MessageDataStruct& stMessageData_, HEADER_FORMAT eHeaderFormat_, ENCODE_FORMAT eFormat_) const;
 
     friend class EncoderBase<Encoder>;

--- a/include/novatel_edie/decoders/oem/encoder.hpp
+++ b/include/novatel_edie/decoders/oem/encoder.hpp
@@ -54,9 +54,9 @@ class Encoder : public EncoderBase<Encoder>
     static constexpr uint32_t indentLengthAbbAscii = OEM4_ABBREV_ASCII_INDENTATION_LENGTH;
 
     // Encode binary
-    [[nodiscard]] static bool FieldToBinary(const FieldContainer& fc_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_);
-    [[nodiscard]] static bool EncodeBinaryHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_);
-    [[nodiscard]] static bool EncodeBinaryShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_);
+    [[nodiscard]] static bool FieldToBinary(const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_);
+    [[nodiscard]] static bool EncodeBinaryHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_);
+    [[nodiscard]] static bool EncodeBinaryShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_);
 
     // Encode ascii
     [[nodiscard]] bool EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const;

--- a/include/novatel_edie/decoders/oem/rangecmp/common.hpp
+++ b/include/novatel_edie/decoders/oem/rangecmp/common.hpp
@@ -118,8 +118,8 @@ template <typename T, uint32_t BitfieldBits> T ExtractBitfield(unsigned char** p
         const int32_t extraBits = uiBitOffset_ + BitfieldBits - 64;
         if (extraBits > 0)
         {
-            uint64_t nextBytes = (*reinterpret_cast<uint64_t*>(*ppucData_ + 8)) & ((1ULL << extraBits) - 1);
-            result |= nextBytes << (64 - uiBitOffset_);
+            uint8_t nextByte = *(*ppucData_ + sizeof(uint64_t)) & static_cast<uint8_t>((1U << extraBits) - 1);
+            result |= static_cast<uint64_t>(nextByte) << (64 - uiBitOffset_);
         }
     }
     const uint32_t uiBitTotal = uiBitOffset_ + BitfieldBits;
@@ -148,8 +148,8 @@ template <typename T> T ExtractBitfield(unsigned char** ppucData_, uint32_t& uiB
     const int32_t extraBits = uiBitOffset_ + uiBitsInBitfield_ - 64;
     if (extraBits > 0)
     {
-        uint64_t nextBytes = (*reinterpret_cast<uint64_t*>(*ppucData_ + 8)) & ((1ULL << extraBits) - 1);
-        result |= nextBytes << (64 - uiBitOffset_);
+        uint8_t nextByte = *(*ppucData_ + sizeof(uint64_t)) & static_cast<uint8_t>((1U << extraBits) - 1);
+        result |= static_cast<uint64_t>(nextByte) << (64 - uiBitOffset_);
     }
     const uint32_t uiBitTotal = uiBitOffset_ + uiBitsInBitfield_;
     const uint32_t uiBytesConsumed = uiBitTotal / 8;

--- a/include/novatel_edie/decoders/oem/rxconfig/rxconfig_handler.hpp
+++ b/include/novatel_edie/decoders/oem/rxconfig/rxconfig_handler.hpp
@@ -122,7 +122,7 @@ class RxConfigHandler
     //!   UNSUPPORTED: eFormat_ contains a format that is not supported for
     //! encoding.
     //----------------------------------------------------------------------------
-    [[nodiscard]] STATUS Encode(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+    [[nodiscard]] STATUS Encode(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                 const std::vector<FieldContainer>& stMessage_, MessageDataStruct& stMessageData_,
                                 MessageDataStruct& stEmbeddedMessageData_, MetaDataStruct& stEmbeddedMetaData_, ENCODE_FORMAT eFormat_) const;
 
@@ -144,7 +144,7 @@ class RxConfigHandler
     //! - BUFFER_FULL: The provided buffer was not large enough to hold the encoded message.
     //! - FAILURE: An error occurred during encoding.
     //----------------------------------------------------------------------------
-    [[nodiscard]] STATUS EncodeBinary(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+    [[nodiscard]] STATUS EncodeBinary(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                       MessageDataStruct& stMessageData_, MessageDataStruct& stEmbeddedMessageData_,
                                       MetaDataStruct& stEmbeddedMetaData_, IntermediateHeader& stEmbeddedHeader_,
                                       std::vector<FieldContainer>& stEmbeddedMessage_) const;
@@ -167,7 +167,7 @@ class RxConfigHandler
     //! - BUFFER_FULL: The provided buffer was not large enough to hold the encoded message.
     //! - FAILURE: An error occurred during encoding.
     //----------------------------------------------------------------------------
-    [[nodiscard]] STATUS EncodeAscii(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+    [[nodiscard]] STATUS EncodeAscii(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                      MessageDataStruct& stMessageData_, MessageDataStruct& stEmbeddedMessageData_,
                                      MetaDataStruct& stEmbeddedMetaData_, IntermediateHeader& stEmbeddedHeader_,
                                      std::vector<FieldContainer>& stEmbeddedMessage_) const;
@@ -190,7 +190,7 @@ class RxConfigHandler
     //! - BUFFER_FULL: The provided buffer was not large enough to hold the encoded message.
     //! - FAILURE: An error occurred during encoding.
     //----------------------------------------------------------------------------
-    [[nodiscard]] STATUS EncodeAbbrevAscii(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+    [[nodiscard]] STATUS EncodeAbbrevAscii(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                            MessageDataStruct& stMessageData_, MessageDataStruct& stEmbeddedMessageData_,
                                            MetaDataStruct& stEmbeddedMetaData_, IntermediateHeader& stEmbeddedHeader_,
                                            std::vector<FieldContainer>& stEmbeddedMessage_) const;
@@ -213,7 +213,7 @@ class RxConfigHandler
     //! - BUFFER_FULL: The provided buffer was not large enough to hold the encoded message.
     //! - FAILURE: An error occurred during encoding.
     //----------------------------------------------------------------------------
-    [[nodiscard]] STATUS EncodeJSON(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+    [[nodiscard]] STATUS EncodeJSON(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                     MessageDataStruct& stMessageData_, MessageDataStruct& stEmbeddedMessageData_, MetaDataStruct& stEmbeddedMetaData_,
                                     IntermediateHeader& stEmbeddedHeader_, std::vector<FieldContainer>& stEmbeddedMessage_) const;
 
@@ -334,7 +334,7 @@ class RxConfigHandler
     //!   UNSUPPORTED: eFormat_ contains a format that is not supported for
     //! encoding.
     //----------------------------------------------------------------------------
-    [[nodiscard]] STATUS Encode(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+    [[nodiscard]] STATUS Encode(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                 const std::vector<FieldContainer>& stMessage_, MessageDataStruct& stMessageData_, ENCODE_FORMAT eFormat_) const;
 
     //----------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ build-backend = "scikit_build_core.build"
 # =====================================================================
 
 [tool.scikit-build]
-cmake.minimum-version = "3.24"
-cmake.targets = ["common", "decoders_common", "oem_decoder", "common_bindings", "oem_bindings", "common_stubs", "oem_stubs", "dynamic_stubs"]
+cmake.version = ">=3.24"
+build.targets = ["common", "decoders_common", "oem_decoder", "common_bindings", "oem_bindings", "common_stubs", "oem_stubs", "dynamic_stubs"]
 install.components = ["python"]
 wheel.license-files = ["LICENSE"]
 build-dir = "out/build/{wheel_tag}"

--- a/python/src/py_common/bindings/framer_manager.cpp
+++ b/python/src/py_common/bindings/framer_manager.cpp
@@ -16,7 +16,7 @@ nb::tuple PyFramerManager::PyGetFrame(uint32_t buffer_size)
 {
     std::vector<char> buffer(buffer_size);
     thread_local MetaDataBase* metadata; // maintain metadata until frame is returned
-    STATUS status = GetFrame(reinterpret_cast<uint8_t*>(buffer.data()), buffer_size, metadata);
+    STATUS status = GetFrame(reinterpret_cast<unsigned char*>(buffer.data()), buffer_size, metadata);
     switch (status)
     {
     case STATUS::UNKNOWN: // fall-through
@@ -61,7 +61,7 @@ void py_common::init_common_framer_manager(nb::module_& m)
         .def(
             "write",
             [](PyFramerManager& framer_manager, const nb::bytes& data) {
-                return framer_manager.Write(reinterpret_cast<const uint8_t*>(data.c_str()), data.size());
+                return framer_manager.Write(reinterpret_cast<const unsigned char*>(data.c_str()), data.size());
             },
             R"doc(
             Writes data to the Framer's buffer.
@@ -73,7 +73,7 @@ void py_common::init_common_framer_manager(nb::module_& m)
              [](PyFramerManager& self) {
                  char buffer[MESSAGE_SIZE_MAX];
                  uint32_t buf_size = MESSAGE_SIZE_MAX;
-                 uint32_t flushed = self.Flush(reinterpret_cast<uint8_t*>(buffer), buf_size);
+                 uint32_t flushed = self.Flush(reinterpret_cast<unsigned char*>(buffer), buf_size);
                  return nb::bytes(buffer, flushed);
              })
         .def("get_frame", &PyFramerManager::PyGetFrame, "buffer_size"_a = MESSAGE_SIZE_MAX,

--- a/python/src/py_oem/bindings/decoder.cpp
+++ b/python/src/py_oem/bindings/decoder.cpp
@@ -21,9 +21,9 @@ nb::object py_oem::PyDecoder::DecodeMessage(const nb::bytes raw_body, py_oem::Py
 
     if (rx_config_handler.IsRxConfigTypeMsg(header.usMessageId))
     {
-        status = rx_config_handler.Decode(reinterpret_cast<const uint8_t*>(raw_body.c_str()), fields, metadata);
+        status = rx_config_handler.Decode(reinterpret_cast<const unsigned char*>(raw_body.c_str()), fields, metadata);
     }
-    else { status = message_decoder.Decode(reinterpret_cast<const uint8_t*>(raw_body.c_str()), fields, metadata); }
+    else { status = message_decoder.Decode(reinterpret_cast<const unsigned char*>(raw_body.c_str()), fields, metadata); }
 
     switch (status)
     {
@@ -60,7 +60,7 @@ void py_oem::init_novatel_decoder(nb::module_& m)
                     oem::MetaDataStruct default_metadata = oem::MetaDataStruct();
                     metadata = &default_metadata;
                 }
-                STATUS status = decoder.header_decoder.Decode(reinterpret_cast<const uint8_t*>(raw_header.c_str()), header, *metadata);
+                STATUS status = decoder.header_decoder.Decode(reinterpret_cast<const unsigned char*>(raw_header.c_str()), header, *metadata);
                 if (status != STATUS::SUCCESS) { throw_exception_from_status(status); }
                 header.format = metadata->eFormat;
                 return header;
@@ -118,7 +118,7 @@ void py_oem::init_novatel_decoder(nb::module_& m)
                 metadata.uiLength = static_cast<uint32_t>(raw_message.size());
                 std::vector<FieldContainer> fields;
                 py_oem::PyHeader header;
-                const unsigned char* message_pointer = reinterpret_cast<const uint8_t*>(raw_message.c_str());
+                const unsigned char* message_pointer = reinterpret_cast<const unsigned char*>(raw_message.c_str());
                 STATUS status = decoder.header_decoder.Decode(message_pointer, header, metadata);
                 header.format = metadata.eFormat;
                 if (status != STATUS::SUCCESS) { throw_exception_from_status(status); }

--- a/python/src/py_oem/bindings/file_parser.cpp
+++ b/python/src/py_oem/bindings/file_parser.cpp
@@ -181,7 +181,7 @@ void py_oem::init_novatel_file_parser(nb::module_& m)
             [](py_oem::PyFileParser& self, bool return_flushed_bytes) -> nb::object {
                 if (!return_flushed_bytes) { return nb::int_(self.Flush()); }
                 char buffer[oem::Parser::uiParserInternalBufferSize];
-                uint32_t count = self.Flush(reinterpret_cast<uint8_t*>(buffer), oem::Parser::uiParserInternalBufferSize);
+                uint32_t count = self.Flush(reinterpret_cast<unsigned char*>(buffer), oem::Parser::uiParserInternalBufferSize);
                 return nb::bytes(buffer, count);
             },
             "return_flushed_bytes"_a = false,

--- a/python/src/py_oem/bindings/framer.cpp
+++ b/python/src/py_oem/bindings/framer.cpp
@@ -15,7 +15,7 @@ nb::tuple oem::PyFramer::PyGetFrame(uint32_t buffer_size)
     std::vector<char> buffer(buffer_size);
     thread_local oem::MetaDataStruct metadata; // maintain metadata until frame is returned
     oem::MetaDataStruct metadata_copy;
-    STATUS status = GetFrame(reinterpret_cast<uint8_t*>(buffer.data()), buffer_size, metadata);
+    STATUS status = GetFrame(reinterpret_cast<unsigned char*>(buffer.data()), buffer_size, metadata);
     switch (status)
     {
     case STATUS::UNKNOWN: // fall-through
@@ -96,7 +96,7 @@ void py_oem::init_novatel_framer(nb::module_& m)
             )doc")
         .def(
             "write",
-            [](oem::PyFramer& framer, const nb::bytes& data) { return framer.Write(reinterpret_cast<const uint8_t*>(data.c_str()), data.size()); },
+            [](oem::PyFramer& framer, const nb::bytes& data) { return framer.Write(reinterpret_cast<const unsigned char*>(data.c_str()), data.size()); },
             R"doc(
             Writes data to the Framer's buffer.
 
@@ -114,7 +114,7 @@ void py_oem::init_novatel_framer(nb::module_& m)
             [](oem::PyFramer& framer) {
                 char buffer[MESSAGE_SIZE_MAX];
                 uint32_t buf_size = MESSAGE_SIZE_MAX;
-                uint32_t flushed = framer.Flush(reinterpret_cast<uint8_t*>(buffer), buf_size);
+                uint32_t flushed = framer.Flush(reinterpret_cast<unsigned char*>(buffer), buf_size);
                 return nb::bytes(buffer, flushed);
             },
             R"doc(

--- a/python/src/py_oem/bindings/parser.cpp
+++ b/python/src/py_oem/bindings/parser.cpp
@@ -128,7 +128,7 @@ void py_oem::init_novatel_parser(nb::module_& m)
                      "The number of bytes in the Parser's internal buffer available for writing new data.")
         .def(
             "write",
-            [](py_oem::PyParser& self, const nb::bytes& data) { return self.Write(reinterpret_cast<const uint8_t*>(data.c_str()), data.size()); },
+            [](py_oem::PyParser& self, const nb::bytes& data) { return self.Write(reinterpret_cast<const unsigned char*>(data.c_str()), data.size()); },
             R"doc(
              Writes data to the Parser's internal buffer allowing it to later be parsed.
 

--- a/python/src/py_oem/bindings/py_message_objects.cpp
+++ b/python/src/py_oem/bindings/py_message_objects.cpp
@@ -86,7 +86,7 @@ py_common::PyMessageData py_oem::PyEncodableField::PyEncode(ENCODE_FORMAT format
     // A TRACKSTAT message can use about 47k bytes when encoded as JSON.
     // FIXME: this is still not safe and there is no effective buffer overflow checking implemented in Encoder.
     uint8_t buffer[MESSAGE_SIZE_MAX * 3];
-    auto buf_ptr = reinterpret_cast<uint8_t*>(&buffer);
+    auto buf_ptr = reinterpret_cast<unsigned char*>(&buffer);
     uint32_t buf_size = MESSAGE_SIZE_MAX * 3;
     if (extras.rxConfigHandler->IsRxConfigTypeMsg(this->header.usMessageId))
     {

--- a/python/src/py_oem/bindings/range_decompressor.cpp
+++ b/python/src/py_oem/bindings/range_decompressor.cpp
@@ -35,7 +35,7 @@ void py_oem::init_novatel_range_decompressor(nb::module_& m)
                 uint32_t buf_size = MESSAGE_SIZE_MAX;
                 memcpy(buffer, data.c_str(), data.size());
                 buffer[data.size()] = '\0';
-                STATUS status = self.Decompress(reinterpret_cast<uint8_t*>(buffer), buf_size, metadata, encode_format);
+                STATUS status = self.Decompress(reinterpret_cast<unsigned char*>(buffer), buf_size, metadata, encode_format);
                 throw_exception_from_status(status);
                 return nb::bytes(buffer, metadata.uiLength);
             },

--- a/python/src/py_oem/bindings/rxconfig_handler.cpp
+++ b/python/src/py_oem/bindings/rxconfig_handler.cpp
@@ -26,7 +26,7 @@ void py_oem::init_novatel_rxconfig_handler(nb::module_& m)
             nb::arg("message_db") = nb::none()) // NOLINT(*.NewDeleteLeaks)
         .def("write",
              [](oem::RxConfigHandler& self, const nb::bytes& data) {
-                 return self.Write(reinterpret_cast<uint8_t*>(const_cast<char*>(data.c_str())), static_cast<uint32_t>(data.size()));
+                 return self.Write(reinterpret_cast<const unsigned char*>(data.c_str()), static_cast<uint32_t>(data.size()));
              })
         .def(
             "convert",

--- a/src/decoders/common/src/common.cpp
+++ b/src/decoders/common/src/common.cpp
@@ -116,7 +116,7 @@ void ConsumeAbbrevFormatting(const char** ppcMessageBuffer_)
         case '<': [[fallthrough]];
         case ' ': [[fallthrough]];
         case '\r': [[fallthrough]];
-        case '\n': *ppcMessageBuffer_ += sizeof(int8_t); break;
+        case '\n': *ppcMessageBuffer_ += sizeof(char); break;
         default: return;
         }
     }

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -461,6 +461,7 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
         case FIELD_TYPE::ENUM:
             switch (field->dataType.length)
             {
+            case 1: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<int8_t>(*ppucLogBuf_), field); break;
             case 2: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<int16_t>(*ppucLogBuf_), field); break;
             case 4: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<int32_t>(*ppucLogBuf_), field); break;
             default:

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -408,6 +408,14 @@ void MessageDecoderBase::CreateResponseMsgDefinitions()
 }
 
 // -------------------------------------------------------------------------------------------------------
+template <typename T> inline T loadValueFromBuffer(const unsigned char** ppucLogBuf_)
+{
+    T value;
+    std::memcpy(&value, *ppucLogBuf_, sizeof(T));
+    return value;
+}
+
+// -------------------------------------------------------------------------------------------------------
 void MessageDecoderBase::DecodeBinaryField(BaseField::ConstPtr&& pstMessageDataType_, const unsigned char** ppucLogBuf_,
                                            std::vector<FieldContainer>& vIntermediateFormat_)
 {
@@ -417,57 +425,17 @@ void MessageDecoderBase::DecodeBinaryField(BaseField::ConstPtr&& pstMessageDataT
     case DATA_TYPE::HEXBYTE: [[fallthrough]];
     case DATA_TYPE::UCHAR: vIntermediateFormat_.emplace_back(static_cast<uint8_t>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
     case DATA_TYPE::CHAR: vIntermediateFormat_.emplace_back(static_cast<int8_t>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
-    case DATA_TYPE::USHORT: {
-        uint16_t uiVal;
-        std::memcpy(&uiVal, *ppucLogBuf_, sizeof(uint16_t));
-        vIntermediateFormat_.emplace_back(uiVal, std::move(pstMessageDataType_));
-        break;
-    }
-    case DATA_TYPE::SHORT: {
-        int16_t iVal;
-        std::memcpy(&iVal, *ppucLogBuf_, sizeof(int16_t));
-        vIntermediateFormat_.emplace_back(iVal, std::move(pstMessageDataType_));
-        break;
-    }
+    case DATA_TYPE::USHORT: vIntermediateFormat_.emplace_back(loadValueFromBuffer<uint16_t>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::SHORT: vIntermediateFormat_.emplace_back(loadValueFromBuffer<int16_t>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
     case DATA_TYPE::UINT: [[fallthrough]];
     case DATA_TYPE::SATELLITEID: [[fallthrough]];
-    case DATA_TYPE::ULONG: {
-        uint32_t uiVal;
-        std::memcpy(&uiVal, *ppucLogBuf_, sizeof(uint32_t));
-        vIntermediateFormat_.emplace_back(uiVal, std::move(pstMessageDataType_));
-        break;
-    }
+    case DATA_TYPE::ULONG: vIntermediateFormat_.emplace_back(loadValueFromBuffer<uint32_t>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
     case DATA_TYPE::INT: [[fallthrough]];
-    case DATA_TYPE::LONG: {
-        int32_t iVal;
-        std::memcpy(&iVal, *ppucLogBuf_, sizeof(int32_t));
-        vIntermediateFormat_.emplace_back(iVal, std::move(pstMessageDataType_));
-        break;
-    }
-    case DATA_TYPE::ULONGLONG: {
-        uint64_t uiVal;
-        std::memcpy(&uiVal, *ppucLogBuf_, sizeof(uint64_t));
-        vIntermediateFormat_.emplace_back(uiVal, std::move(pstMessageDataType_));
-        break;
-    }
-    case DATA_TYPE::LONGLONG: {
-        int64_t iVal;
-        std::memcpy(&iVal, *ppucLogBuf_, sizeof(int64_t));
-        vIntermediateFormat_.emplace_back(iVal, std::move(pstMessageDataType_));
-        break;
-    }
-    case DATA_TYPE::FLOAT: {
-        float fVal;
-        std::memcpy(&fVal, *ppucLogBuf_, sizeof(float));
-        vIntermediateFormat_.emplace_back(fVal, std::move(pstMessageDataType_));
-        break;
-    }
-    case DATA_TYPE::DOUBLE: {
-        double dVal;
-        std::memcpy(&dVal, *ppucLogBuf_, sizeof(double));
-        vIntermediateFormat_.emplace_back(dVal, std::move(pstMessageDataType_));
-        break;
-    }
+    case DATA_TYPE::LONG: vIntermediateFormat_.emplace_back(loadValueFromBuffer<int32_t>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::ULONGLONG: vIntermediateFormat_.emplace_back(loadValueFromBuffer<uint64_t>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::LONGLONG: vIntermediateFormat_.emplace_back(loadValueFromBuffer<int64_t>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::FLOAT: vIntermediateFormat_.emplace_back(loadValueFromBuffer<float>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::DOUBLE: vIntermediateFormat_.emplace_back(loadValueFromBuffer<double>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
     default: throw std::runtime_error("DecodeBinaryField(): Unknown field type\n");
     }
 
@@ -501,31 +469,18 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
         case FIELD_TYPE::ENUM:
             switch (field->dataType.length)
             {
-            case 2: {
-                int16_t iVal;
-                std::memcpy(&iVal, *ppucLogBuf_, sizeof(int16_t));
-                vIntermediateFormat_.emplace_back(iVal, field);
-                break;
-            }
-            case 4: {
-                int32_t iVal;
-                std::memcpy(&iVal, *ppucLogBuf_, sizeof(int32_t));
-                vIntermediateFormat_.emplace_back(iVal, field);
-                break;
-            }
+            case 2: vIntermediateFormat_.emplace_back(loadValueFromBuffer<int16_t>(ppucLogBuf_), field); break;
+            case 4: vIntermediateFormat_.emplace_back(loadValueFromBuffer<int32_t>(ppucLogBuf_), field); break;
             default:
                 SPDLOG_LOGGER_CRITICAL(pclMyLogger, "DecodeBinary(): Invalid field length\n");
                 throw std::runtime_error("DecodeBinary(): Invalid field length\n");
             }
             *ppucLogBuf_ += field->dataType.length;
             break;
-        case FIELD_TYPE::RESPONSE_ID: {
-            int32_t iVal;
-            std::memcpy(&iVal, *ppucLogBuf_, sizeof(int32_t));
-            vIntermediateFormat_.emplace_back(iVal, field);
+        case FIELD_TYPE::RESPONSE_ID:
+            vIntermediateFormat_.emplace_back(loadValueFromBuffer<int32_t>(ppucLogBuf_), field);
             *ppucLogBuf_ += sizeof(int32_t);
             break;
-        }
         case FIELD_TYPE::RESPONSE_STR: {
             std::string_view sTemp(reinterpret_cast<const char*>(*ppucLogBuf_), uiMessageLength_ - sizeof(int32_t)); // Remove CRC
             vIntermediateFormat_.emplace_back(std::string(sTemp), field);

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -408,14 +408,6 @@ void MessageDecoderBase::CreateResponseMsgDefinitions()
 }
 
 // -------------------------------------------------------------------------------------------------------
-template <typename T> inline T loadValueFromBuffer(const unsigned char** ppucLogBuf_)
-{
-    T value;
-    std::memcpy(&value, *ppucLogBuf_, sizeof(T));
-    return value;
-}
-
-// -------------------------------------------------------------------------------------------------------
 void MessageDecoderBase::DecodeBinaryField(BaseField::ConstPtr&& pstMessageDataType_, const unsigned char** ppucLogBuf_,
                                            std::vector<FieldContainer>& vIntermediateFormat_)
 {
@@ -425,17 +417,17 @@ void MessageDecoderBase::DecodeBinaryField(BaseField::ConstPtr&& pstMessageDataT
     case DATA_TYPE::HEXBYTE: [[fallthrough]];
     case DATA_TYPE::UCHAR: vIntermediateFormat_.emplace_back(static_cast<uint8_t>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
     case DATA_TYPE::CHAR: vIntermediateFormat_.emplace_back(static_cast<int8_t>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
-    case DATA_TYPE::USHORT: vIntermediateFormat_.emplace_back(loadValueFromBuffer<uint16_t>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
-    case DATA_TYPE::SHORT: vIntermediateFormat_.emplace_back(loadValueFromBuffer<int16_t>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::USHORT: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<uint16_t>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::SHORT: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<int16_t>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
     case DATA_TYPE::UINT: [[fallthrough]];
     case DATA_TYPE::SATELLITEID: [[fallthrough]];
-    case DATA_TYPE::ULONG: vIntermediateFormat_.emplace_back(loadValueFromBuffer<uint32_t>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::ULONG: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<uint32_t>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
     case DATA_TYPE::INT: [[fallthrough]];
-    case DATA_TYPE::LONG: vIntermediateFormat_.emplace_back(loadValueFromBuffer<int32_t>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
-    case DATA_TYPE::ULONGLONG: vIntermediateFormat_.emplace_back(loadValueFromBuffer<uint64_t>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
-    case DATA_TYPE::LONGLONG: vIntermediateFormat_.emplace_back(loadValueFromBuffer<int64_t>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
-    case DATA_TYPE::FLOAT: vIntermediateFormat_.emplace_back(loadValueFromBuffer<float>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
-    case DATA_TYPE::DOUBLE: vIntermediateFormat_.emplace_back(loadValueFromBuffer<double>(ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::LONG: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<int32_t>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::ULONGLONG: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<uint64_t>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::LONGLONG: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<int64_t>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::FLOAT: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<float>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::DOUBLE: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<double>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
     default: throw std::runtime_error("DecodeBinaryField(): Unknown field type\n");
     }
 
@@ -469,8 +461,8 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
         case FIELD_TYPE::ENUM:
             switch (field->dataType.length)
             {
-            case 2: vIntermediateFormat_.emplace_back(loadValueFromBuffer<int16_t>(ppucLogBuf_), field); break;
-            case 4: vIntermediateFormat_.emplace_back(loadValueFromBuffer<int32_t>(ppucLogBuf_), field); break;
+            case 2: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<int16_t>(*ppucLogBuf_), field); break;
+            case 4: vIntermediateFormat_.emplace_back(LoadValueFromBuffer<int32_t>(*ppucLogBuf_), field); break;
             default:
                 SPDLOG_LOGGER_CRITICAL(pclMyLogger, "DecodeBinary(): Invalid field length\n");
                 throw std::runtime_error("DecodeBinary(): Invalid field length\n");
@@ -478,7 +470,7 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
             *ppucLogBuf_ += field->dataType.length;
             break;
         case FIELD_TYPE::RESPONSE_ID:
-            vIntermediateFormat_.emplace_back(loadValueFromBuffer<int32_t>(ppucLogBuf_), field);
+            vIntermediateFormat_.emplace_back(LoadValueFromBuffer<int32_t>(*ppucLogBuf_), field);
             *ppucLogBuf_ += sizeof(int32_t);
             break;
         case FIELD_TYPE::RESPONSE_STR: {

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -413,27 +413,61 @@ void MessageDecoderBase::DecodeBinaryField(BaseField::ConstPtr&& pstMessageDataT
 {
     switch (pstMessageDataType_->dataType.name)
     {
-    case DATA_TYPE::BOOL: vIntermediateFormat_.emplace_back(*reinterpret_cast<const bool*>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::BOOL: vIntermediateFormat_.emplace_back(static_cast<const bool>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
     case DATA_TYPE::HEXBYTE: [[fallthrough]];
-    case DATA_TYPE::UCHAR: vIntermediateFormat_.emplace_back(*reinterpret_cast<const uint8_t*>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
-    case DATA_TYPE::CHAR: vIntermediateFormat_.emplace_back(*reinterpret_cast<const int8_t*>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
-    case DATA_TYPE::USHORT:
-        vIntermediateFormat_.emplace_back(*reinterpret_cast<const uint16_t*>(*ppucLogBuf_), std::move(pstMessageDataType_));
+    case DATA_TYPE::UCHAR: vIntermediateFormat_.emplace_back(static_cast<const uint8_t>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::CHAR: vIntermediateFormat_.emplace_back(static_cast<const int8_t>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::USHORT: {
+        uint16_t uiVal;
+        std::memcpy(&uiVal, *ppucLogBuf_, sizeof(uint16_t));
+        vIntermediateFormat_.emplace_back(uiVal, std::move(pstMessageDataType_));
         break;
-    case DATA_TYPE::SHORT: vIntermediateFormat_.emplace_back(*reinterpret_cast<const int16_t*>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    }
+    case DATA_TYPE::SHORT: {
+        int16_t iVal;
+        std::memcpy(&iVal, *ppucLogBuf_, sizeof(int16_t));
+        vIntermediateFormat_.emplace_back(iVal, std::move(pstMessageDataType_));
+        break;
+    }
     case DATA_TYPE::UINT: [[fallthrough]];
     case DATA_TYPE::SATELLITEID: [[fallthrough]];
-    case DATA_TYPE::ULONG: vIntermediateFormat_.emplace_back(*reinterpret_cast<const uint32_t*>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::ULONG: {
+        uint32_t uiVal;
+        std::memcpy(&uiVal, *ppucLogBuf_, sizeof(uint32_t));
+        vIntermediateFormat_.emplace_back(uiVal, std::move(pstMessageDataType_));
+        break;
+    }
     case DATA_TYPE::INT: [[fallthrough]];
-    case DATA_TYPE::LONG: vIntermediateFormat_.emplace_back(*reinterpret_cast<const int32_t*>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
-    case DATA_TYPE::ULONGLONG:
-        vIntermediateFormat_.emplace_back(*reinterpret_cast<const uint64_t*>(*ppucLogBuf_), std::move(pstMessageDataType_));
+    case DATA_TYPE::LONG: {
+        int32_t iVal;
+        std::memcpy(&iVal, *ppucLogBuf_, sizeof(int32_t));
+        vIntermediateFormat_.emplace_back(iVal, std::move(pstMessageDataType_));
         break;
-    case DATA_TYPE::LONGLONG:
-        vIntermediateFormat_.emplace_back(*reinterpret_cast<const int64_t*>(*ppucLogBuf_), std::move(pstMessageDataType_));
+    }
+    case DATA_TYPE::ULONGLONG: {
+        uint64_t uiVal;
+        std::memcpy(&uiVal, *ppucLogBuf_, sizeof(uint64_t));
+        vIntermediateFormat_.emplace_back(uiVal, std::move(pstMessageDataType_));
         break;
-    case DATA_TYPE::FLOAT: vIntermediateFormat_.emplace_back(*reinterpret_cast<const float*>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
-    case DATA_TYPE::DOUBLE: vIntermediateFormat_.emplace_back(*reinterpret_cast<const double*>(*ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    }
+    case DATA_TYPE::LONGLONG: {
+        int64_t iVal;
+        std::memcpy(&iVal, *ppucLogBuf_, sizeof(int64_t));
+        vIntermediateFormat_.emplace_back(iVal, std::move(pstMessageDataType_));
+        break;
+    }
+    case DATA_TYPE::FLOAT: {
+        float fVal;
+        std::memcpy(&fVal, *ppucLogBuf_, sizeof(float));
+        vIntermediateFormat_.emplace_back(fVal, std::move(pstMessageDataType_));
+        break;
+    }
+    case DATA_TYPE::DOUBLE: {
+        double dVal;
+        std::memcpy(&dVal, *ppucLogBuf_, sizeof(double));
+        vIntermediateFormat_.emplace_back(dVal, std::move(pstMessageDataType_));
+        break;
+    }
     default: throw std::runtime_error("DecodeBinaryField(): Unknown field type\n");
     }
 
@@ -467,19 +501,31 @@ MessageDecoderBase::DecodeBinary(const std::vector<BaseField::Ptr>& vMsgDefField
         case FIELD_TYPE::ENUM:
             switch (field->dataType.length)
             {
-            case 1: vIntermediateFormat_.emplace_back(*reinterpret_cast<const std::int8_t*>(*ppucLogBuf_), field); break;
-            case 2: vIntermediateFormat_.emplace_back(*reinterpret_cast<const std::int16_t*>(*ppucLogBuf_), field); break;
-            case 4: vIntermediateFormat_.emplace_back(*reinterpret_cast<const std::int32_t*>(*ppucLogBuf_), field); break;
+            case 2: {
+                int16_t iVal;
+                std::memcpy(&iVal, *ppucLogBuf_, sizeof(int16_t));
+                vIntermediateFormat_.emplace_back(iVal, field);
+                break;
+            }
+            case 4: {
+                int32_t iVal;
+                std::memcpy(&iVal, *ppucLogBuf_, sizeof(int32_t));
+                vIntermediateFormat_.emplace_back(iVal, field);
+                break;
+            }
             default:
                 SPDLOG_LOGGER_CRITICAL(pclMyLogger, "DecodeBinary(): Invalid field length\n");
                 throw std::runtime_error("DecodeBinary(): Invalid field length\n");
             }
             *ppucLogBuf_ += field->dataType.length;
             break;
-        case FIELD_TYPE::RESPONSE_ID:
-            vIntermediateFormat_.emplace_back(*reinterpret_cast<const std::int32_t*>(*ppucLogBuf_), field);
+        case FIELD_TYPE::RESPONSE_ID: {
+            int32_t iVal;
+            std::memcpy(&iVal, *ppucLogBuf_, sizeof(int32_t));
+            vIntermediateFormat_.emplace_back(iVal, field);
             *ppucLogBuf_ += sizeof(int32_t);
             break;
+        }
         case FIELD_TYPE::RESPONSE_STR: {
             std::string_view sTemp(reinterpret_cast<const char*>(*ppucLogBuf_), uiMessageLength_ - sizeof(int32_t)); // Remove CRC
             vIntermediateFormat_.emplace_back(std::string(sTemp), field);
@@ -1016,17 +1062,21 @@ MessageDecoderBase::Decode(const unsigned char* pucMessage_, std::vector<FieldCo
     switch (stMetaData_.eFormat)
     {
     case HEADER_FORMAT::ASCII: [[fallthrough]];
-    case HEADER_FORMAT::SHORT_ASCII: //
-        return DecodeAscii<false>(msgFields, reinterpret_cast<const char**>(&pucTempInData), stInterMessage_,
+    case HEADER_FORMAT::SHORT_ASCII: {
+        const auto* pcTempInData = reinterpret_cast<const char*>(pucTempInData);
+        return DecodeAscii<false>(msgFields, &pcTempInData, stInterMessage_,
                                   stMetaData_.uiLength > stMetaData_.uiHeaderLength
-                                      ? reinterpret_cast<const char*>(pucTempInData) + stMetaData_.uiLength - stMetaData_.uiHeaderLength
+                                      ? pcTempInData + stMetaData_.uiLength - stMetaData_.uiHeaderLength
                                       : nullptr);
+    }
     case HEADER_FORMAT::ABB_ASCII: [[fallthrough]];
-    case HEADER_FORMAT::SHORT_ABB_ASCII: //
-        return DecodeAscii<true>(msgFields, reinterpret_cast<const char**>(&pucTempInData), stInterMessage_,
+    case HEADER_FORMAT::SHORT_ABB_ASCII: {
+        const auto* pcTempInData = reinterpret_cast<const char*>(pucTempInData);
+        return DecodeAscii<true>(msgFields, &pcTempInData, stInterMessage_,
                                  stMetaData_.uiLength > stMetaData_.uiHeaderLength
-                                     ? reinterpret_cast<const char*>(pucTempInData) + stMetaData_.uiLength - stMetaData_.uiHeaderLength
+                                     ? pcTempInData + stMetaData_.uiLength - stMetaData_.uiHeaderLength
                                      : nullptr);
+    }
     case HEADER_FORMAT::BINARY: [[fallthrough]];
     case HEADER_FORMAT::SHORT_BINARY: //
         return DecodeBinary(msgFields, &pucTempInData, stInterMessage_, stMetaData_.uiBinaryMsgLength);

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -1065,17 +1065,15 @@ MessageDecoderBase::Decode(const unsigned char* pucMessage_, std::vector<FieldCo
     case HEADER_FORMAT::SHORT_ASCII: {
         const auto* pcTempInData = reinterpret_cast<const char*>(pucTempInData);
         return DecodeAscii<false>(msgFields, &pcTempInData, stInterMessage_,
-                                  stMetaData_.uiLength > stMetaData_.uiHeaderLength
-                                      ? pcTempInData + stMetaData_.uiLength - stMetaData_.uiHeaderLength
-                                      : nullptr);
+                                  stMetaData_.uiLength > stMetaData_.uiHeaderLength ? pcTempInData + stMetaData_.uiLength - stMetaData_.uiHeaderLength
+                                                                                    : nullptr);
     }
     case HEADER_FORMAT::ABB_ASCII: [[fallthrough]];
     case HEADER_FORMAT::SHORT_ABB_ASCII: {
         const auto* pcTempInData = reinterpret_cast<const char*>(pucTempInData);
         return DecodeAscii<true>(msgFields, &pcTempInData, stInterMessage_,
-                                 stMetaData_.uiLength > stMetaData_.uiHeaderLength
-                                     ? pcTempInData + stMetaData_.uiLength - stMetaData_.uiHeaderLength
-                                     : nullptr);
+                                 stMetaData_.uiLength > stMetaData_.uiHeaderLength ? pcTempInData + stMetaData_.uiLength - stMetaData_.uiHeaderLength
+                                                                                   : nullptr);
     }
     case HEADER_FORMAT::BINARY: [[fallthrough]];
     case HEADER_FORMAT::SHORT_BINARY: //

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -413,10 +413,10 @@ void MessageDecoderBase::DecodeBinaryField(BaseField::ConstPtr&& pstMessageDataT
 {
     switch (pstMessageDataType_->dataType.name)
     {
-    case DATA_TYPE::BOOL: vIntermediateFormat_.emplace_back(static_cast<const bool>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::BOOL: vIntermediateFormat_.emplace_back(static_cast<bool>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
     case DATA_TYPE::HEXBYTE: [[fallthrough]];
-    case DATA_TYPE::UCHAR: vIntermediateFormat_.emplace_back(static_cast<const uint8_t>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
-    case DATA_TYPE::CHAR: vIntermediateFormat_.emplace_back(static_cast<const int8_t>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::UCHAR: vIntermediateFormat_.emplace_back(static_cast<uint8_t>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
+    case DATA_TYPE::CHAR: vIntermediateFormat_.emplace_back(static_cast<int8_t>(**ppucLogBuf_), std::move(pstMessageDataType_)); break;
     case DATA_TYPE::USHORT: {
         uint16_t uiVal;
         std::memcpy(&uiVal, *ppucLogBuf_, sizeof(uint16_t));

--- a/src/decoders/oem/src/commander.cpp
+++ b/src/decoders/oem/src/commander.cpp
@@ -133,8 +133,8 @@ STATUS Commander::Encode(const char* pcAbbrevAsciiCommand_, const uint32_t uiAbb
     stIntermediateHeader.uiMessageDefinitionCrc = stMetaData.uiMessageCrc;
 
     auto* pucEncodeBuffer = reinterpret_cast<unsigned char*>(pcEncodeBuffer_);
-    eStatus = clMyEncoder.Encode(&pucEncodeBuffer, uiEncodeBufferSize_, stIntermediateHeader,
-                                 stIntermediateMessage, stMessageData, stMetaData.eFormat, eEncodeFormat_);
+    eStatus = clMyEncoder.Encode(&pucEncodeBuffer, uiEncodeBufferSize_, stIntermediateHeader, stIntermediateMessage, stMessageData,
+                                 stMetaData.eFormat, eEncodeFormat_);
 
     if (eStatus != STATUS::SUCCESS) { return eStatus; }
 
@@ -188,8 +188,8 @@ STATUS Commander::Encode(const MessageDatabase& clJsonDb_, const MessageDecoder&
     stIntermediateHeader.uiMessageDefinitionCrc = stMetaData.uiMessageCrc;
 
     auto* pucEncodeBuffer = reinterpret_cast<unsigned char*>(pcEncodeBuffer_);
-    const STATUS eEncoderStatus = clEncoder_.Encode(&pucEncodeBuffer, uiEncodeBufferSize_, stIntermediateHeader,
-                                                    stIntermediateMessage, stMessageData, stMetaData.eFormat, eEncodeFormat_);
+    const STATUS eEncoderStatus = clEncoder_.Encode(&pucEncodeBuffer, uiEncodeBufferSize_, stIntermediateHeader, stIntermediateMessage, stMessageData,
+                                                    stMetaData.eFormat, eEncodeFormat_);
 
     if (eEncoderStatus != STATUS::SUCCESS) { return eEncoderStatus; }
 

--- a/src/decoders/oem/src/commander.cpp
+++ b/src/decoders/oem/src/commander.cpp
@@ -132,7 +132,8 @@ STATUS Commander::Encode(const char* pcAbbrevAsciiCommand_, const uint32_t uiAbb
     stIntermediateHeader.usMessageId = stMetaData.usMessageId;
     stIntermediateHeader.uiMessageDefinitionCrc = stMetaData.uiMessageCrc;
 
-    eStatus = clMyEncoder.Encode(reinterpret_cast<unsigned char**>(&pcEncodeBuffer_), uiEncodeBufferSize_, stIntermediateHeader,
+    auto* pucEncodeBuffer = reinterpret_cast<unsigned char*>(pcEncodeBuffer_);
+    eStatus = clMyEncoder.Encode(&pucEncodeBuffer, uiEncodeBufferSize_, stIntermediateHeader,
                                  stIntermediateMessage, stMessageData, stMetaData.eFormat, eEncodeFormat_);
 
     if (eStatus != STATUS::SUCCESS) { return eStatus; }
@@ -186,7 +187,8 @@ STATUS Commander::Encode(const MessageDatabase& clJsonDb_, const MessageDecoder&
     stIntermediateHeader.usMessageId = stMetaData.usMessageId;
     stIntermediateHeader.uiMessageDefinitionCrc = stMetaData.uiMessageCrc;
 
-    const STATUS eEncoderStatus = clEncoder_.Encode(reinterpret_cast<unsigned char**>(&pcEncodeBuffer_), uiEncodeBufferSize_, stIntermediateHeader,
+    auto* pucEncodeBuffer = reinterpret_cast<unsigned char*>(pcEncodeBuffer_);
+    const STATUS eEncoderStatus = clEncoder_.Encode(&pucEncodeBuffer, uiEncodeBufferSize_, stIntermediateHeader,
                                                     stIntermediateMessage, stMessageData, stMetaData.eFormat, eEncodeFormat_);
 
     if (eEncoderStatus != STATUS::SUCCESS) { return eEncoderStatus; }

--- a/src/decoders/oem/src/encoder.cpp
+++ b/src/decoders/oem/src/encoder.cpp
@@ -79,12 +79,12 @@ void Encoder::InitFieldMaps()
     asciiFieldMap[CalculateBlockCrc32("B")] = BasicIntMapEntry<int8_t>();
     asciiFieldMap[CalculateBlockCrc32("XB")] = BasicHexMapEntry<uint8_t>(2);
 
-    asciiFieldMap[CalculateBlockCrc32("x")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("x")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        if (fc_.fieldDef->dataType.length == 1) { return WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue), 2); }
-        if (fc_.fieldDef->dataType.length == 2) { return WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint16_t>(fc_.fieldValue), 4); }
-        if (fc_.fieldDef->dataType.length == 4) { return WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue), 8); }
-        if (fc_.fieldDef->dataType.length == 8) { return WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint64_t>(fc_.fieldValue), 16); }
+        if (fc_.fieldDef->dataType.length == 1) { return WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue), 2); }
+        if (fc_.fieldDef->dataType.length == 2) { return WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint16_t>(fc_.fieldValue), 4); }
+        if (fc_.fieldDef->dataType.length == 4) { return WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue), 8); }
+        if (fc_.fieldDef->dataType.length == 8) { return WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint64_t>(fc_.fieldValue), 16); }
         return false;
     };
 
@@ -92,34 +92,34 @@ void Encoder::InitFieldMaps()
     asciiFieldMap[CalculateBlockCrc32("lx")] = BasicHexMapEntry<uint32_t>(8);
     asciiFieldMap[CalculateBlockCrc32("llx")] = BasicHexMapEntry<uint64_t>(16);
 
-    asciiFieldMap[CalculateBlockCrc32("s")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("s")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         return fc_.fieldDef->dataType.name == DATA_TYPE::UCHAR
-                   ? CopyToBuffer(ppcOutBuf_, uiBytesLeft_, static_cast<char>(std::get<uint8_t>(fc_.fieldValue)))
-                   : CopyToBuffer(ppcOutBuf_, uiBytesLeft_, static_cast<char>(std::get<int8_t>(fc_.fieldValue)));
+                   ? CopyToBuffer(ppucOutBuf_, uiBytesLeft_, static_cast<char>(std::get<uint8_t>(fc_.fieldValue)))
+                   : CopyToBuffer(ppucOutBuf_, uiBytesLeft_, static_cast<char>(std::get<int8_t>(fc_.fieldValue)));
     };
 
-    asciiFieldMap[CalculateBlockCrc32("m")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("m")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, pclMsgDb_.MsgIdToMsgName(std::get<uint32_t>(fc_.fieldValue)).c_str());
+        return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, pclMsgDb_.MsgIdToMsgName(std::get<uint32_t>(fc_.fieldValue)).c_str());
     };
 
-    asciiFieldMap[CalculateBlockCrc32("T")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("T")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue) / 1000.0, std::chars_format::fixed, 3);
+        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue) / 1000.0, std::chars_format::fixed, 3);
     };
 
-    asciiFieldMap[CalculateBlockCrc32("id")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("id")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                   [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         const uint32_t uiTempId = std::get<uint32_t>(fc_.fieldValue);
         const uint16_t usSv = uiTempId & 0x0000FFFF;
         const int16_t sGloChan = (uiTempId & 0xFFFF0000) >> 16;
-        return (sGloChan < 0)    ? CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, usSv, sGloChan)
-               : (sGloChan != 0) ? CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, usSv, '+', sGloChan)
-                                 : WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, usSv);
+        return (sGloChan < 0)    ? CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, usSv, sGloChan)
+               : (sGloChan != 0) ? CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, usSv, '+', sGloChan)
+                                 : WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, usSv);
     };
 
-    asciiFieldMap[CalculateBlockCrc32("P")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("P")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         // Allow signed integers to be used but interpret them as if they were unsigned
         // If all logs with %P version strings are updated to use an unsigned DATA_TYPE this can be removed
@@ -127,39 +127,39 @@ void Encoder::InitFieldMaps()
         if (std::holds_alternative<int8_t>(fc_.fieldValue)) { uiValue = static_cast<uint8_t>(std::get<int8_t>(fc_.fieldValue)); }
         else { uiValue = std::get<uint8_t>(fc_.fieldValue); }
 
-        if (uiValue == '\\') { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\\\\"); }
-        if (uiValue > 31 && uiValue < 127) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, static_cast<char>(uiValue)); }
-        return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\\x") && WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, uiValue, 2);
+        if (uiValue == '\\') { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\\\\"); }
+        if (uiValue > 31 && uiValue < 127) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, static_cast<char>(uiValue)); }
+        return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\\x") && WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, uiValue, 2);
     };
 
-    asciiFieldMap[CalculateBlockCrc32("f")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("f")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         if (fc_.fieldDef->dataType.length == 4)
         {
-            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
+            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
         }
         if (fc_.fieldDef->dataType.length == 8)
         {
-            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
+            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
         }
         return false;
     };
 
-    asciiFieldMap[CalculateBlockCrc32("lf")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("lf")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                   [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
+        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
     };
 
-    asciiFieldMap[CalculateBlockCrc32("e")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("e")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         if (fc_.fieldDef->dataType.length == 4)
         {
-            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::scientific,
+            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::scientific,
                                       fc_.fieldDef->precision);
         }
         if (fc_.fieldDef->dataType.length == 8)
         {
-            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::scientific,
+            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::scientific,
                                       fc_.fieldDef->precision);
         }
         return false;
@@ -167,27 +167,27 @@ void Encoder::InitFieldMaps()
 
     asciiFieldMap[CalculateBlockCrc32("le")] = asciiFieldMap[CalculateBlockCrc32("e")];
 
-    asciiFieldMap[CalculateBlockCrc32("k")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("k")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
+        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
                                   fc_.fieldDef->precision);
     };
 
-    asciiFieldMap[CalculateBlockCrc32("lk")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("lk")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                   [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
+        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
                                   fc_.fieldDef->precision);
     };
 
-    asciiFieldMap[CalculateBlockCrc32("c")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("c")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         if (fc_.fieldDef->dataType.length == 1)
         {
-            return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, static_cast<char>(std::get<uint8_t>(fc_.fieldValue)));
+            return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, static_cast<char>(std::get<uint8_t>(fc_.fieldValue)));
         }
         if (fc_.fieldDef->dataType.length == 4 && fc_.fieldDef->dataType.name == DATA_TYPE::ULONG)
         {
-            return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, static_cast<char>(std::get<uint32_t>(fc_.fieldValue)));
+            return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, static_cast<char>(std::get<uint32_t>(fc_.fieldValue)));
         }
         return false;
     };
@@ -197,54 +197,54 @@ void Encoder::InitFieldMaps()
     // =========================================================
     jsonFieldMap[CalculateBlockCrc32("P")] = BasicIntMapEntry<uint8_t>();
 
-    jsonFieldMap[CalculateBlockCrc32("T")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("T")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue) / 1000.0, std::chars_format::fixed, 3);
+        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue) / 1000.0, std::chars_format::fixed, 3);
     };
 
-    jsonFieldMap[CalculateBlockCrc32("m")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("m")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(pclMsgDb_.MsgIdToMsgName(std::get<uint32_t>(fc_.fieldValue))), '"');
+        return CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(pclMsgDb_.MsgIdToMsgName(std::get<uint32_t>(fc_.fieldValue))), '"');
     };
 
-    jsonFieldMap[CalculateBlockCrc32("id")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("id")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         const auto uiTempId = std::get<uint32_t>(fc_.fieldValue);
         const uint16_t usSv = uiTempId & 0x0000FFFF;
         const int16_t sGloChan = (uiTempId & 0xFFFF0000) >> 16;
-        return (sGloChan < 0)    ? CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', usSv, sGloChan, '"')
-               : (sGloChan != 0) ? CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', usSv, '+', sGloChan, '"')
-                                 : CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', usSv, '"');
+        return (sGloChan < 0)    ? CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', usSv, sGloChan, '"')
+               : (sGloChan != 0) ? CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', usSv, '+', sGloChan, '"')
+                                 : CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', usSv, '"');
     };
 
-    jsonFieldMap[CalculateBlockCrc32("f")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("f")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         if (fc_.fieldDef->dataType.length == 4)
         {
-            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
+            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
         }
         if (fc_.fieldDef->dataType.length == 8)
         {
-            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
+            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
         }
         return false;
     };
 
-    jsonFieldMap[CalculateBlockCrc32("lf")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("lf")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
+        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
     };
 
-    jsonFieldMap[CalculateBlockCrc32("e")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("e")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         if (fc_.fieldDef->dataType.length == 4)
         {
-            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::scientific,
+            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::scientific,
                                       fc_.fieldDef->precision);
         }
         if (fc_.fieldDef->dataType.length == 8)
         {
-            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::scientific,
+            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::scientific,
                                       fc_.fieldDef->precision);
         }
         return false;
@@ -252,72 +252,72 @@ void Encoder::InitFieldMaps()
 
     jsonFieldMap[CalculateBlockCrc32("le")] = jsonFieldMap[CalculateBlockCrc32("e")];
 
-    jsonFieldMap[CalculateBlockCrc32("k")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("k")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
+        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
                                   fc_.fieldDef->precision);
     };
 
-    jsonFieldMap[CalculateBlockCrc32("lk")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("lk")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
+        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
                                   fc_.fieldDef->precision);
     };
 
-    jsonFieldMap[CalculateBlockCrc32("s")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("s")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return CopyToBuffer(ppcOutBuf_, uiBytesLeft_,
+        return CopyToBuffer(ppucOutBuf_, uiBytesLeft_,
                             fc_.fieldDef->dataType.name == DATA_TYPE::UCHAR ? static_cast<char>(std::get<uint8_t>(fc_.fieldValue))
                                                                             : static_cast<char>(std::get<int8_t>(fc_.fieldValue)));
     };
 
-    jsonFieldMap[CalculateBlockCrc32("c")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("c")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         if (fc_.fieldDef->dataType.length == 1)
         {
-            return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', static_cast<char>(std::get<uint8_t>(fc_.fieldValue)), '"');
+            return CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', static_cast<char>(std::get<uint8_t>(fc_.fieldValue)), '"');
         }
         if (fc_.fieldDef->dataType.length == 4 && fc_.fieldDef->dataType.name == DATA_TYPE::ULONG)
         {
-            return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', static_cast<char>(std::get<uint32_t>(fc_.fieldValue)), '"');
+            return CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', static_cast<char>(std::get<uint32_t>(fc_.fieldValue)), '"');
         }
         return false;
     };
 }
 
-bool Encoder::FieldToBinary(const FieldContainer& fc_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_)
+bool Encoder::FieldToBinary(const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_)
 {
-    if (const auto* pValue = std::get_if<uint8_t>(&fc_.fieldValue)) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, *pValue); }
-    if (const auto* pValue = std::get_if<float>(&fc_.fieldValue)) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, *pValue); }
-    if (const auto* pValue = std::get_if<double>(&fc_.fieldValue)) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, *pValue); }
-    if (const auto* pValue = std::get_if<bool>(&fc_.fieldValue)) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, static_cast<int32_t>(*pValue)); }
-    if (const auto* pValue = std::get_if<int8_t>(&fc_.fieldValue)) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, *pValue); }
-    if (const auto* pValue = std::get_if<int16_t>(&fc_.fieldValue)) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, *pValue); }
-    if (const auto* pValue = std::get_if<int32_t>(&fc_.fieldValue)) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, *pValue); }
-    if (const auto* pValue = std::get_if<int64_t>(&fc_.fieldValue)) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, *pValue); }
-    if (const auto* pValue = std::get_if<uint16_t>(&fc_.fieldValue)) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, *pValue); }
-    if (const auto* pValue = std::get_if<uint32_t>(&fc_.fieldValue)) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, *pValue); }
-    if (const auto* pValue = std::get_if<uint64_t>(&fc_.fieldValue)) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, *pValue); }
+    if (const auto* pValue = std::get_if<uint8_t>(&fc_.fieldValue)) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, *pValue); }
+    if (const auto* pValue = std::get_if<float>(&fc_.fieldValue)) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, *pValue); }
+    if (const auto* pValue = std::get_if<double>(&fc_.fieldValue)) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, *pValue); }
+    if (const auto* pValue = std::get_if<bool>(&fc_.fieldValue)) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, static_cast<int32_t>(*pValue)); }
+    if (const auto* pValue = std::get_if<int8_t>(&fc_.fieldValue)) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, *pValue); }
+    if (const auto* pValue = std::get_if<int16_t>(&fc_.fieldValue)) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, *pValue); }
+    if (const auto* pValue = std::get_if<int32_t>(&fc_.fieldValue)) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, *pValue); }
+    if (const auto* pValue = std::get_if<int64_t>(&fc_.fieldValue)) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, *pValue); }
+    if (const auto* pValue = std::get_if<uint16_t>(&fc_.fieldValue)) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, *pValue); }
+    if (const auto* pValue = std::get_if<uint32_t>(&fc_.fieldValue)) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, *pValue); }
+    if (const auto* pValue = std::get_if<uint64_t>(&fc_.fieldValue)) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, *pValue); }
 
     throw std::runtime_error("Unsupported field type");
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeBinaryHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_)
+bool Encoder::EncodeBinaryHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_)
 {
-    return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, Oem4BinaryHeader(stInterHeader_));
+    return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, Oem4BinaryHeader(stInterHeader_));
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeBinaryShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppcOutBuf_, uint32_t& uiBytesLeft_)
+bool Encoder::EncodeBinaryShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_)
 {
-    return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, Oem4BinaryShortHeader(stInterHeader_));
+    return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, Oem4BinaryShortHeader(stInterHeader_));
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
+bool Encoder::EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
 {
-    if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_ASCII_SYNC)) { return false; }
+    if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_ASCII_SYNC)) { return false; }
 
     MessageDefinition::ConstPtr pclMessageDef = pclMyMsgDb->GetMsgDef(stInterHeader_.usMessageId);
     std::string sMsgName(pclMessageDef != nullptr ? pclMessageDef->name : GetEnumString(vMyCommandDefinitions, stInterHeader_.usMessageId));
@@ -325,7 +325,7 @@ bool Encoder::EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, char**
     sMsgName.push_back(uiResponse != 0U ? 'R' : 'A'); // Append 'A' for ascii, or 'R' for ascii response
     AppendSiblingId(sMsgName, stInterHeader_);
 
-    return CopyAllToBufferSeparated(ppcOutBuf_, uiBytesLeft_, OEM4_ASCII_FIELD_SEPARATOR,
+    return CopyAllToBufferSeparated(ppucOutBuf_, uiBytesLeft_, OEM4_ASCII_FIELD_SEPARATOR,
                                     std::string_view(sMsgName),                                                                             //
                                     GetEnumString(vMyPortAddressDefinitions, stInterHeader_.uiPortAddress),                                 //
                                     stInterHeader_.usSequence,                                                                              //
@@ -337,19 +337,19 @@ bool Encoder::EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, char**
                                     HexValue<uint32_t>{stInterHeader_.uiMessageDefinitionCrc, 4},                                           //
                                     stInterHeader_.usReceiverSwVersion                                                                      //
                                     ) &&
-           CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_ASCII_HEADER_TERMINATOR);
+           CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_ASCII_HEADER_TERMINATOR);
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeAbbrevAsciiHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_, bool bIsEmbedded_) const
+bool Encoder::EncodeAbbrevAsciiHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_, bool bIsEmbedded_) const
 {
-    if (!bIsEmbedded_ && !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SYNC)) { return false; }
+    if (!bIsEmbedded_ && !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SYNC)) { return false; }
 
     MessageDefinition::ConstPtr pclMessageDef = pclMyMsgDb->GetMsgDef(stInterHeader_.usMessageId);
     std::string sMsgName(pclMessageDef != nullptr ? pclMessageDef->name : GetEnumString(vMyCommandDefinitions, stInterHeader_.usMessageId));
     AppendSiblingId(sMsgName, stInterHeader_);
 
-    return CopyAllToBufferSeparated(ppcOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR,
+    return CopyAllToBufferSeparated(ppucOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR,
                                     std::string_view(sMsgName),                                                                             //
                                     GetEnumString(vMyPortAddressDefinitions, stInterHeader_.uiPortAddress),                                 //
                                     stInterHeader_.usSequence,                                                                              //
@@ -361,41 +361,41 @@ bool Encoder::EncodeAbbrevAsciiHeader(const IntermediateHeader& stInterHeader_, 
                                     HexValue<uint32_t>{stInterHeader_.uiMessageDefinitionCrc, 4},                                           //
                                     stInterHeader_.usReceiverSwVersion                                                                      //
                                     ) &&
-           (bIsEmbedded_ ? CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR) : CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\r\n"));
+           (bIsEmbedded_ ? CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR) : CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\r\n"));
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeAsciiShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
+bool Encoder::EncodeAsciiShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
 {
-    if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_SHORT_ASCII_SYNC)) { return false; }
+    if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_SHORT_ASCII_SYNC)) { return false; }
 
     std::string sMsgName(pclMyMsgDb->GetMsgDef(stInterHeader_.usMessageId)->name);
     const uint32_t uiResponse = (stInterHeader_.ucMessageType & static_cast<uint32_t>(MESSAGE_TYPE_MASK::RESPONSE)) >> 7;
     sMsgName.push_back(uiResponse != 0U ? 'R' : 'A'); // Append 'A' for ascii, or 'R' for ascii response
     AppendSiblingId(sMsgName, stInterHeader_);
 
-    return CopyAllToBufferSeparated(ppcOutBuf_, uiBytesLeft_, OEM4_ASCII_FIELD_SEPARATOR,                                  //
+    return CopyAllToBufferSeparated(ppucOutBuf_, uiBytesLeft_, OEM4_ASCII_FIELD_SEPARATOR,                                 //
                                     std::string_view(sMsgName),                                                            //
                                     stInterHeader_.usWeek,                                                                 //
                                     FloatValue<double>{stInterHeader_.dMilliseconds / 1000.0, std::chars_format::fixed, 3} //
                                     ) &&
-           CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_ASCII_HEADER_TERMINATOR);
+           CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_ASCII_HEADER_TERMINATOR);
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeAbbrevAsciiShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
+bool Encoder::EncodeAbbrevAsciiShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
 {
-    if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SYNC)) { return false; }
+    if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SYNC)) { return false; }
 
     std::string sMsgName(pclMyMsgDb->GetMsgDef(stInterHeader_.usMessageId)->name);
     AppendSiblingId(sMsgName, stInterHeader_);
 
-    return CopyAllToBufferSeparated(ppcOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR,                                 //
+    return CopyAllToBufferSeparated(ppucOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR,                                //
                                     std::string_view(sMsgName),                                                            //
                                     stInterHeader_.usWeek,                                                                 //
                                     FloatValue<double>{stInterHeader_.dMilliseconds / 1000.0, std::chars_format::fixed, 3} //
                                     ) &&
-           CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\r\n");
+           CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\r\n");
 }
 
 // -------------------------------------------------------------------------------------------------------
@@ -409,9 +409,9 @@ std::string Encoder::JsonHeaderToMsgName(const IntermediateHeader& stInterHeader
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeJsonHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
+bool Encoder::EncodeJsonHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
 {
-    return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_,                                                                //
+    return CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_,                                                               //
                            R"({"message": ")", JsonHeaderToMsgName(stInterHeader_).c_str(),                         //
                            R"(","id": )", stInterHeader_.usMessageId,                                               //
                            R"(,"port": ")", GetEnumString(vMyPortAddressDefinitions, stInterHeader_.uiPortAddress), //
@@ -427,9 +427,9 @@ bool Encoder::EncodeJsonHeader(const IntermediateHeader& stInterHeader_, char** 
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeJsonShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
+bool Encoder::EncodeJsonShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
 {
-    return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_,                                                                                    //
+    return CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_,                                                                                   //
                            R"({"message": ")", JsonHeaderToMsgName(stInterHeader_).c_str(),                                             //
                            R"(","id": )", stInterHeader_.usMessageId,                                                                   //
                            R"(,"week": )", stInterHeader_.usWeek,                                                                       //
@@ -439,7 +439,7 @@ bool Encoder::EncodeJsonShortHeader(const IntermediateHeader& stInterHeader_, ch
 
 // -------------------------------------------------------------------------------------------------------
 STATUS
-Encoder::Encode(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+Encoder::Encode(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                 const std::vector<FieldContainer>& stMessage_, MessageDataStruct& stMessageData_, HEADER_FORMAT eHeaderFormat_,
                 ENCODE_FORMAT eFormat_) const
 {
@@ -456,12 +456,12 @@ Encoder::Encode(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const Inter
 
     if (eFormat_ == ENCODE_FORMAT::ABBREV_ASCII && ((stHeader_.ucMessageType & static_cast<uint8_t>(MESSAGE_TYPE_MASK::RESPONSE)) != 0))
     {
-        if (!CopyToBuffer(reinterpret_cast<char**>(&pucTempEncodeBuffer), uiBufferSize_, "<")) { return STATUS::BUFFER_FULL; }
+        if (!CopyToBuffer(&pucTempEncodeBuffer, uiBufferSize_, "<")) { return STATUS::BUFFER_FULL; }
         stMessageData_.uiMessageHeaderLength = 1;
 
         auto sResponse = std::get<std::string>(stMessage_[1].fieldValue);
-        if (!CopyToBuffer(reinterpret_cast<char**>(&pucTempEncodeBuffer), uiBufferSize_, sResponse.c_str())) { return STATUS::BUFFER_FULL; }
-        if (!CopyToBuffer(reinterpret_cast<char**>(&pucTempEncodeBuffer), uiBufferSize_, "\r\n")) { return STATUS::BUFFER_FULL; }
+        if (!CopyToBuffer(&pucTempEncodeBuffer, uiBufferSize_, sResponse.c_str())) { return STATUS::BUFFER_FULL; }
+        if (!CopyToBuffer(&pucTempEncodeBuffer, uiBufferSize_, "\r\n")) { return STATUS::BUFFER_FULL; }
         stMessageData_.pucMessage = *ppucBuffer_;
         stMessageData_.uiMessageLength = pucTempEncodeBuffer - *ppucBuffer_;
         stMessageData_.uiMessageBodyLength = stMessageData_.uiMessageLength - stMessageData_.uiMessageHeaderLength;
@@ -496,7 +496,7 @@ Encoder::Encode(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const Inter
 
 // -------------------------------------------------------------------------------------------------------
 STATUS
-Encoder::EncodeHeader(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_, MessageDataStruct& stMessageData_,
+Encoder::EncodeHeader(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_, MessageDataStruct& stMessageData_,
                       const HEADER_FORMAT eHeaderFormat_, const ENCODE_FORMAT eFormat_, const bool bIsEmbeddedHeader_) const
 {
     if (ppucBuffer_ == nullptr || *ppucBuffer_ == nullptr) { return STATUS::NULL_PROVIDED; }
@@ -504,20 +504,19 @@ Encoder::EncodeHeader(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const
     if (pclMyMsgDb == nullptr) { return STATUS::NO_DATABASE; }
 
     unsigned char* pucTempBuffer = *ppucBuffer_;
-    auto** ppcTempBuffer = reinterpret_cast<char**>(&pucTempBuffer);
 
     switch (eFormat_)
     {
     case ENCODE_FORMAT::ASCII:
-        if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeAsciiShortHeader(stHeader_, ppcTempBuffer, uiBufferSize_)
-                                                : !EncodeAsciiHeader(stHeader_, ppcTempBuffer, uiBufferSize_))
+        if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeAsciiShortHeader(stHeader_, &pucTempBuffer, uiBufferSize_)
+                                                : !EncodeAsciiHeader(stHeader_, &pucTempBuffer, uiBufferSize_))
         {
             return STATUS::BUFFER_FULL;
         }
         break;
     case ENCODE_FORMAT::ABBREV_ASCII:
-        if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeAbbrevAsciiShortHeader(stHeader_, ppcTempBuffer, uiBufferSize_)
-                                                : !EncodeAbbrevAsciiHeader(stHeader_, ppcTempBuffer, uiBufferSize_, bIsEmbeddedHeader_))
+        if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeAbbrevAsciiShortHeader(stHeader_, &pucTempBuffer, uiBufferSize_)
+                                                : !EncodeAbbrevAsciiHeader(stHeader_, &pucTempBuffer, uiBufferSize_, bIsEmbeddedHeader_))
         {
             return STATUS::BUFFER_FULL;
         }
@@ -531,8 +530,8 @@ Encoder::EncodeHeader(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const
         }
         break;
     case ENCODE_FORMAT::JSON:
-        if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeJsonShortHeader(stHeader_, ppcTempBuffer, uiBufferSize_)
-                                                : !EncodeJsonHeader(stHeader_, ppcTempBuffer, uiBufferSize_))
+        if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeJsonShortHeader(stHeader_, &pucTempBuffer, uiBufferSize_)
+                                                : !EncodeJsonHeader(stHeader_, &pucTempBuffer, uiBufferSize_))
         {
             return STATUS::BUFFER_FULL;
         }
@@ -548,7 +547,7 @@ Encoder::EncodeHeader(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const
 
 // -------------------------------------------------------------------------------------------------------
 STATUS
-Encoder::EncodeBody(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const std::vector<FieldContainer>& stMessage_,
+Encoder::EncodeBody(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const std::vector<FieldContainer>& stMessage_,
                     MessageDataStruct& stMessageData_, const HEADER_FORMAT eHeaderFormat_, ENCODE_FORMAT eFormat_) const
 {
     // TODO: this entire function should be in common, only header stuff and map redefinitions belong in this file
@@ -556,22 +555,22 @@ Encoder::EncodeBody(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const s
 
     if (pclMyMsgDb == nullptr) { return STATUS::NO_DATABASE; }
 
-    unsigned char* pucTempBuffer = *ppucBuffer_;
+    auto* pucTempBuffer = *ppucBuffer_;
 
     switch (eFormat_)
     {
     case ENCODE_FORMAT::ASCII: {
-        if (!EncodeAsciiBody<false>(stMessage_, reinterpret_cast<char**>(&pucTempBuffer), uiBufferSize_)) { return STATUS::BUFFER_FULL; }
+        if (!EncodeAsciiBody<false>(stMessage_, &pucTempBuffer, uiBufferSize_)) { return STATUS::BUFFER_FULL; }
         pucTempBuffer--; // Remove last delimiter ','
         const uint32_t uiCrc = CalculateBlockCrc32(stMessageData_.pucMessageHeader + 1, pucTempBuffer - stMessageData_.pucMessageHeader - 1);
-        if (!CopyAllToBuffer(reinterpret_cast<char**>(&pucTempBuffer), uiBufferSize_, '*', HexValue<uint32_t>{uiCrc, 8}, "\r\n"))
+        if (!CopyAllToBuffer(&pucTempBuffer, uiBufferSize_, '*', HexValue<uint32_t>{uiCrc, 8}, "\r\n"))
         {
             return STATUS::BUFFER_FULL;
         }
         break;
     }
     case ENCODE_FORMAT::ABBREV_ASCII:
-        if (!EncodeAsciiBody<true>(stMessage_, reinterpret_cast<char**>(&pucTempBuffer), uiBufferSize_)) { return STATUS::BUFFER_FULL; }
+        if (!EncodeAsciiBody<true>(stMessage_, &pucTempBuffer, uiBufferSize_)) { return STATUS::BUFFER_FULL; }
         pucTempBuffer--; // Remove last delimiter ' '
         if (!CopyToBuffer(&pucTempBuffer, uiBufferSize_, "\r\n")) { return STATUS::BUFFER_FULL; }
         break;
@@ -591,11 +590,17 @@ Encoder::EncodeBody(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const s
         // TODO: this block of code below is what's blocking us from moving this function to common (can solve this with dynamic casting or CRTP?)
         if (!IsShortHeaderFormat(eHeaderFormat_))
         {
-            reinterpret_cast<Oem4BinaryHeader*>(stMessageData_.pucMessageHeader)->usLength = static_cast<uint16_t>(pucTempBuffer - *ppucBuffer_);
+            Oem4BinaryHeader stHeader;
+            std::memcpy(&stHeader, stMessageData_.pucMessageHeader, sizeof(Oem4BinaryHeader));
+            stHeader.usLength = static_cast<uint16_t>(pucTempBuffer - *ppucBuffer_);
+            std::memcpy(stMessageData_.pucMessageHeader, &stHeader, sizeof(Oem4BinaryHeader));
         }
         else
         {
-            reinterpret_cast<Oem4BinaryShortHeader*>(stMessageData_.pucMessageHeader)->ucLength = static_cast<uint8_t>(pucTempBuffer - *ppucBuffer_);
+            Oem4BinaryShortHeader stShortHeader;
+            std::memcpy(&stShortHeader, stMessageData_.pucMessageHeader, sizeof(Oem4BinaryShortHeader));
+            stShortHeader.ucLength = static_cast<uint8_t>(pucTempBuffer - *ppucBuffer_);
+            std::memcpy(stMessageData_.pucMessageHeader, &stShortHeader, sizeof(Oem4BinaryShortHeader));
         }
         if (!CopyToBuffer(&pucTempBuffer, uiBufferSize_,
                           CalculateBlockCrc32(stMessageData_.pucMessageHeader, pucTempBuffer - stMessageData_.pucMessageHeader)))
@@ -605,7 +610,7 @@ Encoder::EncodeBody(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const s
         break;
     }
     case ENCODE_FORMAT::JSON:
-        if (!EncodeJsonBody(stMessage_, reinterpret_cast<char**>(&pucTempBuffer), uiBufferSize_)) { return STATUS::BUFFER_FULL; }
+        if (!EncodeJsonBody(stMessage_, &pucTempBuffer, uiBufferSize_)) { return STATUS::BUFFER_FULL; }
         break;
 
     default: return STATUS::UNSUPPORTED;

--- a/src/decoders/oem/src/encoder.cpp
+++ b/src/decoders/oem/src/encoder.cpp
@@ -79,12 +79,12 @@ void Encoder::InitFieldMaps()
     asciiFieldMap[CalculateBlockCrc32("B")] = BasicIntMapEntry<int8_t>();
     asciiFieldMap[CalculateBlockCrc32("XB")] = BasicHexMapEntry<uint8_t>(2);
 
-    asciiFieldMap[CalculateBlockCrc32("x")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("x")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        if (fc_.fieldDef->dataType.length == 1) { return WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue), 2); }
-        if (fc_.fieldDef->dataType.length == 2) { return WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint16_t>(fc_.fieldValue), 4); }
-        if (fc_.fieldDef->dataType.length == 4) { return WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue), 8); }
-        if (fc_.fieldDef->dataType.length == 8) { return WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint64_t>(fc_.fieldValue), 16); }
+        if (fc_.fieldDef->dataType.length == 1) { return WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint8_t>(fc_.fieldValue), 2); }
+        if (fc_.fieldDef->dataType.length == 2) { return WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint16_t>(fc_.fieldValue), 4); }
+        if (fc_.fieldDef->dataType.length == 4) { return WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue), 8); }
+        if (fc_.fieldDef->dataType.length == 8) { return WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint64_t>(fc_.fieldValue), 16); }
         return false;
     };
 
@@ -92,34 +92,34 @@ void Encoder::InitFieldMaps()
     asciiFieldMap[CalculateBlockCrc32("lx")] = BasicHexMapEntry<uint32_t>(8);
     asciiFieldMap[CalculateBlockCrc32("llx")] = BasicHexMapEntry<uint64_t>(16);
 
-    asciiFieldMap[CalculateBlockCrc32("s")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("s")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         return fc_.fieldDef->dataType.name == DATA_TYPE::UCHAR
-                   ? CopyToBuffer(ppucOutBuf_, uiBytesLeft_, static_cast<char>(std::get<uint8_t>(fc_.fieldValue)))
-                   : CopyToBuffer(ppucOutBuf_, uiBytesLeft_, static_cast<char>(std::get<int8_t>(fc_.fieldValue)));
+                   ? CopyToBuffer(ppcOutBuf_, uiBytesLeft_, static_cast<char>(std::get<uint8_t>(fc_.fieldValue)))
+                   : CopyToBuffer(ppcOutBuf_, uiBytesLeft_, static_cast<char>(std::get<int8_t>(fc_.fieldValue)));
     };
 
-    asciiFieldMap[CalculateBlockCrc32("m")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("m")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, pclMsgDb_.MsgIdToMsgName(std::get<uint32_t>(fc_.fieldValue)).c_str());
+        return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, pclMsgDb_.MsgIdToMsgName(std::get<uint32_t>(fc_.fieldValue)).c_str());
     };
 
-    asciiFieldMap[CalculateBlockCrc32("T")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("T")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue) / 1000.0, std::chars_format::fixed, 3);
+        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue) / 1000.0, std::chars_format::fixed, 3);
     };
 
-    asciiFieldMap[CalculateBlockCrc32("id")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("id")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                   [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         const uint32_t uiTempId = std::get<uint32_t>(fc_.fieldValue);
         const uint16_t usSv = uiTempId & 0x0000FFFF;
         const int16_t sGloChan = (uiTempId & 0xFFFF0000) >> 16;
-        return (sGloChan < 0)    ? CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, usSv, sGloChan)
-               : (sGloChan != 0) ? CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, usSv, '+', sGloChan)
-                                 : WriteIntToBuffer(ppucOutBuf_, uiBytesLeft_, usSv);
+        return (sGloChan < 0)    ? CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, usSv, sGloChan)
+               : (sGloChan != 0) ? CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, usSv, '+', sGloChan)
+                                 : WriteIntToBuffer(ppcOutBuf_, uiBytesLeft_, usSv);
     };
 
-    asciiFieldMap[CalculateBlockCrc32("P")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("P")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         // Allow signed integers to be used but interpret them as if they were unsigned
         // If all logs with %P version strings are updated to use an unsigned DATA_TYPE this can be removed
@@ -127,39 +127,39 @@ void Encoder::InitFieldMaps()
         if (std::holds_alternative<int8_t>(fc_.fieldValue)) { uiValue = static_cast<uint8_t>(std::get<int8_t>(fc_.fieldValue)); }
         else { uiValue = std::get<uint8_t>(fc_.fieldValue); }
 
-        if (uiValue == '\\') { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\\\\"); }
-        if (uiValue > 31 && uiValue < 127) { return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, static_cast<char>(uiValue)); }
-        return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\\x") && WriteHexToBuffer(ppucOutBuf_, uiBytesLeft_, uiValue, 2);
+        if (uiValue == '\\') { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\\\\"); }
+        if (uiValue > 31 && uiValue < 127) { return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, static_cast<char>(uiValue)); }
+        return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\\x") && WriteHexToBuffer(ppcOutBuf_, uiBytesLeft_, uiValue, 2);
     };
 
-    asciiFieldMap[CalculateBlockCrc32("f")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("f")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         if (fc_.fieldDef->dataType.length == 4)
         {
-            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
         }
         if (fc_.fieldDef->dataType.length == 8)
         {
-            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
         }
         return false;
     };
 
-    asciiFieldMap[CalculateBlockCrc32("lf")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("lf")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                   [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
+        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
     };
 
-    asciiFieldMap[CalculateBlockCrc32("e")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("e")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         if (fc_.fieldDef->dataType.length == 4)
         {
-            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::scientific,
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::scientific,
                                       fc_.fieldDef->precision);
         }
         if (fc_.fieldDef->dataType.length == 8)
         {
-            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::scientific,
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::scientific,
                                       fc_.fieldDef->precision);
         }
         return false;
@@ -167,27 +167,27 @@ void Encoder::InitFieldMaps()
 
     asciiFieldMap[CalculateBlockCrc32("le")] = asciiFieldMap[CalculateBlockCrc32("e")];
 
-    asciiFieldMap[CalculateBlockCrc32("k")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("k")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
+        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
                                   fc_.fieldDef->precision);
     };
 
-    asciiFieldMap[CalculateBlockCrc32("lk")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("lk")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                   [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
+        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
                                   fc_.fieldDef->precision);
     };
 
-    asciiFieldMap[CalculateBlockCrc32("c")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    asciiFieldMap[CalculateBlockCrc32("c")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         if (fc_.fieldDef->dataType.length == 1)
         {
-            return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, static_cast<char>(std::get<uint8_t>(fc_.fieldValue)));
+            return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, static_cast<char>(std::get<uint8_t>(fc_.fieldValue)));
         }
         if (fc_.fieldDef->dataType.length == 4 && fc_.fieldDef->dataType.name == DATA_TYPE::ULONG)
         {
-            return CopyToBuffer(ppucOutBuf_, uiBytesLeft_, static_cast<char>(std::get<uint32_t>(fc_.fieldValue)));
+            return CopyToBuffer(ppcOutBuf_, uiBytesLeft_, static_cast<char>(std::get<uint32_t>(fc_.fieldValue)));
         }
         return false;
     };
@@ -197,54 +197,54 @@ void Encoder::InitFieldMaps()
     // =========================================================
     jsonFieldMap[CalculateBlockCrc32("P")] = BasicIntMapEntry<uint8_t>();
 
-    jsonFieldMap[CalculateBlockCrc32("T")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("T")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue) / 1000.0, std::chars_format::fixed, 3);
+        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<uint32_t>(fc_.fieldValue) / 1000.0, std::chars_format::fixed, 3);
     };
 
-    jsonFieldMap[CalculateBlockCrc32("m")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("m")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', std::string_view(pclMsgDb_.MsgIdToMsgName(std::get<uint32_t>(fc_.fieldValue))), '"');
+        return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', std::string_view(pclMsgDb_.MsgIdToMsgName(std::get<uint32_t>(fc_.fieldValue))), '"');
     };
 
-    jsonFieldMap[CalculateBlockCrc32("id")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("id")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         const auto uiTempId = std::get<uint32_t>(fc_.fieldValue);
         const uint16_t usSv = uiTempId & 0x0000FFFF;
         const int16_t sGloChan = (uiTempId & 0xFFFF0000) >> 16;
-        return (sGloChan < 0)    ? CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', usSv, sGloChan, '"')
-               : (sGloChan != 0) ? CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', usSv, '+', sGloChan, '"')
-                                 : CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', usSv, '"');
+        return (sGloChan < 0)    ? CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', usSv, sGloChan, '"')
+               : (sGloChan != 0) ? CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', usSv, '+', sGloChan, '"')
+                                 : CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', usSv, '"');
     };
 
-    jsonFieldMap[CalculateBlockCrc32("f")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("f")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         if (fc_.fieldDef->dataType.length == 4)
         {
-            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
         }
         if (fc_.fieldDef->dataType.length == 8)
         {
-            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
         }
         return false;
     };
 
-    jsonFieldMap[CalculateBlockCrc32("lf")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("lf")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
+        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::fixed, fc_.fieldDef->precision);
     };
 
-    jsonFieldMap[CalculateBlockCrc32("e")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("e")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         if (fc_.fieldDef->dataType.length == 4)
         {
-            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::scientific,
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), std::chars_format::scientific,
                                       fc_.fieldDef->precision);
         }
         if (fc_.fieldDef->dataType.length == 8)
         {
-            return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::scientific,
+            return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), std::chars_format::scientific,
                                       fc_.fieldDef->precision);
         }
         return false;
@@ -252,34 +252,34 @@ void Encoder::InitFieldMaps()
 
     jsonFieldMap[CalculateBlockCrc32("le")] = jsonFieldMap[CalculateBlockCrc32("e")];
 
-    jsonFieldMap[CalculateBlockCrc32("k")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("k")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
+        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<float>(fc_.fieldValue), FloatingPointFormat<float>(fc_),
                                   fc_.fieldDef->precision);
     };
 
-    jsonFieldMap[CalculateBlockCrc32("lk")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("lk")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                  [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return WriteFloatToBuffer(ppucOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
+        return WriteFloatToBuffer(ppcOutBuf_, uiBytesLeft_, std::get<double>(fc_.fieldValue), FloatingPointFormat<double>(fc_),
                                   fc_.fieldDef->precision);
     };
 
-    jsonFieldMap[CalculateBlockCrc32("s")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("s")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
-        return CopyToBuffer(ppucOutBuf_, uiBytesLeft_,
+        return CopyToBuffer(ppcOutBuf_, uiBytesLeft_,
                             fc_.fieldDef->dataType.name == DATA_TYPE::UCHAR ? static_cast<char>(std::get<uint8_t>(fc_.fieldValue))
                                                                             : static_cast<char>(std::get<int8_t>(fc_.fieldValue)));
     };
 
-    jsonFieldMap[CalculateBlockCrc32("c")] = [](const FieldContainer& fc_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_,
+    jsonFieldMap[CalculateBlockCrc32("c")] = [](const FieldContainer& fc_, char** ppcOutBuf_, uint32_t& uiBytesLeft_,
                                                 [[maybe_unused]] const MessageDatabase& pclMsgDb_) {
         if (fc_.fieldDef->dataType.length == 1)
         {
-            return CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', static_cast<char>(std::get<uint8_t>(fc_.fieldValue)), '"');
+            return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', static_cast<char>(std::get<uint8_t>(fc_.fieldValue)), '"');
         }
         if (fc_.fieldDef->dataType.length == 4 && fc_.fieldDef->dataType.name == DATA_TYPE::ULONG)
         {
-            return CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_, '"', static_cast<char>(std::get<uint32_t>(fc_.fieldValue)), '"');
+            return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_, '"', static_cast<char>(std::get<uint32_t>(fc_.fieldValue)), '"');
         }
         return false;
     };
@@ -315,9 +315,9 @@ bool Encoder::EncodeBinaryShortHeader(const IntermediateHeader& stInterHeader_, 
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
+bool Encoder::EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
 {
-    if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_ASCII_SYNC)) { return false; }
+    if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_ASCII_SYNC)) { return false; }
 
     MessageDefinition::ConstPtr pclMessageDef = pclMyMsgDb->GetMsgDef(stInterHeader_.usMessageId);
     std::string sMsgName(pclMessageDef != nullptr ? pclMessageDef->name : GetEnumString(vMyCommandDefinitions, stInterHeader_.usMessageId));
@@ -325,7 +325,7 @@ bool Encoder::EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, unsign
     sMsgName.push_back(uiResponse != 0U ? 'R' : 'A'); // Append 'A' for ascii, or 'R' for ascii response
     AppendSiblingId(sMsgName, stInterHeader_);
 
-    return CopyAllToBufferSeparated(ppucOutBuf_, uiBytesLeft_, OEM4_ASCII_FIELD_SEPARATOR,
+    return CopyAllToBufferSeparated(ppcOutBuf_, uiBytesLeft_, OEM4_ASCII_FIELD_SEPARATOR,
                                     std::string_view(sMsgName),                                                                             //
                                     GetEnumString(vMyPortAddressDefinitions, stInterHeader_.uiPortAddress),                                 //
                                     stInterHeader_.usSequence,                                                                              //
@@ -337,19 +337,19 @@ bool Encoder::EncodeAsciiHeader(const IntermediateHeader& stInterHeader_, unsign
                                     HexValue<uint32_t>{stInterHeader_.uiMessageDefinitionCrc, 4},                                           //
                                     stInterHeader_.usReceiverSwVersion                                                                      //
                                     ) &&
-           CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_ASCII_HEADER_TERMINATOR);
+           CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_ASCII_HEADER_TERMINATOR);
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeAbbrevAsciiHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_, bool bIsEmbedded_) const
+bool Encoder::EncodeAbbrevAsciiHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_, bool bIsEmbedded_) const
 {
-    if (!bIsEmbedded_ && !CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SYNC)) { return false; }
+    if (!bIsEmbedded_ && !CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SYNC)) { return false; }
 
     MessageDefinition::ConstPtr pclMessageDef = pclMyMsgDb->GetMsgDef(stInterHeader_.usMessageId);
     std::string sMsgName(pclMessageDef != nullptr ? pclMessageDef->name : GetEnumString(vMyCommandDefinitions, stInterHeader_.usMessageId));
     AppendSiblingId(sMsgName, stInterHeader_);
 
-    return CopyAllToBufferSeparated(ppucOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR,
+    return CopyAllToBufferSeparated(ppcOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR,
                                     std::string_view(sMsgName),                                                                             //
                                     GetEnumString(vMyPortAddressDefinitions, stInterHeader_.uiPortAddress),                                 //
                                     stInterHeader_.usSequence,                                                                              //
@@ -361,41 +361,41 @@ bool Encoder::EncodeAbbrevAsciiHeader(const IntermediateHeader& stInterHeader_, 
                                     HexValue<uint32_t>{stInterHeader_.uiMessageDefinitionCrc, 4},                                           //
                                     stInterHeader_.usReceiverSwVersion                                                                      //
                                     ) &&
-           (bIsEmbedded_ ? CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR) : CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\r\n"));
+           (bIsEmbedded_ ? CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR) : CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\r\n"));
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeAsciiShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
+bool Encoder::EncodeAsciiShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
 {
-    if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_SHORT_ASCII_SYNC)) { return false; }
+    if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_SHORT_ASCII_SYNC)) { return false; }
 
     std::string sMsgName(pclMyMsgDb->GetMsgDef(stInterHeader_.usMessageId)->name);
     const uint32_t uiResponse = (stInterHeader_.ucMessageType & static_cast<uint32_t>(MESSAGE_TYPE_MASK::RESPONSE)) >> 7;
     sMsgName.push_back(uiResponse != 0U ? 'R' : 'A'); // Append 'A' for ascii, or 'R' for ascii response
     AppendSiblingId(sMsgName, stInterHeader_);
 
-    return CopyAllToBufferSeparated(ppucOutBuf_, uiBytesLeft_, OEM4_ASCII_FIELD_SEPARATOR,                                 //
+    return CopyAllToBufferSeparated(ppcOutBuf_, uiBytesLeft_, OEM4_ASCII_FIELD_SEPARATOR,                                 //
                                     std::string_view(sMsgName),                                                            //
                                     stInterHeader_.usWeek,                                                                 //
                                     FloatValue<double>{stInterHeader_.dMilliseconds / 1000.0, std::chars_format::fixed, 3} //
                                     ) &&
-           CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_ASCII_HEADER_TERMINATOR);
+           CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_ASCII_HEADER_TERMINATOR);
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeAbbrevAsciiShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
+bool Encoder::EncodeAbbrevAsciiShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
 {
-    if (!CopyToBuffer(ppucOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SYNC)) { return false; }
+    if (!CopyToBuffer(ppcOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SYNC)) { return false; }
 
     std::string sMsgName(pclMyMsgDb->GetMsgDef(stInterHeader_.usMessageId)->name);
     AppendSiblingId(sMsgName, stInterHeader_);
 
-    return CopyAllToBufferSeparated(ppucOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR,                                //
+    return CopyAllToBufferSeparated(ppcOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR,                                //
                                     std::string_view(sMsgName),                                                            //
                                     stInterHeader_.usWeek,                                                                 //
                                     FloatValue<double>{stInterHeader_.dMilliseconds / 1000.0, std::chars_format::fixed, 3} //
                                     ) &&
-           CopyToBuffer(ppucOutBuf_, uiBytesLeft_, "\r\n");
+           CopyToBuffer(ppcOutBuf_, uiBytesLeft_, "\r\n");
 }
 
 // -------------------------------------------------------------------------------------------------------
@@ -409,9 +409,9 @@ std::string Encoder::JsonHeaderToMsgName(const IntermediateHeader& stInterHeader
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeJsonHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
+bool Encoder::EncodeJsonHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
 {
-    return CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_,                                                               //
+    return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_,                                                               //
                            R"({"message": ")", JsonHeaderToMsgName(stInterHeader_).c_str(),                         //
                            R"(","id": )", stInterHeader_.usMessageId,                                               //
                            R"(,"port": ")", GetEnumString(vMyPortAddressDefinitions, stInterHeader_.uiPortAddress), //
@@ -427,9 +427,9 @@ bool Encoder::EncodeJsonHeader(const IntermediateHeader& stInterHeader_, unsigne
 }
 
 // -------------------------------------------------------------------------------------------------------
-bool Encoder::EncodeJsonShortHeader(const IntermediateHeader& stInterHeader_, unsigned char** ppucOutBuf_, uint32_t& uiBytesLeft_) const
+bool Encoder::EncodeJsonShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
 {
-    return CopyAllToBuffer(ppucOutBuf_, uiBytesLeft_,                                                                                   //
+    return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_,                                                                                   //
                            R"({"message": ")", JsonHeaderToMsgName(stInterHeader_).c_str(),                                             //
                            R"(","id": )", stInterHeader_.usMessageId,                                                                   //
                            R"(,"week": )", stInterHeader_.usWeek,                                                                       //
@@ -507,20 +507,26 @@ Encoder::EncodeHeader(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_,
 
     switch (eFormat_)
     {
-    case ENCODE_FORMAT::ASCII:
-        if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeAsciiShortHeader(stHeader_, &pucTempBuffer, uiBufferSize_)
-                                                : !EncodeAsciiHeader(stHeader_, &pucTempBuffer, uiBufferSize_))
+    case ENCODE_FORMAT::ASCII: {
+        auto* pcTempBuffer = reinterpret_cast<char*>(pucTempBuffer);
+        if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeAsciiShortHeader(stHeader_, &pcTempBuffer, uiBufferSize_)
+                                                : !EncodeAsciiHeader(stHeader_, &pcTempBuffer, uiBufferSize_))
         {
             return STATUS::BUFFER_FULL;
         }
+        pucTempBuffer = reinterpret_cast<unsigned char*>(pcTempBuffer);
         break;
-    case ENCODE_FORMAT::ABBREV_ASCII:
-        if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeAbbrevAsciiShortHeader(stHeader_, &pucTempBuffer, uiBufferSize_)
-                                                : !EncodeAbbrevAsciiHeader(stHeader_, &pucTempBuffer, uiBufferSize_, bIsEmbeddedHeader_))
+    }
+    case ENCODE_FORMAT::ABBREV_ASCII: {
+        auto* pcTempBuffer = reinterpret_cast<char*>(pucTempBuffer);
+        if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeAbbrevAsciiShortHeader(stHeader_, &pcTempBuffer, uiBufferSize_)
+                                                : !EncodeAbbrevAsciiHeader(stHeader_, &pcTempBuffer, uiBufferSize_, bIsEmbeddedHeader_))
         {
             return STATUS::BUFFER_FULL;
         }
+        pucTempBuffer = reinterpret_cast<unsigned char*>(pcTempBuffer);
         break;
+    }
     case ENCODE_FORMAT::FLATTENED_BINARY: [[fallthrough]];
     case ENCODE_FORMAT::BINARY:
         if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeBinaryShortHeader(stHeader_, &pucTempBuffer, uiBufferSize_)
@@ -529,13 +535,16 @@ Encoder::EncodeHeader(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_,
             return STATUS::BUFFER_FULL;
         }
         break;
-    case ENCODE_FORMAT::JSON:
-        if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeJsonShortHeader(stHeader_, &pucTempBuffer, uiBufferSize_)
-                                                : !EncodeJsonHeader(stHeader_, &pucTempBuffer, uiBufferSize_))
+    case ENCODE_FORMAT::JSON: {
+        auto* pcTempBuffer = reinterpret_cast<char*>(pucTempBuffer);
+        if (IsShortHeaderFormat(eHeaderFormat_) ? !EncodeJsonShortHeader(stHeader_, &pcTempBuffer, uiBufferSize_)
+                                                : !EncodeJsonHeader(stHeader_, &pcTempBuffer, uiBufferSize_))
         {
             return STATUS::BUFFER_FULL;
         }
+        pucTempBuffer = reinterpret_cast<unsigned char*>(pcTempBuffer);
         break;
+    }
     default: return STATUS::UNSUPPORTED;
     }
 
@@ -560,21 +569,25 @@ Encoder::EncodeBody(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, c
     switch (eFormat_)
     {
     case ENCODE_FORMAT::ASCII: {
-        if (!EncodeAsciiBody<false>(stMessage_, &pucTempBuffer, uiBufferSize_)) { return STATUS::BUFFER_FULL; }
-        pucTempBuffer--; // Remove last delimiter ','
-        const uint32_t uiCrc = CalculateBlockCrc32(stMessageData_.pucMessageHeader + 1, pucTempBuffer - stMessageData_.pucMessageHeader - 1);
-        if (!CopyAllToBuffer(&pucTempBuffer, uiBufferSize_, '*', HexValue<uint32_t>{uiCrc, 8}, "\r\n"))
+        auto* pcTempBuffer = reinterpret_cast<char*>(pucTempBuffer);
+        if (!EncodeAsciiBody<false>(stMessage_, &pcTempBuffer, uiBufferSize_)) { return STATUS::BUFFER_FULL; }
+        pcTempBuffer--; // Remove last delimiter ','
+        const uint32_t uiCrc = CalculateBlockCrc32(stMessageData_.pucMessageHeader + 1, reinterpret_cast<unsigned char*>(pcTempBuffer) - stMessageData_.pucMessageHeader - 1);
+        if (!CopyAllToBuffer(&pcTempBuffer, uiBufferSize_, '*', HexValue<uint32_t>{uiCrc, 8}, "\r\n"))
         {
             return STATUS::BUFFER_FULL;
         }
+        pucTempBuffer = reinterpret_cast<unsigned char*>(pcTempBuffer);
         break;
     }
-    case ENCODE_FORMAT::ABBREV_ASCII:
-        if (!EncodeAsciiBody<true>(stMessage_, &pucTempBuffer, uiBufferSize_)) { return STATUS::BUFFER_FULL; }
-        pucTempBuffer--; // Remove last delimiter ' '
-        if (!CopyToBuffer(&pucTempBuffer, uiBufferSize_, "\r\n")) { return STATUS::BUFFER_FULL; }
+    case ENCODE_FORMAT::ABBREV_ASCII: {
+        auto* pcTempBuffer = reinterpret_cast<char*>(pucTempBuffer);
+        if (!EncodeAsciiBody<true>(stMessage_, &pcTempBuffer, uiBufferSize_)) { return STATUS::BUFFER_FULL; }
+        pcTempBuffer--; // Remove last delimiter ' '
+        if (!CopyToBuffer(&pcTempBuffer, uiBufferSize_, "\r\n")) { return STATUS::BUFFER_FULL; }
+        pucTempBuffer = reinterpret_cast<unsigned char*>(pcTempBuffer);
         break;
-
+    }
     case ENCODE_FORMAT::FLATTENED_BINARY:
         if (!EncodeBinaryBody<true, true>(stMessage_, &pucTempBuffer, uiBufferSize_)) { return STATUS::BUFFER_FULL; }
         [[fallthrough]];
@@ -609,9 +622,12 @@ Encoder::EncodeBody(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, c
         }
         break;
     }
-    case ENCODE_FORMAT::JSON:
-        if (!EncodeJsonBody(stMessage_, &pucTempBuffer, uiBufferSize_)) { return STATUS::BUFFER_FULL; }
+    case ENCODE_FORMAT::JSON: {
+        auto* pcTempBuffer = reinterpret_cast<char*>(pucTempBuffer);
+        if (!EncodeJsonBody(stMessage_, &pcTempBuffer, uiBufferSize_)) { return STATUS::BUFFER_FULL; }
+        pucTempBuffer = reinterpret_cast<unsigned char*>(pcTempBuffer);
         break;
+    }
 
     default: return STATUS::UNSUPPORTED;
     }

--- a/src/decoders/oem/src/encoder.cpp
+++ b/src/decoders/oem/src/encoder.cpp
@@ -602,15 +602,13 @@ Encoder::EncodeBody(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, c
         // TODO: this block of code below is what's blocking us from moving this function to common (can solve this with dynamic casting or CRTP?)
         if (!IsShortHeaderFormat(eHeaderFormat_))
         {
-            Oem4BinaryHeader stHeader;
-            std::memcpy(&stHeader, stMessageData_.pucMessageHeader, sizeof(Oem4BinaryHeader));
+            auto stHeader = LoadValueFromBuffer<Oem4BinaryHeader>(stMessageData_.pucMessageHeader);
             stHeader.usLength = static_cast<uint16_t>(pucTempBuffer - *ppucBuffer_);
             std::memcpy(stMessageData_.pucMessageHeader, &stHeader, sizeof(Oem4BinaryHeader));
         }
         else
         {
-            Oem4BinaryShortHeader stShortHeader;
-            std::memcpy(&stShortHeader, stMessageData_.pucMessageHeader, sizeof(Oem4BinaryShortHeader));
+            auto stShortHeader = LoadValueFromBuffer<Oem4BinaryShortHeader>(stMessageData_.pucMessageHeader);
             stShortHeader.ucLength = static_cast<uint8_t>(pucTempBuffer - *ppucBuffer_);
             std::memcpy(stMessageData_.pucMessageHeader, &stShortHeader, sizeof(Oem4BinaryShortHeader));
         }

--- a/src/decoders/oem/src/encoder.cpp
+++ b/src/decoders/oem/src/encoder.cpp
@@ -602,15 +602,13 @@ Encoder::EncodeBody(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, c
         // TODO: this block of code below is what's blocking us from moving this function to common (can solve this with dynamic casting or CRTP?)
         if (!IsShortHeaderFormat(eHeaderFormat_))
         {
-            auto stHeader = LoadValueFromBuffer<Oem4BinaryHeader>(stMessageData_.pucMessageHeader);
-            stHeader.usLength = static_cast<uint16_t>(pucTempBuffer - *ppucBuffer_);
-            std::memcpy(stMessageData_.pucMessageHeader, &stHeader, sizeof(Oem4BinaryHeader));
+            auto usLength = static_cast<uint16_t>(pucTempBuffer - *ppucBuffer_);
+            std::memcpy(stMessageData_.pucMessageHeader + offsetof(Oem4BinaryHeader, usLength), &usLength, sizeof(usLength));
         }
         else
         {
-            auto stShortHeader = LoadValueFromBuffer<Oem4BinaryShortHeader>(stMessageData_.pucMessageHeader);
-            stShortHeader.ucLength = static_cast<uint8_t>(pucTempBuffer - *ppucBuffer_);
-            std::memcpy(stMessageData_.pucMessageHeader, &stShortHeader, sizeof(Oem4BinaryShortHeader));
+            auto ucLength = static_cast<uint8_t>(pucTempBuffer - *ppucBuffer_);
+            std::memcpy(stMessageData_.pucMessageHeader + offsetof(Oem4BinaryShortHeader, ucLength), &ucLength, sizeof(ucLength));
         }
         if (!CopyToBuffer(&pucTempBuffer, uiBufferSize_,
                           CalculateBlockCrc32(stMessageData_.pucMessageHeader, pucTempBuffer - stMessageData_.pucMessageHeader)))

--- a/src/decoders/oem/src/encoder.cpp
+++ b/src/decoders/oem/src/encoder.cpp
@@ -374,7 +374,7 @@ bool Encoder::EncodeAsciiShortHeader(const IntermediateHeader& stInterHeader_, c
     sMsgName.push_back(uiResponse != 0U ? 'R' : 'A'); // Append 'A' for ascii, or 'R' for ascii response
     AppendSiblingId(sMsgName, stInterHeader_);
 
-    return CopyAllToBufferSeparated(ppcOutBuf_, uiBytesLeft_, OEM4_ASCII_FIELD_SEPARATOR,                                 //
+    return CopyAllToBufferSeparated(ppcOutBuf_, uiBytesLeft_, OEM4_ASCII_FIELD_SEPARATOR,                                  //
                                     std::string_view(sMsgName),                                                            //
                                     stInterHeader_.usWeek,                                                                 //
                                     FloatValue<double>{stInterHeader_.dMilliseconds / 1000.0, std::chars_format::fixed, 3} //
@@ -390,7 +390,7 @@ bool Encoder::EncodeAbbrevAsciiShortHeader(const IntermediateHeader& stInterHead
     std::string sMsgName(pclMyMsgDb->GetMsgDef(stInterHeader_.usMessageId)->name);
     AppendSiblingId(sMsgName, stInterHeader_);
 
-    return CopyAllToBufferSeparated(ppcOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR,                                //
+    return CopyAllToBufferSeparated(ppcOutBuf_, uiBytesLeft_, OEM4_ABBREV_ASCII_SEPARATOR,                                 //
                                     std::string_view(sMsgName),                                                            //
                                     stInterHeader_.usWeek,                                                                 //
                                     FloatValue<double>{stInterHeader_.dMilliseconds / 1000.0, std::chars_format::fixed, 3} //
@@ -411,7 +411,7 @@ std::string Encoder::JsonHeaderToMsgName(const IntermediateHeader& stInterHeader
 // -------------------------------------------------------------------------------------------------------
 bool Encoder::EncodeJsonHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
 {
-    return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_,                                                               //
+    return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_,                                                                //
                            R"({"message": ")", JsonHeaderToMsgName(stInterHeader_).c_str(),                         //
                            R"(","id": )", stInterHeader_.usMessageId,                                               //
                            R"(,"port": ")", GetEnumString(vMyPortAddressDefinitions, stInterHeader_.uiPortAddress), //
@@ -429,7 +429,7 @@ bool Encoder::EncodeJsonHeader(const IntermediateHeader& stInterHeader_, char** 
 // -------------------------------------------------------------------------------------------------------
 bool Encoder::EncodeJsonShortHeader(const IntermediateHeader& stInterHeader_, char** ppcOutBuf_, uint32_t& uiBytesLeft_) const
 {
-    return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_,                                                                                   //
+    return CopyAllToBuffer(ppcOutBuf_, uiBytesLeft_,                                                                                    //
                            R"({"message": ")", JsonHeaderToMsgName(stInterHeader_).c_str(),                                             //
                            R"(","id": )", stInterHeader_.usMessageId,                                                                   //
                            R"(,"week": )", stInterHeader_.usWeek,                                                                       //
@@ -496,8 +496,9 @@ Encoder::Encode(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const
 
 // -------------------------------------------------------------------------------------------------------
 STATUS
-Encoder::EncodeHeader(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_, MessageDataStruct& stMessageData_,
-                      const HEADER_FORMAT eHeaderFormat_, const ENCODE_FORMAT eFormat_, const bool bIsEmbeddedHeader_) const
+Encoder::EncodeHeader(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+                      MessageDataStruct& stMessageData_, const HEADER_FORMAT eHeaderFormat_, const ENCODE_FORMAT eFormat_,
+                      const bool bIsEmbeddedHeader_) const
 {
     if (ppucBuffer_ == nullptr || *ppucBuffer_ == nullptr) { return STATUS::NULL_PROVIDED; }
 
@@ -572,11 +573,9 @@ Encoder::EncodeBody(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, c
         auto* pcTempBuffer = reinterpret_cast<char*>(pucTempBuffer);
         if (!EncodeAsciiBody<false>(stMessage_, &pcTempBuffer, uiBufferSize_)) { return STATUS::BUFFER_FULL; }
         pcTempBuffer--; // Remove last delimiter ','
-        const uint32_t uiCrc = CalculateBlockCrc32(stMessageData_.pucMessageHeader + 1, reinterpret_cast<unsigned char*>(pcTempBuffer) - stMessageData_.pucMessageHeader - 1);
-        if (!CopyAllToBuffer(&pcTempBuffer, uiBufferSize_, '*', HexValue<uint32_t>{uiCrc, 8}, "\r\n"))
-        {
-            return STATUS::BUFFER_FULL;
-        }
+        const uint32_t uiCrc = CalculateBlockCrc32(stMessageData_.pucMessageHeader + 1,
+                                                   reinterpret_cast<unsigned char*>(pcTempBuffer) - stMessageData_.pucMessageHeader - 1);
+        if (!CopyAllToBuffer(&pcTempBuffer, uiBufferSize_, '*', HexValue<uint32_t>{uiCrc, 8}, "\r\n")) { return STATUS::BUFFER_FULL; }
         pucTempBuffer = reinterpret_cast<unsigned char*>(pcTempBuffer);
         break;
     }

--- a/src/decoders/oem/src/header_decoder.cpp
+++ b/src/decoders/oem/src/header_decoder.cpp
@@ -284,8 +284,7 @@ STATUS HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader
     if (pclMyMsgDb == nullptr) { return STATUS::NO_DATABASE; }
 
     const auto* pcTempBuf = reinterpret_cast<const char*>(pucLogBuf_);
-    Oem4BinaryHeader stBinaryHeader{};
-    std::memcpy(&stBinaryHeader, pucLogBuf_, sizeof(Oem4BinaryHeader));
+    auto stBinaryHeader = LoadValueFromBuffer<Oem4BinaryHeader>(pucLogBuf_);
 
     stMetaData_.eFormat = [&] {
         switch (stBinaryHeader.ucSync1)
@@ -387,8 +386,7 @@ STATUS HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader
     case HEADER_FORMAT::SHORT_BINARY: {
         // Reset the IntermediateHeader ucMessageType because can incorrectly set ucSiblingId and bResponse if it isn't
         stInterHeader_.ucMessageType = 0;
-        Oem4BinaryShortHeader stBinaryShortHeader{};
-        std::memcpy(&stBinaryShortHeader, pucLogBuf_, sizeof(Oem4BinaryShortHeader));
+        auto stBinaryShortHeader = LoadValueFromBuffer<Oem4BinaryShortHeader>(pucLogBuf_);
         stInterHeader_.usLength = stBinaryShortHeader.ucLength;
         stInterHeader_.usMessageId = stBinaryShortHeader.usMessageId;
         stInterHeader_.usWeek = stBinaryShortHeader.usWeekNo;

--- a/src/decoders/oem/src/header_decoder.cpp
+++ b/src/decoders/oem/src/header_decoder.cpp
@@ -284,10 +284,11 @@ STATUS HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader
     if (pclMyMsgDb == nullptr) { return STATUS::NO_DATABASE; }
 
     const auto* pcTempBuf = reinterpret_cast<const char*>(pucLogBuf_);
-    const auto* pstBinaryHeader = reinterpret_cast<const Oem4BinaryHeader*>(pucLogBuf_);
+    Oem4BinaryHeader stBinaryHeader{};
+    std::memcpy(&stBinaryHeader, pucLogBuf_, sizeof(Oem4BinaryHeader));
 
     stMetaData_.eFormat = [&] {
-        switch (pstBinaryHeader->ucSync1)
+        switch (stBinaryHeader.ucSync1)
         {
         case OEM4_ASCII_SYNC: return HEADER_FORMAT::ASCII;
         case OEM4_SHORT_ASCII_SYNC: return HEADER_FORMAT::SHORT_ASCII;
@@ -295,7 +296,7 @@ STATUS HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader
         case NMEA_SYNC: return HEADER_FORMAT::NMEA;
         case '{': return HEADER_FORMAT::JSON;
         case OEM4_BINARY_SYNC1:
-            switch (pstBinaryHeader->ucSync3)
+            switch (stBinaryHeader.ucSync3)
             {
             case OEM4_BINARY_SYNC3: return HEADER_FORMAT::BINARY;
             case OEM4_SHORT_BINARY_SYNC3: return HEADER_FORMAT::SHORT_BINARY;
@@ -368,29 +369,30 @@ STATUS HeaderDecoder::Decode(const unsigned char* pucLogBuf_, IntermediateHeader
         break;
 
     case HEADER_FORMAT::BINARY:
-        stInterHeader_.usMessageId = pstBinaryHeader->usMsgNumber;
-        stInterHeader_.ucMessageType = pstBinaryHeader->ucMsgType;
-        stInterHeader_.uiPortAddress = pstBinaryHeader->ucPort;
-        stInterHeader_.usLength = pstBinaryHeader->usLength;
-        stInterHeader_.usSequence = pstBinaryHeader->usSequenceNumber;
-        stInterHeader_.ucIdleTime = pstBinaryHeader->ucIdleTime;
-        stInterHeader_.uiTimeStatus = pstBinaryHeader->ucTimeStatus;
-        stInterHeader_.usWeek = pstBinaryHeader->usWeekNo;
-        stInterHeader_.dMilliseconds = pstBinaryHeader->uiWeekMSec;
-        stInterHeader_.uiReceiverStatus = pstBinaryHeader->uiStatus;
-        stInterHeader_.usReceiverSwVersion = pstBinaryHeader->usReceiverSwVersion;
-        stInterHeader_.uiMessageDefinitionCrc = pstBinaryHeader->usMsgDefCrc;
+        stInterHeader_.usMessageId = stBinaryHeader.usMsgNumber;
+        stInterHeader_.ucMessageType = stBinaryHeader.ucMsgType;
+        stInterHeader_.uiPortAddress = stBinaryHeader.ucPort;
+        stInterHeader_.usLength = stBinaryHeader.usLength;
+        stInterHeader_.usSequence = stBinaryHeader.usSequenceNumber;
+        stInterHeader_.ucIdleTime = stBinaryHeader.ucIdleTime;
+        stInterHeader_.uiTimeStatus = stBinaryHeader.ucTimeStatus;
+        stInterHeader_.usWeek = stBinaryHeader.usWeekNo;
+        stInterHeader_.dMilliseconds = stBinaryHeader.uiWeekMSec;
+        stInterHeader_.uiReceiverStatus = stBinaryHeader.uiStatus;
+        stInterHeader_.usReceiverSwVersion = stBinaryHeader.usReceiverSwVersion;
+        stInterHeader_.uiMessageDefinitionCrc = stBinaryHeader.usMsgDefCrc;
         pcTempBuf += sizeof(Oem4BinaryHeader);
         break;
 
     case HEADER_FORMAT::SHORT_BINARY: {
         // Reset the IntermediateHeader ucMessageType because can incorrectly set ucSiblingId and bResponse if it isn't
         stInterHeader_.ucMessageType = 0;
-        const auto* pstBinaryShortHeader = reinterpret_cast<const Oem4BinaryShortHeader*>(pucLogBuf_);
-        stInterHeader_.usLength = pstBinaryShortHeader->ucLength;
-        stInterHeader_.usMessageId = pstBinaryShortHeader->usMessageId;
-        stInterHeader_.usWeek = pstBinaryShortHeader->usWeekNo;
-        stInterHeader_.dMilliseconds = pstBinaryShortHeader->uiWeekMSec;
+        Oem4BinaryShortHeader stBinaryShortHeader{};
+        std::memcpy(&stBinaryShortHeader, pucLogBuf_, sizeof(Oem4BinaryShortHeader));
+        stInterHeader_.usLength = stBinaryShortHeader.ucLength;
+        stInterHeader_.usMessageId = stBinaryShortHeader.usMessageId;
+        stInterHeader_.usWeek = stBinaryShortHeader.usWeekNo;
+        stInterHeader_.dMilliseconds = stBinaryShortHeader.uiWeekMSec;
         stInterHeader_.uiTimeStatus = static_cast<uint32_t>(TIME_STATUS::UNKNOWN);
         pcTempBuf += sizeof(Oem4BinaryShortHeader);
         break;

--- a/src/decoders/oem/src/rangecmp/range_decompressor.cpp
+++ b/src/decoders/oem/src/rangecmp/range_decompressor.cpp
@@ -429,8 +429,7 @@ void RangeDecompressor::RangeCmp2ToRange(const rangecmp2::RangeCmp& stRangeCmpMe
     uint32_t uiRangeDataBytesDecompressed = 0;
     while (uiRangeDataBytesDecompressed < stRangeCmpMessage_.uiNumberOfRangeDataBytes)
     {
-        SatelliteBlock stSatBlock;
-        std::memcpy(&stSatBlock, &stRangeCmpMessage_.aucRangeData[uiRangeDataBytesDecompressed], sizeof(SatelliteBlock));
+        auto stSatBlock = LoadValueFromBuffer<SatelliteBlock>(&stRangeCmpMessage_.aucRangeData[uiRangeDataBytesDecompressed]);
 
         const auto eSystem = GetBitfield<SYSTEM, SAT_SATELLITE_SYSTEM_ID_MASK>(stSatBlock.ulCombinedField);
         const auto ucSignalBlockCount = GetBitfield<uint8_t, SAT_NUM_SIGNAL_BLOCKS_BASE_MASK>(stSatBlock.ulCombinedField);
@@ -498,8 +497,7 @@ void RangeDecompressor::RangeCmp4ToRange(unsigned char* pucData_, Range& stRange
 
     stRangeMessage_.uiNumberOfObservations = 0;
     uint32_t uiBitOffset = 0;
-    uint32_t uiBytesLeft;
-    std::memcpy(&uiBytesLeft, pucData_, sizeof(uint32_t));
+    auto uiBytesLeft = LoadValueFromBuffer<uint32_t>(pucData_);
     pucData_ += sizeof(uint32_t);
 
     auto systems = ExtractBitfield<uint16_t, SATELLITE_SYSTEMS_BITS>(&pucData_, uiBytesLeft, uiBitOffset);
@@ -664,8 +662,7 @@ void RangeDecompressor::RangeCmp5ToRange(unsigned char* pucData_, Range& stRange
 
     stRangeMessage_.uiNumberOfObservations = 0;
     uint32_t uiBitOffset = 0;
-    uint32_t uiBytesLeft;
-    std::memcpy(&uiBytesLeft, pucData_, sizeof(uint32_t));
+    auto uiBytesLeft = LoadValueFromBuffer<uint32_t>(pucData_);
     pucData_ += sizeof(uint32_t);
 
     auto systems = ExtractBitfield<uint16_t, SATELLITE_SYSTEMS_BITS>(&pucData_, uiBytesLeft, uiBitOffset);
@@ -780,18 +777,8 @@ STATUS RangeDecompressor::Decompress(unsigned char* pucBuffer_, uint32_t uiBuffe
         Range stRange;
         switch (stMetaData_.usMessageId)
         {
-        case RANGECMP_MSG_ID: {
-            rangecmp::RangeCmp stRangeCmp;
-            std::memcpy(&stRangeCmp, pucTempMessagePointer, sizeof(rangecmp::RangeCmp));
-            RangeCmpToRange(stRangeCmp, stRange);
-            break;
-        }
-        case RANGECMP2_MSG_ID: {
-            rangecmp2::RangeCmp stRangeCmp2;
-            std::memcpy(&stRangeCmp2, pucTempMessagePointer, sizeof(rangecmp2::RangeCmp));
-            RangeCmp2ToRange(stRangeCmp2, stRange, stMetaData_);
-            break;
-        }
+        case RANGECMP_MSG_ID: RangeCmpToRange(LoadValueFromBuffer<rangecmp::RangeCmp>(pucTempMessagePointer), stRange); break;
+        case RANGECMP2_MSG_ID: RangeCmp2ToRange(LoadValueFromBuffer<rangecmp2::RangeCmp>(pucTempMessagePointer), stRange, stMetaData_); break;
         case RANGECMP3_MSG_ID: [[fallthrough]];
         case RANGECMP4_MSG_ID: RangeCmp4ToRange(pucTempMessagePointer, stRange, stMetaData_); break;
         case RANGECMP5_MSG_ID: RangeCmp5ToRange(pucTempMessagePointer, stRange, stMetaData_); break;

--- a/src/decoders/oem/src/rangecmp/range_decompressor.cpp
+++ b/src/decoders/oem/src/rangecmp/range_decompressor.cpp
@@ -429,7 +429,8 @@ void RangeDecompressor::RangeCmp2ToRange(const rangecmp2::RangeCmp& stRangeCmpMe
     uint32_t uiRangeDataBytesDecompressed = 0;
     while (uiRangeDataBytesDecompressed < stRangeCmpMessage_.uiNumberOfRangeDataBytes)
     {
-        const auto& stSatBlock = reinterpret_cast<const SatelliteBlock&>(stRangeCmpMessage_.aucRangeData[uiRangeDataBytesDecompressed]);
+        SatelliteBlock stSatBlock;
+        std::memcpy(&stSatBlock, &stRangeCmpMessage_.aucRangeData[uiRangeDataBytesDecompressed], sizeof(SatelliteBlock));
 
         const auto eSystem = GetBitfield<SYSTEM, SAT_SATELLITE_SYSTEM_ID_MASK>(stSatBlock.ulCombinedField);
         const auto ucSignalBlockCount = GetBitfield<uint8_t, SAT_NUM_SIGNAL_BLOCKS_BASE_MASK>(stSatBlock.ulCombinedField);
@@ -445,7 +446,8 @@ void RangeDecompressor::RangeCmp2ToRange(const rangecmp2::RangeCmp& stRangeCmpMe
         for (uint8_t ucSignalBlockIndex = 0; ucSignalBlockIndex < ucSignalBlockCount; ucSignalBlockIndex++)
         {
             // Decompress the signal block
-            const auto& stSigBlock = reinterpret_cast<const SignalBlock&>(stRangeCmpMessage_.aucRangeData[uiRangeDataBytesDecompressed]);
+            SignalBlock stSigBlock;
+            std::memcpy(&stSigBlock, &stRangeCmpMessage_.aucRangeData[uiRangeDataBytesDecompressed], sizeof(SignalBlock));
 
             const auto eSignalType = GetBitfield<SIGNAL_TYPE, SIG_SIGNAL_TYPE_MASK>(stSigBlock.uiCombinedField1);
             const auto ucPsrBitfield = GetBitfield<uint8_t, SIG_PSR_STDDEV_MASK>(stSigBlock.ullCombinedField2);
@@ -497,7 +499,7 @@ void RangeDecompressor::RangeCmp4ToRange(unsigned char* pucData_, Range& stRange
     stRangeMessage_.uiNumberOfObservations = 0;
     uint32_t uiBitOffset = 0;
     uint32_t uiBytesLeft;
-    memcpy(&uiBytesLeft, pucData_, sizeof(uint32_t));
+    std::memcpy(&uiBytesLeft, pucData_, sizeof(uint32_t));
     pucData_ += sizeof(uint32_t);
 
     auto systems = ExtractBitfield<uint16_t, SATELLITE_SYSTEMS_BITS>(&pucData_, uiBytesLeft, uiBitOffset);
@@ -662,7 +664,8 @@ void RangeDecompressor::RangeCmp5ToRange(unsigned char* pucData_, Range& stRange
 
     stRangeMessage_.uiNumberOfObservations = 0;
     uint32_t uiBitOffset = 0;
-    uint32_t uiBytesLeft = *reinterpret_cast<uint32_t*>(pucData_);
+    uint32_t uiBytesLeft;
+    std::memcpy(&uiBytesLeft, pucData_, sizeof(uint32_t));
     pucData_ += sizeof(uint32_t);
 
     auto systems = ExtractBitfield<uint16_t, SATELLITE_SYSTEMS_BITS>(&pucData_, uiBytesLeft, uiBitOffset);
@@ -777,8 +780,18 @@ STATUS RangeDecompressor::Decompress(unsigned char* pucBuffer_, uint32_t uiBuffe
         Range stRange;
         switch (stMetaData_.usMessageId)
         {
-        case RANGECMP_MSG_ID: RangeCmpToRange(*reinterpret_cast<rangecmp::RangeCmp*>(pucTempMessagePointer), stRange); break;
-        case RANGECMP2_MSG_ID: RangeCmp2ToRange(*reinterpret_cast<rangecmp2::RangeCmp*>(pucTempMessagePointer), stRange, stMetaData_); break;
+        case RANGECMP_MSG_ID: {
+            rangecmp::RangeCmp stRangeCmp;
+            std::memcpy(&stRangeCmp, pucTempMessagePointer, sizeof(rangecmp::RangeCmp));
+            RangeCmpToRange(stRangeCmp, stRange);
+            break;
+        }
+        case RANGECMP2_MSG_ID: {
+            rangecmp2::RangeCmp stRangeCmp2;
+            std::memcpy(&stRangeCmp2, pucTempMessagePointer, sizeof(rangecmp2::RangeCmp));
+            RangeCmp2ToRange(stRangeCmp2, stRange, stMetaData_);
+            break;
+        }
         case RANGECMP3_MSG_ID: [[fallthrough]];
         case RANGECMP4_MSG_ID: RangeCmp4ToRange(pucTempMessagePointer, stRange, stMetaData_); break;
         case RANGECMP5_MSG_ID: RangeCmp5ToRange(pucTempMessagePointer, stRange, stMetaData_); break;

--- a/src/decoders/oem/src/rangecmp/range_decompressor.cpp
+++ b/src/decoders/oem/src/rangecmp/range_decompressor.cpp
@@ -445,8 +445,7 @@ void RangeDecompressor::RangeCmp2ToRange(const rangecmp2::RangeCmp& stRangeCmpMe
         for (uint8_t ucSignalBlockIndex = 0; ucSignalBlockIndex < ucSignalBlockCount; ucSignalBlockIndex++)
         {
             // Decompress the signal block
-            SignalBlock stSigBlock;
-            std::memcpy(&stSigBlock, &stRangeCmpMessage_.aucRangeData[uiRangeDataBytesDecompressed], sizeof(SignalBlock));
+            auto stSigBlock = LoadValueFromBuffer<SignalBlock>(&stRangeCmpMessage_.aucRangeData[uiRangeDataBytesDecompressed]);
 
             const auto eSignalType = GetBitfield<SIGNAL_TYPE, SIG_SIGNAL_TYPE_MASK>(stSigBlock.uiCombinedField1);
             const auto ucPsrBitfield = GetBitfield<uint8_t, SIG_PSR_STDDEV_MASK>(stSigBlock.ullCombinedField2);

--- a/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
+++ b/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
@@ -136,7 +136,7 @@ STATUS RxConfigHandler::Decode(const unsigned char* pucMessage_, std::vector<Fie
     {
     case HEADER_FORMAT::ABB_ASCII: {
         // Fix embedded header indentation
-        auto* pcTempBuffer = reinterpret_cast<const char*>(pucTempMessagePointer);
+        const auto* pcTempBuffer = reinterpret_cast<const char*>(pucTempMessagePointer);
         ConsumeAbbrevFormatting(&pcTempBuffer);
         pucTempMessagePointer = reinterpret_cast<const unsigned char*>(pcTempBuffer);
         stEmbeddedMessageData.emplace_back(static_cast<uint8_t>(OEM4_ABBREV_ASCII_SYNC), CopyAndMove(pclFieldDef));
@@ -175,10 +175,7 @@ STATUS RxConfigHandler::Decode(const unsigned char* pucMessage_, std::vector<Fie
         const uint32_t uiCRC = strtoul(reinterpret_cast<const char*>(pucTempMessagePointer), nullptr, 16) ^ 0xFFFFFFFF;
         char pucCRC[OEM4_ASCII_CRC_LENGTH];
         std::to_chars(pucCRC, pucCRC + OEM4_ASCII_CRC_LENGTH, uiCRC, 16);
-        for (uint32_t i = 0; i < OEM4_ASCII_CRC_LENGTH; ++i)
-        {
-            stEmbeddedMessageData.emplace_back(static_cast<uint8_t>(pucCRC[i]), CopyAndMove(pclFieldDef));
-        }
+        for (auto c : pucCRC) { stEmbeddedMessageData.emplace_back(static_cast<uint8_t>(c), CopyAndMove(pclFieldDef)); }
         stEmbeddedMessageData.emplace_back(static_cast<uint8_t>('\r'), CopyAndMove(pclFieldDef));
         stEmbeddedMessageData.emplace_back(static_cast<uint8_t>('\n'), CopyAndMove(pclFieldDef));
         break;

--- a/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
+++ b/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
@@ -136,7 +136,9 @@ STATUS RxConfigHandler::Decode(const unsigned char* pucMessage_, std::vector<Fie
     {
     case HEADER_FORMAT::ABB_ASCII: {
         // Fix embedded header indentation
-        ConsumeAbbrevFormatting(reinterpret_cast<const char**>(&pucTempMessagePointer));
+        auto* pcTempBuffer = reinterpret_cast<const char*>(pucTempMessagePointer);
+        ConsumeAbbrevFormatting(&pcTempBuffer);
+        pucTempMessagePointer = reinterpret_cast<const unsigned char*>(pcTempBuffer);
         stEmbeddedMessageData.emplace_back(static_cast<uint8_t>(OEM4_ABBREV_ASCII_SYNC), CopyAndMove(pclFieldDef));
         uiCopyableEmbeddedMsgBytes = uiTotalPayloadSize - (pucTempMessagePointer - pucMessage_);
         break;
@@ -161,7 +163,7 @@ STATUS RxConfigHandler::Decode(const unsigned char* pucMessage_, std::vector<Fie
     stEmbeddedMessageData.reserve(uiCopyableEmbeddedMsgBytes);
     for (uint32_t i = 0; i < uiCopyableEmbeddedMsgBytes; ++i)
     {
-        stEmbeddedMessageData.emplace_back(*(reinterpret_cast<const uint8_t*>(pucTempMessagePointer)), CopyAndMove(pclFieldDef));
+        stEmbeddedMessageData.emplace_back(static_cast<uint8_t>(*pucTempMessagePointer), CopyAndMove(pclFieldDef));
         pucTempMessagePointer++;
     }
 
@@ -175,14 +177,16 @@ STATUS RxConfigHandler::Decode(const unsigned char* pucMessage_, std::vector<Fie
         std::to_chars(pucCRC, pucCRC + OEM4_ASCII_CRC_LENGTH, uiCRC, 16);
         for (uint32_t i = 0; i < OEM4_ASCII_CRC_LENGTH; ++i)
         {
-            stEmbeddedMessageData.emplace_back(*(reinterpret_cast<uint8_t*>(pucCRC) + i), CopyAndMove(pclFieldDef));
+            stEmbeddedMessageData.emplace_back(static_cast<uint8_t>(pucCRC[i]), CopyAndMove(pclFieldDef));
         }
         stEmbeddedMessageData.emplace_back(static_cast<uint8_t>('\r'), CopyAndMove(pclFieldDef));
         stEmbeddedMessageData.emplace_back(static_cast<uint8_t>('\n'), CopyAndMove(pclFieldDef));
         break;
     }
     case HEADER_FORMAT::BINARY: {
-        uint32_t uiCRC = *reinterpret_cast<const uint32_t*>(pucTempMessagePointer) ^ 0xFFFFFFFF;
+        uint32_t uiCRC;
+        std::memcpy(&uiCRC, pucTempMessagePointer, sizeof(uint32_t));
+        uiCRC ^= 0xFFFFFFFF;
         stEmbeddedMessageData.emplace_back(static_cast<uint8_t>(uiCRC >> 24), CopyAndMove(pclFieldDef));
         stEmbeddedMessageData.emplace_back(static_cast<uint8_t>(uiCRC >> 16), CopyAndMove(pclFieldDef));
         stEmbeddedMessageData.emplace_back(static_cast<uint8_t>(uiCRC >> 8), CopyAndMove(pclFieldDef));
@@ -195,7 +199,7 @@ STATUS RxConfigHandler::Decode(const unsigned char* pucMessage_, std::vector<Fie
     return STATUS::SUCCESS;
 }
 
-STATUS RxConfigHandler::Encode(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+STATUS RxConfigHandler::Encode(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                const std::vector<FieldContainer>& stMessage_, MessageDataStruct& stMessageData_, ENCODE_FORMAT eFormat_) const
 {
     MessageDataStruct stEmbeddedMessageData;
@@ -203,7 +207,7 @@ STATUS RxConfigHandler::Encode(unsigned char** ppucBuffer_, uint32_t uiBufferSiz
     return Encode(ppucBuffer_, uiBufferSize_, stHeader_, stMessage_, stMessageData_, stEmbeddedMessageData, stEmbeddedMetaData, eFormat_);
 }
 
-STATUS RxConfigHandler::EncodeJSON(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+STATUS RxConfigHandler::EncodeJSON(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                    MessageDataStruct& stMessageData_, MessageDataStruct& stEmbeddedMessageData_, MetaDataStruct& stEmbeddedMetaData_,
                                    IntermediateHeader& stEmbeddedHeader_, std::vector<FieldContainer>& stEmbeddedMessage_) const
 {
@@ -238,7 +242,7 @@ STATUS RxConfigHandler::EncodeJSON(unsigned char** ppucBuffer_, uint32_t uiBuffe
     return STATUS::SUCCESS;
 }
 
-STATUS RxConfigHandler::EncodeAbbrevAscii(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+STATUS RxConfigHandler::EncodeAbbrevAscii(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                           MessageDataStruct& stMessageData_, MessageDataStruct& stEmbeddedMessageData_,
                                           MetaDataStruct& stEmbeddedMetaData_, IntermediateHeader& stEmbeddedHeader_,
                                           std::vector<FieldContainer>& stEmbeddedMessage_) const
@@ -275,7 +279,7 @@ STATUS RxConfigHandler::EncodeAbbrevAscii(unsigned char** ppucBuffer_, uint32_t 
     pucTempEncodeBuffer -= 2;
     uiBufferSize_ += 2;
     // add in a space
-    if (!CopyToBuffer(reinterpret_cast<char**>(&pucTempEncodeBuffer), uiBufferSize_, " \r\n")) { return STATUS::BUFFER_FULL; }
+    if (!CopyToBuffer(&pucTempEncodeBuffer, uiBufferSize_, " \r\n")) { return STATUS::BUFFER_FULL; }
     // adjust header pointer for prefix
     stEmbeddedMessageData_.pucMessageHeader -= (szAbbrevAsciiEmbeddedHeaderPrefix.length() - 1);
     // adjust header length for prefix and additoinal ending space
@@ -295,7 +299,7 @@ STATUS RxConfigHandler::EncodeAbbrevAscii(unsigned char** ppucBuffer_, uint32_t 
     return STATUS::SUCCESS;
 }
 
-STATUS RxConfigHandler::EncodeAscii(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+STATUS RxConfigHandler::EncodeAscii(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                     MessageDataStruct& stMessageData_, MessageDataStruct& stEmbeddedMessageData_, MetaDataStruct& stEmbeddedMetaData_,
                                     IntermediateHeader& stEmbeddedHeader_, std::vector<FieldContainer>& stEmbeddedMessage_) const
 {
@@ -329,14 +333,14 @@ STATUS RxConfigHandler::EncodeAscii(unsigned char** ppucBuffer_, uint32_t uiBuff
         CalculateBlockCrc32(stEmbeddedMessageData_.pucMessageHeader + 1, (pucTempEncodeBuffer - stEmbeddedMessageData_.pucMessageHeader) - 2) ^
         0xFFFFFFFF;
     // Write embedded CRC
-    if (!CopyAllToBuffer(reinterpret_cast<char**>(&pucTempEncodeBuffer), uiBufferSize_, HexValue<uint32_t>{uiCrc, 8})) { return STATUS::BUFFER_FULL; }
+    if (!CopyAllToBuffer(&pucTempEncodeBuffer, uiBufferSize_, HexValue<uint32_t>{uiCrc, 8})) { return STATUS::BUFFER_FULL; }
     // Fix embedded message length
     stEmbeddedMessageData_.uiMessageBodyLength = pucTempEncodeBuffer - stEmbeddedMessageData_.pucMessageBody;
 
     // Encode regular CRC
     unsigned char* pucStartPoint = *ppucBuffer_ + 1; // Skip the first byte, which is the sync byte
     uiCrc = CalculateBlockCrc32(pucStartPoint, pucTempEncodeBuffer - pucStartPoint);
-    if (!CopyAllToBuffer(reinterpret_cast<char**>(&pucTempEncodeBuffer), uiBufferSize_, '*', HexValue<uint32_t>{uiCrc, 8}, "\r\n"))
+    if (!CopyAllToBuffer(&pucTempEncodeBuffer, uiBufferSize_, '*', HexValue<uint32_t>{uiCrc, 8}, "\r\n"))
     {
         return STATUS::BUFFER_FULL;
     }
@@ -349,7 +353,7 @@ STATUS RxConfigHandler::EncodeAscii(unsigned char** ppucBuffer_, uint32_t uiBuff
     return STATUS::SUCCESS;
 }
 
-STATUS RxConfigHandler::EncodeBinary(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+STATUS RxConfigHandler::EncodeBinary(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                      MessageDataStruct& stMessageData_, MessageDataStruct& stEmbeddedMessageData_,
                                      MetaDataStruct& stEmbeddedMetaData_, IntermediateHeader& stEmbeddedHeader_,
                                      std::vector<FieldContainer>& stEmbeddedMessage_) const
@@ -378,17 +382,25 @@ STATUS RxConfigHandler::EncodeBinary(unsigned char** ppucBuffer_, uint32_t uiBuf
     uiBufferSize_ += OEM4_BINARY_CRC_LENGTH;
     // Fill in Embedded Binary Header length
     uint32_t uiEmbeddedBodyLength = pucTempEncodeBuffer - stEmbeddedMessageData_.pucMessageBody;
-    reinterpret_cast<Oem4BinaryHeader*>(stEmbeddedMessageData_.pucMessageHeader)->usLength = static_cast<uint16_t>(uiEmbeddedBodyLength);
+    Oem4BinaryHeader stEmbeddedHeader;
+    std::memcpy(&stEmbeddedHeader, stEmbeddedMessageData_.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    stEmbeddedHeader.usLength = static_cast<uint16_t>(uiEmbeddedBodyLength);
+    std::memcpy(stEmbeddedMessageData_.pucMessageHeader, &stEmbeddedHeader, sizeof(Oem4BinaryHeader));
+
     // Fill in Regular Binary Header length
     uint32_t uiRxLength = pucTempEncodeBuffer - stMessageData_.pucMessageBody + OEM4_BINARY_CRC_LENGTH;
-    reinterpret_cast<Oem4BinaryHeader*>(stMessageData_.pucMessageHeader)->usLength = static_cast<uint16_t>(uiRxLength);
+    Oem4BinaryHeader stRxHeader;
+    std::memcpy(&stRxHeader, stMessageData_.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    stRxHeader.usLength = static_cast<uint16_t>(uiRxLength);
+    std::memcpy(stMessageData_.pucMessageHeader, &stRxHeader, sizeof(Oem4BinaryHeader));
+
     // Overwrite Embedded CRC
     uint32_t uiCrc =
         CalculateBlockCrc32(stEmbeddedMessageData_.pucMessageHeader, pucTempEncodeBuffer - stEmbeddedMessageData_.pucMessageHeader) ^ 0xFFFFFFFF;
-    if (!CopyToBuffer(reinterpret_cast<char**>(&pucTempEncodeBuffer), uiBufferSize_, uiCrc)) { return STATUS::BUFFER_FULL; }
+    if (!CopyToBuffer(&pucTempEncodeBuffer, uiBufferSize_, uiCrc)) { return STATUS::BUFFER_FULL; }
     // Add Regular CRC
     uiCrc = CalculateBlockCrc32(stMessageData_.pucMessageHeader, pucTempEncodeBuffer - stMessageData_.pucMessageHeader);
-    if (!CopyToBuffer(reinterpret_cast<char**>(&pucTempEncodeBuffer), uiBufferSize_, uiCrc)) { return STATUS::BUFFER_FULL; }
+    if (!CopyToBuffer(&pucTempEncodeBuffer, uiBufferSize_, uiCrc)) { return STATUS::BUFFER_FULL; }
 
     // -- Resolve Message Lengths --
     stMessageData_.uiMessageBodyLength = pucTempEncodeBuffer - stMessageData_.pucMessageBody;
@@ -398,7 +410,7 @@ STATUS RxConfigHandler::EncodeBinary(unsigned char** ppucBuffer_, uint32_t uiBuf
     return STATUS::SUCCESS;
 }
 
-STATUS RxConfigHandler::Encode(unsigned char** ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
+STATUS RxConfigHandler::Encode(unsigned char* const* ppucBuffer_, uint32_t uiBufferSize_, const IntermediateHeader& stHeader_,
                                const std::vector<FieldContainer>& stMessage_, MessageDataStruct& stMessageData_,
                                MessageDataStruct& stEmbeddedMessageData_, MetaDataStruct& stEmbeddedMetaData_, ENCODE_FORMAT eFormat_) const
 {

--- a/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
+++ b/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
@@ -181,9 +181,7 @@ STATUS RxConfigHandler::Decode(const unsigned char* pucMessage_, std::vector<Fie
         break;
     }
     case HEADER_FORMAT::BINARY: {
-        uint32_t uiCRC;
-        std::memcpy(&uiCRC, pucTempMessagePointer, sizeof(uint32_t));
-        uiCRC ^= 0xFFFFFFFF;
+        auto uiCRC = LoadValueFromBuffer<uint32_t>(pucTempMessagePointer) ^ 0xFFFFFFFF;
         stEmbeddedMessageData.emplace_back(static_cast<uint8_t>(uiCRC >> 24), CopyAndMove(pclFieldDef));
         stEmbeddedMessageData.emplace_back(static_cast<uint8_t>(uiCRC >> 16), CopyAndMove(pclFieldDef));
         stEmbeddedMessageData.emplace_back(static_cast<uint8_t>(uiCRC >> 8), CopyAndMove(pclFieldDef));
@@ -376,15 +374,13 @@ STATUS RxConfigHandler::EncodeBinary(unsigned char* const* ppucBuffer_, uint32_t
     uiBufferSize_ += OEM4_BINARY_CRC_LENGTH;
     // Fill in Embedded Binary Header length
     uint32_t uiEmbeddedBodyLength = pucTempEncodeBuffer - stEmbeddedMessageData_.pucMessageBody;
-    Oem4BinaryHeader stEmbeddedHeader;
-    std::memcpy(&stEmbeddedHeader, stEmbeddedMessageData_.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    auto stEmbeddedHeader = LoadValueFromBuffer<Oem4BinaryHeader>(stEmbeddedMessageData_.pucMessageHeader);
     stEmbeddedHeader.usLength = static_cast<uint16_t>(uiEmbeddedBodyLength);
     std::memcpy(stEmbeddedMessageData_.pucMessageHeader, &stEmbeddedHeader, sizeof(Oem4BinaryHeader));
 
     // Fill in Regular Binary Header length
     uint32_t uiRxLength = pucTempEncodeBuffer - stMessageData_.pucMessageBody + OEM4_BINARY_CRC_LENGTH;
-    Oem4BinaryHeader stRxHeader;
-    std::memcpy(&stRxHeader, stMessageData_.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    auto stRxHeader = LoadValueFromBuffer<Oem4BinaryHeader>(stMessageData_.pucMessageHeader);
     stRxHeader.usLength = static_cast<uint16_t>(uiRxLength);
     std::memcpy(stMessageData_.pucMessageHeader, &stRxHeader, sizeof(Oem4BinaryHeader));
 

--- a/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
+++ b/src/decoders/oem/src/rxconfig/rxconfig_handler.cpp
@@ -340,10 +340,7 @@ STATUS RxConfigHandler::EncodeAscii(unsigned char* const* ppucBuffer_, uint32_t 
     // Encode regular CRC
     unsigned char* pucStartPoint = *ppucBuffer_ + 1; // Skip the first byte, which is the sync byte
     uiCrc = CalculateBlockCrc32(pucStartPoint, pucTempEncodeBuffer - pucStartPoint);
-    if (!CopyAllToBuffer(&pucTempEncodeBuffer, uiBufferSize_, '*', HexValue<uint32_t>{uiCrc, 8}, "\r\n"))
-    {
-        return STATUS::BUFFER_FULL;
-    }
+    if (!CopyAllToBuffer(&pucTempEncodeBuffer, uiBufferSize_, '*', HexValue<uint32_t>{uiCrc, 8}, "\r\n")) { return STATUS::BUFFER_FULL; }
 
     // -- Resolve Message Lengths --
     stMessageData_.uiMessageBodyLength = pucTempEncodeBuffer - stMessageData_.pucMessageBody;

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -2243,12 +2243,20 @@ class DecodeEncodeTest : public ::testing::Test
         ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, pucLog1, aucLog1EncodeBuffer, sizeof(aucLog1EncodeBuffer), stMetaData1, stMessageData1));
         ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, pucLog2, aucLog2EncodeBuffer, sizeof(aucLog2EncodeBuffer), stMetaData2, stMessageData2));
 
-        ASSERT_EQ(*reinterpret_cast<Oem4BinaryHeader*>(stMessageData1.pucMessageHeader), *reinterpret_cast<T2*>(stMessageData2.pucMessageHeader));
+        Oem4BinaryHeader stHeader1;
+        std::memcpy(&stHeader1, stMessageData1.pucMessageHeader, sizeof(Oem4BinaryHeader));
+        T2 stHeader2;
+        std::memcpy(&stHeader2, stMessageData2.pucMessageHeader, sizeof(T2));
+        ASSERT_EQ(stHeader1, stHeader2);
 
         // we shouldn't have to do this. should make structs for the log types tested with T != void
         if constexpr (!std::is_same<T, void>())
         {
-            ASSERT_EQ(*reinterpret_cast<T*>(stMessageData1.pucMessageBody), *reinterpret_cast<T*>(stMessageData2.pucMessageBody));
+            T stLog1;
+            std::memcpy(&stLog1, stMessageData1.pucMessageBody, sizeof(T));
+            T stLog2;
+            std::memcpy(&stLog2, stMessageData2.pucMessageBody, sizeof(T));
+            ASSERT_EQ(stLog1, stLog2);
         }
     }
 
@@ -2367,36 +2375,37 @@ TEST_F(DecodeEncodeTest, ASCII_LOG_ROUNDTRIP_GLOEPHEM)
 
     ASSERT_EQ(0, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucEncodeBuffer, sizeof(acEncodeBuffer), stMetaData, stMessageData));
 
-    auto* pstGloEphemeris = reinterpret_cast<GLOEPHEMERIS*>(stMessageData.pucMessageBody);
-    ASSERT_EQ(pstGloEphemeris->sloto, 51);
-    ASSERT_EQ(pstGloEphemeris->freqo, 0);
-    ASSERT_EQ(pstGloEphemeris->sat_type, 1);
-    ASSERT_EQ(pstGloEphemeris->false_iod, 80);
-    ASSERT_EQ(pstGloEphemeris->ephem_week, 2168);
-    ASSERT_EQ(pstGloEphemeris->ephem_time, 161118000U);
-    ASSERT_EQ(pstGloEphemeris->time_offset, 10782U);
-    ASSERT_EQ(pstGloEphemeris->nt, 573);
-    ASSERT_EQ(pstGloEphemeris->GLOEPHEMERIS_reserved, 0);
-    ASSERT_EQ(pstGloEphemeris->GLOEPHEMERIS_reserved_9, 0);
-    ASSERT_EQ(pstGloEphemeris->issue, 95U);
-    ASSERT_EQ(pstGloEphemeris->broadcast_health, 0U);
-    ASSERT_EQ(pstGloEphemeris->pos_x, -2.3917966796875000e+07);
-    ASSERT_EQ(pstGloEphemeris->pos_y, 4.8163881835937500e+06);
-    ASSERT_EQ(pstGloEphemeris->pos_z, 7.4258510742187500e+06);
-    ASSERT_EQ(pstGloEphemeris->vel_x, -1.0062713623046875e+03);
-    ASSERT_EQ(pstGloEphemeris->vel_y, 1.8321990966796875e+02);
-    ASSERT_EQ(pstGloEphemeris->vel_z, -3.3695755004882813e+03);
-    ASSERT_NEAR(pstGloEphemeris->ls_acc_x, 1.86264514923095700e-06, 0.0000000000000001e-06);
-    ASSERT_NEAR(pstGloEphemeris->ls_acc_y, -9.31322574615478510e-07, 0.0000000000000001e-07);
-    ASSERT_NEAR(pstGloEphemeris->ls_acc_z, -0.00000000000000000, 0.0000000000000001);
-    ASSERT_NEAR(pstGloEphemeris->tau, -6.69313594698905940e-05, 0.0000000000000001e-05);
-    ASSERT_EQ(pstGloEphemeris->delta_tau, 5.587935448e-09);
-    ASSERT_NEAR(pstGloEphemeris->gamma, 0.00000000000000000, 0.0000000000000001);
-    ASSERT_EQ(pstGloEphemeris->tk, 84600U);
-    ASSERT_EQ(pstGloEphemeris->p, 3U);
-    ASSERT_EQ(pstGloEphemeris->ft, 2U);
-    ASSERT_EQ(pstGloEphemeris->age, 0U);
-    ASSERT_EQ(pstGloEphemeris->flags, 13U);
+    GLOEPHEMERIS stGloEphemeris;
+    std::memcpy(&stGloEphemeris, stMessageData.pucMessageBody, sizeof(GLOEPHEMERIS));
+    ASSERT_EQ(stGloEphemeris.sloto, 51);
+    ASSERT_EQ(stGloEphemeris.freqo, 0);
+    ASSERT_EQ(stGloEphemeris.sat_type, 1);
+    ASSERT_EQ(stGloEphemeris.false_iod, 80);
+    ASSERT_EQ(stGloEphemeris.ephem_week, 2168);
+    ASSERT_EQ(stGloEphemeris.ephem_time, 161118000U);
+    ASSERT_EQ(stGloEphemeris.time_offset, 10782U);
+    ASSERT_EQ(stGloEphemeris.nt, 573);
+    ASSERT_EQ(stGloEphemeris.GLOEPHEMERIS_reserved, 0);
+    ASSERT_EQ(stGloEphemeris.GLOEPHEMERIS_reserved_9, 0);
+    ASSERT_EQ(stGloEphemeris.issue, 95U);
+    ASSERT_EQ(stGloEphemeris.broadcast_health, 0U);
+    ASSERT_EQ(stGloEphemeris.pos_x, -2.3917966796875000e+07);
+    ASSERT_EQ(stGloEphemeris.pos_y, 4.8163881835937500e+06);
+    ASSERT_EQ(stGloEphemeris.pos_z, 7.4258510742187500e+06);
+    ASSERT_EQ(stGloEphemeris.vel_x, -1.0062713623046875e+03);
+    ASSERT_EQ(stGloEphemeris.vel_y, 1.8321990966796875e+02);
+    ASSERT_EQ(stGloEphemeris.vel_z, -3.3695755004882813e+03);
+    ASSERT_NEAR(stGloEphemeris.ls_acc_x, 1.86264514923095700e-06, 0.0000000000000001e-06);
+    ASSERT_NEAR(stGloEphemeris.ls_acc_y, -9.31322574615478510e-07, 0.0000000000000001e-07);
+    ASSERT_NEAR(stGloEphemeris.ls_acc_z, -0.00000000000000000, 0.0000000000000001);
+    ASSERT_NEAR(stGloEphemeris.tau, -6.69313594698905940e-05, 0.0000000000000001e-05);
+    ASSERT_EQ(stGloEphemeris.delta_tau, 5.587935448e-09);
+    ASSERT_NEAR(stGloEphemeris.gamma, 0.00000000000000000, 0.0000000000000001);
+    ASSERT_EQ(stGloEphemeris.tk, 84600U);
+    ASSERT_EQ(stGloEphemeris.p, 3U);
+    ASSERT_EQ(stGloEphemeris.ft, 2U);
+    ASSERT_EQ(stGloEphemeris.age, 0U);
+    ASSERT_EQ(stGloEphemeris.flags, 13U);
 }
 
 TEST_F(DecodeEncodeTest, ASCII_LOG_ROUNDTRIP_IONUTC)
@@ -2617,47 +2626,49 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_BESTPOS)
 
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
 
-    auto* pstLogHeader = reinterpret_cast<Oem4BinaryHeader*>(stMessageData.pucMessageHeader);
-    ASSERT_EQ(pstLogHeader->ucSync1, OEM4_BINARY_SYNC1);
-    ASSERT_EQ(pstLogHeader->ucSync2, OEM4_BINARY_SYNC2);
-    ASSERT_EQ(pstLogHeader->ucSync3, OEM4_BINARY_SYNC3);
-    ASSERT_EQ(pstLogHeader->ucHeaderLength, OEM4_BINARY_HEADER_LENGTH);
-    ASSERT_EQ(pstLogHeader->usMsgNumber, 42);
-    ASSERT_EQ(pstLogHeader->ucMsgType, 0);
-    ASSERT_EQ(pstLogHeader->ucPort, 0x20);
-    ASSERT_EQ(pstLogHeader->usLength, 72);
-    ASSERT_EQ(pstLogHeader->usSequenceNumber, 0);
-    ASSERT_EQ(pstLogHeader->ucIdleTime, 0x90);
-    ASSERT_EQ(pstLogHeader->ucTimeStatus, 180);
-    ASSERT_EQ(pstLogHeader->usWeekNo, 2215);
-    ASSERT_EQ(pstLogHeader->uiWeekMSec, 148248000U);
-    ASSERT_EQ(pstLogHeader->uiStatus, 0x02000020U);
-    ASSERT_EQ(pstLogHeader->usMsgDefCrc, 0xcdba);
-    ASSERT_EQ(pstLogHeader->usReceiverSwVersion, 32768);
+    Oem4BinaryHeader stHeader;
+    std::memcpy(&stHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    ASSERT_EQ(stHeader.ucSync1, OEM4_BINARY_SYNC1);
+    ASSERT_EQ(stHeader.ucSync2, OEM4_BINARY_SYNC2);
+    ASSERT_EQ(stHeader.ucSync3, OEM4_BINARY_SYNC3);
+    ASSERT_EQ(stHeader.ucHeaderLength, OEM4_BINARY_HEADER_LENGTH);
+    ASSERT_EQ(stHeader.usMsgNumber, 42);
+    ASSERT_EQ(stHeader.ucMsgType, 0);
+    ASSERT_EQ(stHeader.ucPort, 0x20);
+    ASSERT_EQ(stHeader.usLength, 72);
+    ASSERT_EQ(stHeader.usSequenceNumber, 0);
+    ASSERT_EQ(stHeader.ucIdleTime, 0x90);
+    ASSERT_EQ(stHeader.ucTimeStatus, 180);
+    ASSERT_EQ(stHeader.usWeekNo, 2215);
+    ASSERT_EQ(stHeader.uiWeekMSec, 148248000U);
+    ASSERT_EQ(stHeader.uiStatus, 0x02000020U);
+    ASSERT_EQ(stHeader.usMsgDefCrc, 0xcdba);
+    ASSERT_EQ(stHeader.usReceiverSwVersion, 32768);
 
     // SOL_COMPUTED SINGLE 51.15043711386 -114.03067767000 1097.2099 -17.0000 WGS84 0.9038 0.8534 1.7480 \"\" 0.000 0.000 35 30 30 30 00 06 39 33\r\n"
-    auto* pstLogBody = reinterpret_cast<BESTPOS*>(stMessageData.pucMessageBody);
-    ASSERT_EQ(pstLogBody->solution_status, 0);
-    ASSERT_EQ(pstLogBody->position_type, 16);
-    ASSERT_EQ(pstLogBody->latitude, 51.15043711386);
-    ASSERT_EQ(pstLogBody->longitude, -114.03067767000);
-    ASSERT_EQ(pstLogBody->orthometric_height, 1097.2099);
-    ASSERT_EQ(pstLogBody->undulation, -17.0000);
-    ASSERT_EQ(pstLogBody->datum_id, 61);
-    ASSERT_NEAR(pstLogBody->latitude_std_dev, 0.9038, 0.00001);
-    ASSERT_NEAR(pstLogBody->longitude_std_dev, 0.8534, 0.00001);
-    ASSERT_NEAR(pstLogBody->height_std_dev, 1.7480, 0.00001);
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->base_id), ""));
-    ASSERT_EQ(pstLogBody->diff_age, 0.000);
-    ASSERT_EQ(pstLogBody->solution_age, 0.000);
-    ASSERT_EQ(pstLogBody->num_svs, 35);
-    ASSERT_EQ(pstLogBody->num_soln_svs, 30);
-    ASSERT_EQ(pstLogBody->num_soln_L1_svs, 30);
-    ASSERT_EQ(pstLogBody->num_soln_multi_svs, 30);
-    ASSERT_EQ(pstLogBody->extended_solution_status2, 0x00);
-    ASSERT_EQ(pstLogBody->ext_sol_stat, 0x06);
-    ASSERT_EQ(pstLogBody->gal_and_bds_mask, 0x39);
-    ASSERT_EQ(pstLogBody->gps_and_glo_mask, 0x33);
+    BESTPOS stLogBody;
+    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(BESTPOS));
+    ASSERT_EQ(stLogBody.solution_status, 0);
+    ASSERT_EQ(stLogBody.position_type, 16);
+    ASSERT_EQ(stLogBody.latitude, 51.15043711386);
+    ASSERT_EQ(stLogBody.longitude, -114.03067767000);
+    ASSERT_EQ(stLogBody.orthometric_height, 1097.2099);
+    ASSERT_EQ(stLogBody.undulation, -17.0000);
+    ASSERT_EQ(stLogBody.datum_id, 61);
+    ASSERT_NEAR(stLogBody.latitude_std_dev, 0.9038, 0.00001);
+    ASSERT_NEAR(stLogBody.longitude_std_dev, 0.8534, 0.00001);
+    ASSERT_NEAR(stLogBody.height_std_dev, 1.7480, 0.00001);
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.base_id), ""));
+    ASSERT_EQ(stLogBody.diff_age, 0.000);
+    ASSERT_EQ(stLogBody.solution_age, 0.000);
+    ASSERT_EQ(stLogBody.num_svs, 35);
+    ASSERT_EQ(stLogBody.num_soln_svs, 30);
+    ASSERT_EQ(stLogBody.num_soln_L1_svs, 30);
+    ASSERT_EQ(stLogBody.num_soln_multi_svs, 30);
+    ASSERT_EQ(stLogBody.extended_solution_status2, 0x00);
+    ASSERT_EQ(stLogBody.ext_sol_stat, 0x06);
+    ASSERT_EQ(stLogBody.gal_and_bds_mask, 0x39);
+    ASSERT_EQ(stLogBody.gps_and_glo_mask, 0x33);
 }
 
 TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_GLOEPHEMA)
@@ -2672,54 +2683,56 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_GLOEPHEMA)
 
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
 
-    auto* pstLogHeader = reinterpret_cast<Oem4BinaryHeader*>(stMessageData.pucMessageHeader);
-    ASSERT_EQ(pstLogHeader->ucSync1, OEM4_BINARY_SYNC1);
-    ASSERT_EQ(pstLogHeader->ucSync2, OEM4_BINARY_SYNC2);
-    ASSERT_EQ(pstLogHeader->ucSync3, OEM4_BINARY_SYNC3);
-    ASSERT_EQ(pstLogHeader->ucHeaderLength, OEM4_BINARY_HEADER_LENGTH);
-    ASSERT_EQ(pstLogHeader->usMsgNumber, 723);
-    ASSERT_EQ(pstLogHeader->ucMsgType, 0);
-    ASSERT_EQ(pstLogHeader->ucPort, 0x20);
-    ASSERT_EQ(pstLogHeader->usLength, 144);
-    ASSERT_EQ(pstLogHeader->usSequenceNumber, 11);
-    ASSERT_EQ(pstLogHeader->ucIdleTime, 0x86);
-    ASSERT_EQ(pstLogHeader->ucTimeStatus, 200);
-    ASSERT_EQ(pstLogHeader->usWeekNo, 2168);
-    ASSERT_EQ(pstLogHeader->uiWeekMSec, 160218000U);
-    ASSERT_EQ(pstLogHeader->uiStatus, 0x02000820U);
-    ASSERT_EQ(pstLogHeader->usMsgDefCrc, 0x8d29);
-    ASSERT_EQ(pstLogHeader->usReceiverSwVersion, 32768);
+    Oem4BinaryHeader stLogHeader;
+    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    ASSERT_EQ(stLogHeader.ucSync1, OEM4_BINARY_SYNC1);
+    ASSERT_EQ(stLogHeader.ucSync2, OEM4_BINARY_SYNC2);
+    ASSERT_EQ(stLogHeader.ucSync3, OEM4_BINARY_SYNC3);
+    ASSERT_EQ(stLogHeader.ucHeaderLength, OEM4_BINARY_HEADER_LENGTH);
+    ASSERT_EQ(stLogHeader.usMsgNumber, 723);
+    ASSERT_EQ(stLogHeader.ucMsgType, 0);
+    ASSERT_EQ(stLogHeader.ucPort, 0x20);
+    ASSERT_EQ(stLogHeader.usLength, 144);
+    ASSERT_EQ(stLogHeader.usSequenceNumber, 11);
+    ASSERT_EQ(stLogHeader.ucIdleTime, 0x86);
+    ASSERT_EQ(stLogHeader.ucTimeStatus, 200);
+    ASSERT_EQ(stLogHeader.usWeekNo, 2168);
+    ASSERT_EQ(stLogHeader.uiWeekMSec, 160218000U);
+    ASSERT_EQ(stLogHeader.uiStatus, 0x02000820U);
+    ASSERT_EQ(stLogHeader.usMsgDefCrc, 0x8d29);
+    ASSERT_EQ(stLogHeader.usReceiverSwVersion, 32768);
 
-    auto* pstLogBody = reinterpret_cast<GLOEPHEMERIS*>(stMessageData.pucMessageBody);
-    ASSERT_EQ(pstLogBody->sloto, 51);
-    ASSERT_EQ(pstLogBody->freqo, 0);
-    ASSERT_EQ(pstLogBody->sat_type, 1);
-    ASSERT_EQ(pstLogBody->false_iod, 80);
-    ASSERT_EQ(pstLogBody->ephem_week, 2168);
-    ASSERT_EQ(pstLogBody->ephem_time, 161118000U);
-    ASSERT_EQ(pstLogBody->time_offset, 10782U);
-    ASSERT_EQ(pstLogBody->nt, 573);
-    ASSERT_EQ(pstLogBody->GLOEPHEMERIS_reserved, 0);
-    ASSERT_EQ(pstLogBody->GLOEPHEMERIS_reserved_9, 0);
-    ASSERT_EQ(pstLogBody->issue, 95U);
-    ASSERT_EQ(pstLogBody->broadcast_health, 0U);
-    ASSERT_EQ(pstLogBody->pos_x, -2.3917966796875000e+07);
-    ASSERT_EQ(pstLogBody->pos_y, 4.8163881835937500e+06);
-    ASSERT_EQ(pstLogBody->pos_z, 7.4258510742187500e+06);
-    ASSERT_EQ(pstLogBody->vel_x, -1.0062713623046875e+03);
-    ASSERT_EQ(pstLogBody->vel_y, 1.8321990966796875e+02);
-    ASSERT_EQ(pstLogBody->vel_z, -3.3695755004882813e+03);
-    ASSERT_NEAR(pstLogBody->ls_acc_x, 1.86264514923095700e-06, 0.0000000000000001e-06);
-    ASSERT_NEAR(pstLogBody->ls_acc_y, -9.31322574615478510e-07, 0.0000000000000001e-07);
-    ASSERT_NEAR(pstLogBody->ls_acc_z, -0.00000000000000000, 0.0000000000000001);
-    ASSERT_NEAR(pstLogBody->tau, -6.69313594698905940e-05, 0.0000000000000001e-05);
-    ASSERT_EQ(pstLogBody->delta_tau, 5.587935448e-09);
-    ASSERT_NEAR(pstLogBody->gamma, 0.00000000000000000, 0.0000000000000001);
-    ASSERT_EQ(pstLogBody->tk, 84600U);
-    ASSERT_EQ(pstLogBody->p, 3U);
-    ASSERT_EQ(pstLogBody->ft, 2U);
-    ASSERT_EQ(pstLogBody->age, 0U);
-    ASSERT_EQ(pstLogBody->flags, 13U);
+    GLOEPHEMERIS stLogBody;
+    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(GLOEPHEMERIS));
+    ASSERT_EQ(stLogBody.sloto, 51);
+    ASSERT_EQ(stLogBody.freqo, 0);
+    ASSERT_EQ(stLogBody.sat_type, 1);
+    ASSERT_EQ(stLogBody.false_iod, 80);
+    ASSERT_EQ(stLogBody.ephem_week, 2168);
+    ASSERT_EQ(stLogBody.ephem_time, 161118000U);
+    ASSERT_EQ(stLogBody.time_offset, 10782U);
+    ASSERT_EQ(stLogBody.nt, 573);
+    ASSERT_EQ(stLogBody.GLOEPHEMERIS_reserved, 0);
+    ASSERT_EQ(stLogBody.GLOEPHEMERIS_reserved_9, 0);
+    ASSERT_EQ(stLogBody.issue, 95U);
+    ASSERT_EQ(stLogBody.broadcast_health, 0U);
+    ASSERT_EQ(stLogBody.pos_x, -2.3917966796875000e+07);
+    ASSERT_EQ(stLogBody.pos_y, 4.8163881835937500e+06);
+    ASSERT_EQ(stLogBody.pos_z, 7.4258510742187500e+06);
+    ASSERT_EQ(stLogBody.vel_x, -1.0062713623046875e+03);
+    ASSERT_EQ(stLogBody.vel_y, 1.8321990966796875e+02);
+    ASSERT_EQ(stLogBody.vel_z, -3.3695755004882813e+03);
+    ASSERT_NEAR(stLogBody.ls_acc_x, 1.86264514923095700e-06, 0.0000000000000001e-06);
+    ASSERT_NEAR(stLogBody.ls_acc_y, -9.31322574615478510e-07, 0.0000000000000001e-07);
+    ASSERT_NEAR(stLogBody.ls_acc_z, -0.00000000000000000, 0.0000000000000001);
+    ASSERT_NEAR(stLogBody.tau, -6.69313594698905940e-05, 0.0000000000000001e-05);
+    ASSERT_EQ(stLogBody.delta_tau, 5.587935448e-09);
+    ASSERT_NEAR(stLogBody.gamma, 0.00000000000000000, 0.0000000000000001);
+    ASSERT_EQ(stLogBody.tk, 84600U);
+    ASSERT_EQ(stLogBody.p, 3U);
+    ASSERT_EQ(stLogBody.ft, 2U);
+    ASSERT_EQ(stLogBody.age, 0U);
+    ASSERT_EQ(stLogBody.flags, 13U);
 }
 
 TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_PORTSTATSB)
@@ -2737,9 +2750,12 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_PORTSTATSB)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
     ASSERT_EQ(1356U, stMessageData.uiMessageLength);
 
-    Oem4BinaryHeader stLogHeader = *reinterpret_cast<Oem4BinaryHeader*>(stMessageData.pucMessageHeader);
-    PORTSTATS stLogBody = *reinterpret_cast<PORTSTATS*>(stMessageData.pucMessageBody);
-    Oem4BinaryHeader stTestLogHeader = *reinterpret_cast<Oem4BinaryHeader*>(aucLog);
+    Oem4BinaryHeader stLogHeader;
+    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    PORTSTATS stLogBody;
+    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(PORTSTATS));
+    Oem4BinaryHeader stTestLogHeader;
+    std::memcpy(&stTestLogHeader, aucLog, sizeof(Oem4BinaryHeader));
     stTestLogHeader.usLength = 1356 - (OEM4_BINARY_HEADER_LENGTH + OEM4_BINARY_CRC_LENGTH); // Change the length so header comparison passes
     ASSERT_EQ(stTestLogHeader, stLogHeader);
 
@@ -2781,9 +2797,12 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_PSRDOPB)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
     ASSERT_EQ(1360U, stMessageData.uiMessageLength);
 
-    auto stLogHeader = *reinterpret_cast<Oem4BinaryHeader*>(stMessageData.pucMessageHeader);
-    auto stLogBody = *reinterpret_cast<PSRDOP*>(stMessageData.pucMessageBody);
-    auto stTestLogHeader = *reinterpret_cast<Oem4BinaryHeader*>(aucLog);
+    Oem4BinaryHeader stLogHeader;
+    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    PSRDOP stLogBody;
+    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(PSRDOP));
+    Oem4BinaryHeader stTestLogHeader;
+    std::memcpy(&stTestLogHeader, aucLog, sizeof(Oem4BinaryHeader));
     stTestLogHeader.usLength = 1360 - (OEM4_BINARY_HEADER_LENGTH + OEM4_BINARY_CRC_LENGTH); // Change the length so header comparison passes
     ASSERT_EQ(stTestLogHeader, stLogHeader);
 
@@ -2814,9 +2833,12 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_VALIDMODELSB)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
     ASSERT_EQ(708U, stMessageData.uiMessageLength);
 
-    auto stLogHeader = *reinterpret_cast<Oem4BinaryHeader*>(stMessageData.pucMessageHeader);
-    auto stLogBody = *reinterpret_cast<VALIDMODELS*>(stMessageData.pucMessageBody);
-    auto stTestLogHeader = *reinterpret_cast<Oem4BinaryHeader*>(aucLog);
+    Oem4BinaryHeader stLogHeader;
+    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    VALIDMODELS stLogBody;
+    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(VALIDMODELS));
+    Oem4BinaryHeader stTestLogHeader;
+    std::memcpy(&stTestLogHeader, aucLog, sizeof(Oem4BinaryHeader));
     stTestLogHeader.usLength = 708 - (OEM4_BINARY_HEADER_LENGTH + OEM4_BINARY_CRC_LENGTH); // Change the length so header comparison passes
     ASSERT_EQ(stTestLogHeader, stLogHeader);
 
@@ -2854,68 +2876,70 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_VERSION)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
     ASSERT_EQ(2196U, stMessageData.uiMessageLength);
 
-    auto* pstLogHeader = reinterpret_cast<Oem4BinaryHeader*>(stMessageData.pucMessageHeader);
-    ASSERT_EQ(pstLogHeader->ucSync1, OEM4_BINARY_SYNC1);
-    ASSERT_EQ(pstLogHeader->ucSync2, OEM4_BINARY_SYNC2);
-    ASSERT_EQ(pstLogHeader->ucSync3, OEM4_BINARY_SYNC3);
-    ASSERT_EQ(pstLogHeader->ucHeaderLength, OEM4_BINARY_HEADER_LENGTH);
-    ASSERT_EQ(pstLogHeader->usMsgNumber, 37);
-    ASSERT_EQ(pstLogHeader->ucMsgType, 0);
-    ASSERT_EQ(pstLogHeader->ucPort, 0x20);
-    ASSERT_EQ(pstLogHeader->usLength, 2164);
-    ASSERT_EQ(pstLogHeader->usSequenceNumber, 0);
-    ASSERT_EQ(pstLogHeader->ucIdleTime, 0x8D);
-    ASSERT_EQ(pstLogHeader->ucTimeStatus, 180);
-    ASSERT_EQ(pstLogHeader->usWeekNo, 2215);
-    ASSERT_EQ(pstLogHeader->uiWeekMSec, 148710357U);
-    ASSERT_EQ(pstLogHeader->uiStatus, 0x02000020U);
-    ASSERT_EQ(pstLogHeader->usMsgDefCrc, 0x3681);
-    ASSERT_EQ(pstLogHeader->usReceiverSwVersion, 32768);
+    Oem4BinaryHeader stLogHeader;
+    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    ASSERT_EQ(stLogHeader.ucSync1, OEM4_BINARY_SYNC1);
+    ASSERT_EQ(stLogHeader.ucSync2, OEM4_BINARY_SYNC2);
+    ASSERT_EQ(stLogHeader.ucSync3, OEM4_BINARY_SYNC3);
+    ASSERT_EQ(stLogHeader.ucHeaderLength, OEM4_BINARY_HEADER_LENGTH);
+    ASSERT_EQ(stLogHeader.usMsgNumber, 37);
+    ASSERT_EQ(stLogHeader.ucMsgType, 0);
+    ASSERT_EQ(stLogHeader.ucPort, 0x20);
+    ASSERT_EQ(stLogHeader.usLength, 2164);
+    ASSERT_EQ(stLogHeader.usSequenceNumber, 0);
+    ASSERT_EQ(stLogHeader.ucIdleTime, 0x8D);
+    ASSERT_EQ(stLogHeader.ucTimeStatus, 180);
+    ASSERT_EQ(stLogHeader.usWeekNo, 2215);
+    ASSERT_EQ(stLogHeader.uiWeekMSec, 148710357U);
+    ASSERT_EQ(stLogHeader.uiStatus, 0x02000020U);
+    ASSERT_EQ(stLogHeader.usMsgDefCrc, 0x3681);
+    ASSERT_EQ(stLogHeader.usReceiverSwVersion, 32768);
 
-    auto* pstLogBody = reinterpret_cast<VERSION*>(stMessageData.pucMessageBody);
+    VERSION stLogBody;
+    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(VERSION));
 
     // Check the populated parts of the log
-    ASSERT_EQ(4U, pstLogBody->versions_arraylength);
+    ASSERT_EQ(4U, stLogBody.versions_arraylength);
 
     // Check GPSCARD fields
-    ASSERT_EQ(pstLogBody->versions[0].component_type, 1);
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].model_name), "FFNRNNCBN"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].psn), "BMGX15360035V"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].hardware_version), "OEM729-0.00H"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].software_version), "OM7MG0810DN0000"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].boot_version), "OM7BR0000ABG001"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].compile_date), "2022/Jun/17"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].compile_time), "08:24:06"));
+    ASSERT_EQ(stLogBody.versions[0].component_type, 1);
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].model_name), "FFNRNNCBN"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].psn), "BMGX15360035V"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].hardware_version), "OEM729-0.00H"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].software_version), "OM7MG0810DN0000"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].boot_version), "OM7BR0000ABG001"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].compile_date), "2022/Jun/17"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].compile_time), "08:24:06"));
 
     // Check OEM7FPGA fields
-    ASSERT_EQ(pstLogBody->versions[1].component_type, 21);
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].model_name), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].psn), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].hardware_version), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].software_version), "OMV070001RN0000"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].boot_version), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].compile_date), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].compile_time), ""));
+    ASSERT_EQ(stLogBody.versions[1].component_type, 21);
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].model_name), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].psn), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].hardware_version), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].software_version), "OMV070001RN0000"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].boot_version), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].compile_date), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].compile_time), ""));
 
     // Check DB_LUA_SCRIPTS fields
-    ASSERT_EQ(pstLogBody->versions[2].component_type, 981073930);
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[2].model_name), "SCRIPTS"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[2].psn), "Block1"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[2].hardware_version), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[2].software_version), "Package1_1.0"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[2].boot_version), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[2].compile_date), "2017/Oct/27"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[2].compile_time), "16:02:54"));
+    ASSERT_EQ(stLogBody.versions[2].component_type, 981073930);
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[2].model_name), "SCRIPTS"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[2].psn), "Block1"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[2].hardware_version), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[2].software_version), "Package1_1.0"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[2].boot_version), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[2].compile_date), "2017/Oct/27"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[2].compile_time), "16:02:54"));
 
     // Check DB_WWWISO fields
-    ASSERT_EQ(pstLogBody->versions[3].component_type, 981073928);
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[3].model_name), "WWWISO"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[3].psn), "0"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[3].hardware_version), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[3].software_version), "WMC010202RN0002"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[3].boot_version), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[3].compile_date), "2017/Dec/15"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[3].compile_time), "9:08:56"));
+    ASSERT_EQ(stLogBody.versions[3].component_type, 981073928);
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[3].model_name), "WWWISO"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[3].psn), "0"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[3].hardware_version), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[3].software_version), "WMC010202RN0002"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[3].boot_version), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[3].compile_date), "2017/Dec/15"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[3].compile_time), "9:08:56"));
 }
 
 TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_VERSIONA)
@@ -2931,60 +2955,62 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_VERSIONA)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
     ASSERT_EQ(2196U, stMessageData.uiMessageLength);
 
-    auto* pstLogHeader = reinterpret_cast<Oem4BinaryHeader*>(stMessageData.pucMessageHeader);
-    ASSERT_EQ(pstLogHeader->ucSync1, OEM4_BINARY_SYNC1);
-    ASSERT_EQ(pstLogHeader->ucSync2, OEM4_BINARY_SYNC2);
-    ASSERT_EQ(pstLogHeader->ucSync3, OEM4_BINARY_SYNC3);
-    ASSERT_EQ(pstLogHeader->ucHeaderLength, OEM4_BINARY_HEADER_LENGTH);
-    ASSERT_EQ(pstLogHeader->usMsgNumber, 37);
-    ASSERT_EQ(pstLogHeader->ucMsgType, 0);
-    ASSERT_EQ(pstLogHeader->ucPort, 0x20);
-    ASSERT_EQ(pstLogHeader->usLength, 2164);
-    ASSERT_EQ(pstLogHeader->usSequenceNumber, 0);
-    ASSERT_EQ(pstLogHeader->ucIdleTime, 0x6F);
-    ASSERT_EQ(pstLogHeader->ucTimeStatus, 180);
-    ASSERT_EQ(pstLogHeader->usWeekNo, 2167);
-    ASSERT_EQ(pstLogHeader->uiWeekMSec, 254938857U);
-    ASSERT_EQ(pstLogHeader->uiStatus, 0x02000000U);
-    ASSERT_EQ(pstLogHeader->usMsgDefCrc, 0x3681);
-    ASSERT_EQ(pstLogHeader->usReceiverSwVersion, 16248);
+    Oem4BinaryHeader stLogHeader;
+    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    ASSERT_EQ(stLogHeader.ucSync1, OEM4_BINARY_SYNC1);
+    ASSERT_EQ(stLogHeader.ucSync2, OEM4_BINARY_SYNC2);
+    ASSERT_EQ(stLogHeader.ucSync3, OEM4_BINARY_SYNC3);
+    ASSERT_EQ(stLogHeader.ucHeaderLength, OEM4_BINARY_HEADER_LENGTH);
+    ASSERT_EQ(stLogHeader.usMsgNumber, 37);
+    ASSERT_EQ(stLogHeader.ucMsgType, 0);
+    ASSERT_EQ(stLogHeader.ucPort, 0x20);
+    ASSERT_EQ(stLogHeader.usLength, 2164);
+    ASSERT_EQ(stLogHeader.usSequenceNumber, 0);
+    ASSERT_EQ(stLogHeader.ucIdleTime, 0x6F);
+    ASSERT_EQ(stLogHeader.ucTimeStatus, 180);
+    ASSERT_EQ(stLogHeader.usWeekNo, 2167);
+    ASSERT_EQ(stLogHeader.uiWeekMSec, 254938857U);
+    ASSERT_EQ(stLogHeader.uiStatus, 0x02000000U);
+    ASSERT_EQ(stLogHeader.usMsgDefCrc, 0x3681);
+    ASSERT_EQ(stLogHeader.usReceiverSwVersion, 16248);
 
-    auto* pstLogBody = reinterpret_cast<VERSION*>(stMessageData.pucMessageBody);
+    VERSION stLogBody;
+    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(VERSION));
 
     // Check the populated parts of the log
-    ASSERT_EQ(8U, pstLogBody->versions_arraylength);
+    ASSERT_EQ(8U, stLogBody.versions_arraylength);
 
     // Check GPSCARD fields
-    ASSERT_EQ(pstLogBody->versions[0].component_type, 1);
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].model_name), "FFNBYNTMNP1"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].psn), "BMHR15470120X"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].hardware_version), "OEM719N-0.00C"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].software_version), "OM7CR0707RN0000"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].boot_version), "OM7BR0000RBG000"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].compile_date), "2020/Apr/09"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[0].compile_time), "13:40:45"));
+    ASSERT_EQ(stLogBody.versions[0].component_type, 1);
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].model_name), "FFNBYNTMNP1"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].psn), "BMHR15470120X"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].hardware_version), "OEM719N-0.00C"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].software_version), "OM7CR0707RN0000"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].boot_version), "OM7BR0000RBG000"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].compile_date), "2020/Apr/09"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[0].compile_time), "13:40:45"));
 
     // Check OEM7FPGA fields
-    ASSERT_EQ(pstLogBody->versions[1].component_type, 21);
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].model_name), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].psn), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].hardware_version), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].software_version), "OMV070001RN0000"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].boot_version), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].compile_date), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[1].compile_time), ""));
+    ASSERT_EQ(stLogBody.versions[1].component_type, 21);
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].model_name), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].psn), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].hardware_version), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].software_version), "OMV070001RN0000"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].boot_version), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].compile_date), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[1].compile_time), ""));
 
     // If the last component is correct, we can assume the middle ones are as well.
 
     // Check RADIO fields
-    ASSERT_EQ(pstLogBody->versions[7].component_type, 18);
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[7].model_name), "M3-R4"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[7].psn), "1843000570"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[7].hardware_version), "SPL0020d12"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[7].software_version), "V07.34.2.5.1.11"));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[7].boot_version), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[7].compile_date), ""));
-    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(pstLogBody->versions[7].compile_time), ""));
+    ASSERT_EQ(stLogBody.versions[7].component_type, 18);
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[7].model_name), "M3-R4"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[7].psn), "1843000570"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[7].hardware_version), "SPL0020d12"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[7].software_version), "V07.34.2.5.1.11"));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[7].boot_version), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[7].compile_date), ""));
+    ASSERT_EQ(0, strcmp(reinterpret_cast<char*>(stLogBody.versions[7].compile_time), ""));
 }
 
 TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_VERSIONB)
@@ -3002,9 +3028,12 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_VERSIONB)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
     ASSERT_EQ(2196U, stMessageData.uiMessageLength);
 
-    auto stLogHeader = *reinterpret_cast<Oem4BinaryHeader*>(stMessageData.pucMessageHeader);
-    auto stLogBody = *reinterpret_cast<VERSION*>(stMessageData.pucMessageBody);
-    auto stTestLogHeader = *reinterpret_cast<Oem4BinaryHeader*>(aucLog);
+    Oem4BinaryHeader stLogHeader;
+    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    VERSION stLogBody;
+    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(VERSION));
+    Oem4BinaryHeader stTestLogHeader;
+    std::memcpy(&stTestLogHeader, aucLog, sizeof(Oem4BinaryHeader));
     stTestLogHeader.usLength = 2196 - (OEM4_BINARY_HEADER_LENGTH + OEM4_BINARY_CRC_LENGTH); // Change the length so header comparison passes
     ASSERT_EQ(stTestLogHeader, stLogHeader);
 
@@ -4171,7 +4200,7 @@ TEST_F(ParserTest, PARSE_FILE_WITH_FILTER)
     std::vector<char> buffer(chunkSize);
     while (clInputFileStream.read(buffer.data(), chunkSize) || clInputFileStream.gcount() > 0) {
         auto n = static_cast<uint32_t>(clInputFileStream.gcount());
-        if (pclParser->Write(reinterpret_cast<const uint8_t*>(buffer.data()), n) != n) {
+        if (pclParser->Write(reinterpret_cast<const unsigned char*>(buffer.data()), n) != n) {
             std::cerr << "Failed to write data to parser.";
             break;
         };

--- a/src/decoders/oem/test/oem_test.cpp
+++ b/src/decoders/oem/test/oem_test.cpp
@@ -2243,19 +2243,15 @@ class DecodeEncodeTest : public ::testing::Test
         ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, pucLog1, aucLog1EncodeBuffer, sizeof(aucLog1EncodeBuffer), stMetaData1, stMessageData1));
         ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, pucLog2, aucLog2EncodeBuffer, sizeof(aucLog2EncodeBuffer), stMetaData2, stMessageData2));
 
-        Oem4BinaryHeader stHeader1;
-        std::memcpy(&stHeader1, stMessageData1.pucMessageHeader, sizeof(Oem4BinaryHeader));
-        T2 stHeader2;
-        std::memcpy(&stHeader2, stMessageData2.pucMessageHeader, sizeof(T2));
+        auto stHeader1 = LoadValueFromBuffer<Oem4BinaryHeader>(stMessageData1.pucMessageHeader);
+        auto stHeader2 = LoadValueFromBuffer<T2>(stMessageData2.pucMessageHeader);
         ASSERT_EQ(stHeader1, stHeader2);
 
         // we shouldn't have to do this. should make structs for the log types tested with T != void
         if constexpr (!std::is_same<T, void>())
         {
-            T stLog1;
-            std::memcpy(&stLog1, stMessageData1.pucMessageBody, sizeof(T));
-            T stLog2;
-            std::memcpy(&stLog2, stMessageData2.pucMessageBody, sizeof(T));
+            auto stLog1 = LoadValueFromBuffer<T>(stMessageData1.pucMessageBody);
+            auto stLog2 = LoadValueFromBuffer<T>(stMessageData2.pucMessageBody);
             ASSERT_EQ(stLog1, stLog2);
         }
     }
@@ -2375,8 +2371,7 @@ TEST_F(DecodeEncodeTest, ASCII_LOG_ROUNDTRIP_GLOEPHEM)
 
     ASSERT_EQ(0, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucEncodeBuffer, sizeof(acEncodeBuffer), stMetaData, stMessageData));
 
-    GLOEPHEMERIS stGloEphemeris;
-    std::memcpy(&stGloEphemeris, stMessageData.pucMessageBody, sizeof(GLOEPHEMERIS));
+    auto stGloEphemeris = LoadValueFromBuffer<GLOEPHEMERIS>(stMessageData.pucMessageBody);
     ASSERT_EQ(stGloEphemeris.sloto, 51);
     ASSERT_EQ(stGloEphemeris.freqo, 0);
     ASSERT_EQ(stGloEphemeris.sat_type, 1);
@@ -2626,8 +2621,7 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_BESTPOS)
 
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
 
-    Oem4BinaryHeader stHeader;
-    std::memcpy(&stHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    auto stHeader = LoadValueFromBuffer<Oem4BinaryHeader>(stMessageData.pucMessageHeader);
     ASSERT_EQ(stHeader.ucSync1, OEM4_BINARY_SYNC1);
     ASSERT_EQ(stHeader.ucSync2, OEM4_BINARY_SYNC2);
     ASSERT_EQ(stHeader.ucSync3, OEM4_BINARY_SYNC3);
@@ -2646,8 +2640,7 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_BESTPOS)
     ASSERT_EQ(stHeader.usReceiverSwVersion, 32768);
 
     // SOL_COMPUTED SINGLE 51.15043711386 -114.03067767000 1097.2099 -17.0000 WGS84 0.9038 0.8534 1.7480 \"\" 0.000 0.000 35 30 30 30 00 06 39 33\r\n"
-    BESTPOS stLogBody;
-    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(BESTPOS));
+    auto stLogBody = LoadValueFromBuffer<BESTPOS>(stMessageData.pucMessageBody);
     ASSERT_EQ(stLogBody.solution_status, 0);
     ASSERT_EQ(stLogBody.position_type, 16);
     ASSERT_EQ(stLogBody.latitude, 51.15043711386);
@@ -2683,8 +2676,7 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_GLOEPHEMA)
 
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
 
-    Oem4BinaryHeader stLogHeader;
-    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    auto stLogHeader = LoadValueFromBuffer<Oem4BinaryHeader>(stMessageData.pucMessageHeader);
     ASSERT_EQ(stLogHeader.ucSync1, OEM4_BINARY_SYNC1);
     ASSERT_EQ(stLogHeader.ucSync2, OEM4_BINARY_SYNC2);
     ASSERT_EQ(stLogHeader.ucSync3, OEM4_BINARY_SYNC3);
@@ -2702,8 +2694,7 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_GLOEPHEMA)
     ASSERT_EQ(stLogHeader.usMsgDefCrc, 0x8d29);
     ASSERT_EQ(stLogHeader.usReceiverSwVersion, 32768);
 
-    GLOEPHEMERIS stLogBody;
-    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(GLOEPHEMERIS));
+    auto stLogBody = LoadValueFromBuffer<GLOEPHEMERIS>(stMessageData.pucMessageBody);
     ASSERT_EQ(stLogBody.sloto, 51);
     ASSERT_EQ(stLogBody.freqo, 0);
     ASSERT_EQ(stLogBody.sat_type, 1);
@@ -2750,12 +2741,9 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_PORTSTATSB)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
     ASSERT_EQ(1356U, stMessageData.uiMessageLength);
 
-    Oem4BinaryHeader stLogHeader;
-    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
-    PORTSTATS stLogBody;
-    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(PORTSTATS));
-    Oem4BinaryHeader stTestLogHeader;
-    std::memcpy(&stTestLogHeader, aucLog, sizeof(Oem4BinaryHeader));
+    auto stLogHeader = LoadValueFromBuffer<Oem4BinaryHeader>(stMessageData.pucMessageHeader);
+    auto stLogBody = LoadValueFromBuffer<PORTSTATS>(stMessageData.pucMessageBody);
+    auto stTestLogHeader = LoadValueFromBuffer<Oem4BinaryHeader>(aucLog);
     stTestLogHeader.usLength = 1356 - (OEM4_BINARY_HEADER_LENGTH + OEM4_BINARY_CRC_LENGTH); // Change the length so header comparison passes
     ASSERT_EQ(stTestLogHeader, stLogHeader);
 
@@ -2797,12 +2785,9 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_PSRDOPB)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
     ASSERT_EQ(1360U, stMessageData.uiMessageLength);
 
-    Oem4BinaryHeader stLogHeader;
-    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
-    PSRDOP stLogBody;
-    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(PSRDOP));
-    Oem4BinaryHeader stTestLogHeader;
-    std::memcpy(&stTestLogHeader, aucLog, sizeof(Oem4BinaryHeader));
+    auto stLogHeader = LoadValueFromBuffer<Oem4BinaryHeader>(stMessageData.pucMessageHeader);
+    auto stLogBody = LoadValueFromBuffer<PSRDOP>(stMessageData.pucMessageBody);
+    auto stTestLogHeader = LoadValueFromBuffer<Oem4BinaryHeader>(aucLog);
     stTestLogHeader.usLength = 1360 - (OEM4_BINARY_HEADER_LENGTH + OEM4_BINARY_CRC_LENGTH); // Change the length so header comparison passes
     ASSERT_EQ(stTestLogHeader, stLogHeader);
 
@@ -2833,12 +2818,9 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_VALIDMODELSB)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
     ASSERT_EQ(708U, stMessageData.uiMessageLength);
 
-    Oem4BinaryHeader stLogHeader;
-    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
-    VALIDMODELS stLogBody;
-    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(VALIDMODELS));
-    Oem4BinaryHeader stTestLogHeader;
-    std::memcpy(&stTestLogHeader, aucLog, sizeof(Oem4BinaryHeader));
+    auto stLogHeader = LoadValueFromBuffer<Oem4BinaryHeader>(stMessageData.pucMessageHeader);
+    auto stLogBody = LoadValueFromBuffer<VALIDMODELS>(stMessageData.pucMessageBody);
+    auto stTestLogHeader = LoadValueFromBuffer<Oem4BinaryHeader>(aucLog);
     stTestLogHeader.usLength = 708 - (OEM4_BINARY_HEADER_LENGTH + OEM4_BINARY_CRC_LENGTH); // Change the length so header comparison passes
     ASSERT_EQ(stTestLogHeader, stLogHeader);
 
@@ -2876,8 +2858,7 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_VERSION)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
     ASSERT_EQ(2196U, stMessageData.uiMessageLength);
 
-    Oem4BinaryHeader stLogHeader;
-    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    auto stLogHeader = LoadValueFromBuffer<Oem4BinaryHeader>(stMessageData.pucMessageHeader);
     ASSERT_EQ(stLogHeader.ucSync1, OEM4_BINARY_SYNC1);
     ASSERT_EQ(stLogHeader.ucSync2, OEM4_BINARY_SYNC2);
     ASSERT_EQ(stLogHeader.ucSync3, OEM4_BINARY_SYNC3);
@@ -2895,8 +2876,7 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_VERSION)
     ASSERT_EQ(stLogHeader.usMsgDefCrc, 0x3681);
     ASSERT_EQ(stLogHeader.usReceiverSwVersion, 32768);
 
-    VERSION stLogBody;
-    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(VERSION));
+    auto stLogBody = LoadValueFromBuffer<VERSION>(stMessageData.pucMessageBody);
 
     // Check the populated parts of the log
     ASSERT_EQ(4U, stLogBody.versions_arraylength);
@@ -2955,8 +2935,7 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_VERSIONA)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
     ASSERT_EQ(2196U, stMessageData.uiMessageLength);
 
-    Oem4BinaryHeader stLogHeader;
-    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
+    auto stLogHeader = LoadValueFromBuffer<Oem4BinaryHeader>(stMessageData.pucMessageHeader);
     ASSERT_EQ(stLogHeader.ucSync1, OEM4_BINARY_SYNC1);
     ASSERT_EQ(stLogHeader.ucSync2, OEM4_BINARY_SYNC2);
     ASSERT_EQ(stLogHeader.ucSync3, OEM4_BINARY_SYNC3);
@@ -2974,8 +2953,7 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_VERSIONA)
     ASSERT_EQ(stLogHeader.usMsgDefCrc, 0x3681);
     ASSERT_EQ(stLogHeader.usReceiverSwVersion, 16248);
 
-    VERSION stLogBody;
-    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(VERSION));
+    auto stLogBody = LoadValueFromBuffer<VERSION>(stMessageData.pucMessageBody);
 
     // Check the populated parts of the log
     ASSERT_EQ(8U, stLogBody.versions_arraylength);
@@ -3028,12 +3006,9 @@ TEST_F(DecodeEncodeTest, FLAT_BINARY_LOG_DECODE_VERSIONB)
     ASSERT_EQ(DecodeEncodeTest::SUCCESS, DecodeEncode(ENCODE_FORMAT::FLATTENED_BINARY, aucLog, pucOutBuf, MAX_BINARY_MESSAGE_LENGTH, stMetaData, stMessageData));
     ASSERT_EQ(2196U, stMessageData.uiMessageLength);
 
-    Oem4BinaryHeader stLogHeader;
-    std::memcpy(&stLogHeader, stMessageData.pucMessageHeader, sizeof(Oem4BinaryHeader));
-    VERSION stLogBody;
-    std::memcpy(&stLogBody, stMessageData.pucMessageBody, sizeof(VERSION));
-    Oem4BinaryHeader stTestLogHeader;
-    std::memcpy(&stTestLogHeader, aucLog, sizeof(Oem4BinaryHeader));
+    auto stLogHeader = LoadValueFromBuffer<Oem4BinaryHeader>(stMessageData.pucMessageHeader);
+    auto stLogBody = LoadValueFromBuffer<VERSION>(stMessageData.pucMessageBody);
+    auto stTestLogHeader = LoadValueFromBuffer<Oem4BinaryHeader>(aucLog);
     stTestLogHeader.usLength = 2196 - (OEM4_BINARY_HEADER_LENGTH + OEM4_BINARY_CRC_LENGTH); // Change the length so header comparison passes
     ASSERT_EQ(stTestLogHeader, stLogHeader);
 

--- a/src/decoders/oem/test/range_cmp_test.cpp
+++ b/src/decoders/oem/test/range_cmp_test.cpp
@@ -172,7 +172,7 @@ TEST_F(RangeCmpTest, BITFIELD_5)
 {
     // Edge case where bitfield occupies 9 bytes
     std::array<uint64_t, 2> arr = {0x2, 0x1};
-    auto* pucBytesPointer = reinterpret_cast<uint8_t*>(arr.data());
+    auto* pucBytesPointer = reinterpret_cast<unsigned char*>(arr.data());
     uint32_t uiBytesLeft = sizeof(arr);
     uint32_t uiBitOffset = 1;
     ASSERT_EQ(1ULL << 0 | 1ULL << 63, (ExtractBitfield<uint64_t, 64>(&pucBytesPointer, uiBytesLeft, uiBitOffset)));


### PR DESCRIPTION
## Summary

- Replaces all calls to `reinterpret_cast<T*>(...)` where `T` $\not\in$ {`char`, `unsigned char`, `std::byte`} with a safe alternative
- Removes `reinterpret_cast` from C++ field access instructions

## Explanation

The C++ standard only relaxes strict type aliasing for `char`, `unsigned char`, and `std::byte`, so the compiler is allowed to assume that pointers to any other types cannot overlap. Therefore, dereferencing a pointer like `reinterpret_cast<T*>(ptr)` has **undefined behaviour** if `T` is not a `char`, `unsigned char`, or `std::byte`, even when the alignment of `T` is just as strict as the alignment of `ptr`'s type.

Note: as far as I understand, in almost all cases `int8_t`/`uint8_t` are simply aliases for `char`/`unsigned char`, respectively, so dereferencing a pointer obtained through `reinterpret_cast<int8_t*/uint8_t*>(...)` is generally fine. However, in theory it is possible that these types are defined as some distinct extended integer types different from `char`/`unsigned char`, so I decided to remove all reinterpret casts to `int8_t*`/`uint8_t*` as well.

## Additional changes

- Changed buffer types for some encoder/commander functions from `unsigned char**` to `unsigned char* const*` to better reflect function behaviour
- Added `BufferType` template argument to `CopyAllToBuffer` to match other `Copy...` functions and prevent needing to keep switching from `unsigned char**` to `char**`

## Performance impact

Binary decoding/encoding performance seems to be negatively affected by these changes on the runner. I have reproduced this slowdown locally (though the slowdown is much smaller on my machine i.e. <5% for binary decoding). The slowdown only seems to happen when compiling with `g++` on Linux - I observe no significant difference in performance (on my local machine) when compiling with MSVC on Windows or `clang++` on Linux. Interestingly, with Linux `g++` performance was _significantly_ improved (from ~40% slowdown to ~25%) by moving variable initialization/memcpy into a function (`LoadValueFromBuffer`) rather than initializing a local variable and memcpying directly inline.

Note that this performance impact is irrelevant for the message data structure refactor (#241), since binary decoding/encoding simply involves copying raw byte regions in the updated code.