### PR TITLE
Switch to CMakeConfigDeps to fix VS 2026 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,35 +80,6 @@ The build can then be started with:
 cmake --build {path_to_build_folder}
 ```
 
-> **⚠️ Known issue — IDE configure fails on CMake 4.x with `IMPORTED_LOCATION not set`**
->
-> When a project that consumes EDIE's dependencies through Conan's classic `CMakeDeps`
-> generator is configured **from an IDE** (Visual Studio / VS Code) using **CMake 4.x**, 
-> configuration fails during CMake's file-API *codemodel* generation with errors such as:
->
-> ```
-> CMake Error in src/common/CMakeLists.txt:
->   IMPORTED_LOCATION not set for imported target "CONAN_LIB::fmt_fmt_RELEASE" configuration "Debug".
-> ```
->
-> **Cause:** Conan's `CMakeDeps` generator creates the per-config imported
-> targets with `IMPORTED_LOCATION_<CONFIG>` but never sets `IMPORTED_CONFIGURATIONS`
-> [(conan-io/conan#14606)](https://github.com/conan-io/conan/issues/14606). CMake 4.x's codemodel resolution no longer tolerates that
-> omission; Building the model for one configuration demands incompatible targets from the *other* configuration. 
-> Plain command-line `cmake` configures are **not** affected — they do not request the codemodel — so this only surfaces
-> through an IDE's CMake integration. Older versions of CMake are also unaffected.
->
-> **Fix:** switch Conan to the newer `CMakeConfigDeps` generator, which sets
-> `IMPORTED_CONFIGURATIONS`. Add this line to your Conan `global.conf` (its folder is
-> printed by `conan config home`):
->
-> ```
-> tools.cmake.cmakedeps:new=will_break_next
-> ```
->
-> Note: this conf and `CMakeConfigDeps` are experimental hence the name
-> `will_break_next`.
-
 ### CMake Presets
 
 It is recommended to use [CMake presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) to define specific build parameters, such as compiler and build type.

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain, CMakeDeps
+from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain, CMakeConfigDeps
 from conan.tools.files import copy, rmdir
 
 required_conan_version = ">=2.4.0"
@@ -121,7 +121,9 @@ class NovatelEdieConan(ConanFile):
         cmake_driven = self.conf.get("user.novatel_edie:cmake_driven", default=False)
 
         # Deploy CMake information for dependencies
-        deps = CMakeDeps(self)
+        # Experimental generator (fixes VS 2026 builds)
+        # https://github.com/conan-io/conan/issues/20148#issuecomment-4912499844
+        deps = CMakeConfigDeps(self)
         deps.generate()
 
         # Deploy any shared libraries


### PR DESCRIPTION
The conan maintainer clarified that the CMakeConfigDeps generator is primarily marked as experimental because it is new: https://github.com/conan-io/conan/issues/20148#issuecomment-4912499844

In light of this I think it makes sense to switch over so that users don't have to update their config manually if they encounter build errors.