### PR TITLE
Restore: Switch to CMakeConfigDeps to fix VS 2026 build

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain, CMakeConfigDeps
 from conan.tools.files import copy, rmdir
 
-required_conan_version = ">=2.4.0"
+required_conan_version = ">=2.25.0"
 
 class NovatelEdieConan(ConanFile):
     name = "novatel_edie"

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain, CMakeDeps
+from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain, CMakeConfigDeps
 from conan.tools.files import copy, rmdir
 
 required_conan_version = ">=2.4.0"
@@ -122,7 +122,7 @@ class NovatelEdieConan(ConanFile):
         # Deploy CMake information for dependencies
         # Experimental generator (fixes VS 2026 builds)
         # https://github.com/conan-io/conan/issues/20148#issuecomment-4912499844
-        deps = CMakeDeps(self)
+        deps = CMakeConfigDeps(self)
         deps.generate()
 
         # Deploy any shared libraries


### PR DESCRIPTION
Sorry @riley-kinahan, looks like I accidentally reverted this change as part of #241.

Also, I noticed that using `CMakeConfigDeps` still requires the `global.conf` modification with older versions of Conan (< 2.25.0). Do you think it is worth changing the required Conan version to >=2.25.0? Or do you think Conan's error message is informative enough, i.e.

> `ConanException: CMakeConfigDeps is being used in conanfile, but the conf 'tools.cmake.cmakedeps:new' is not enabled. This is an incubatingfeature, please define it to enable CMakeConfigDeps usage`