### PR TITLE
Generalized field array access

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,21 @@ while (eStatus != STATUS::STREAM_EMPTY)
 
 The same accesses can use `stMessage.GetFieldValueByName<FieldArray>("obs")` and `obs.GetFieldValueByName<float>("C_No")`, but that performs a definition search for every access and is slower. Advanced users can request `CompositeFieldArray` or `FlatFieldArray` directly when the concrete storage representation is known. `FieldArray` is preferred when code should work with either representation.
 
+> [!WARNING]
+> The `CompositeField` that owns a message's data must remain alive for as long as any field values obtained from that message are being used.
+> For example, the following code is unsafe:
+
+```
+FieldArray obsArr;
+if (...)
+{
+    CompositeField stMessage;
+    ...
+    obsArr = stMessage.GetFieldValueByName<FieldArray>("obs");
+} // Lifetime of stMessage ends after this block
+obsArr.GetFieldValueByName<float>("C_No"); // BAD - undefined behaviour!
+```
+
 #### Copy to generated struct (specialized use cases)
 
 If your input data is in the flattened binary format then, after decoding a message's header, you may copy it to the appropriate struct and access its fields as member variables.

--- a/README.md
+++ b/README.md
@@ -306,14 +306,13 @@ The template argument `T` is the C++ type returned by `GetFieldValue<T>`:
 | `STRING` or `RESPONSE_STR` | `std::string` |
 | Scalar, enum, or response ID | The corresponding C++ type, such as `bool`, `uint32_t`, `int32_t`, `float`, or `double` |
 
-For an individual variable-length or fixed-length array element, pass the element index as the second argument and use the element type rather than the container type:
+For an individual variable-length or fixed-length array element, you may also pass the element index as the second argument and use the element type rather than the container type:
 
 ```cpp
 const auto variableElement = message.GetFieldValue<float>(*variableArrayDef, elementIndex);
 const auto fixedElement = message.GetFieldValue<uint32_t>(*fixedArrayDef, elementIndex);
 ```
 
-Use `TypedBuffer<T>` to inspect a complete fixed-length array without copying it. Use `std::vector<T>` to retrieve a complete variable-length array.
 
 #### Reading field-array elements
 
@@ -348,7 +347,7 @@ while (eStatus != STATUS::STREAM_EMPTY)
 }
 ```
 
-The same accesses can use `stMessage.GetFieldValueByName<FieldArray>("obs")` and `obs.GetFieldValueByName<float>("C_No")`, but that performs a definition search for every access and is slower. Advanced users can request `CompositeFieldArray` or `FlatFieldArray` directly when the concrete storage representation matters. `FieldArray` is preferred when code should work with either representation.
+The same accesses can use `stMessage.GetFieldValueByName<FieldArray>("obs")` and `obs.GetFieldValueByName<float>("C_No")`, but that performs a definition search for every access and is slower. Advanced users can request `CompositeFieldArray` or `FlatFieldArray` directly when the concrete storage representation is known. `FieldArray` is preferred when code should work with either representation.
 
 #### Copy to generated struct (specialized use cases)
 
@@ -365,7 +364,7 @@ This will generate a header file called `novatel_message_definitions.hpp` in you
 - Direct access to fields via member variables (very fast)
 
 **⚠️ Disadvantages:**
-- Only works with the flattened binary format
+- Only works with the flattened binary format (if your data is in a different format, you must first encode it to flattened binary)
 - Requires running Python script to generate structs
 - No feedback if you copy data into the wrong message type
 

--- a/README.md
+++ b/README.md
@@ -251,69 +251,108 @@ Run the resulting executable with the following command: `rxconfig_handler.exe <
 
 ### Accessing Message Fields
 
-There are a few ways to access a message's fields after decoding.
-The following examples show how to access the "latitude" field of a BESTPOS message:
+Use `GetFieldValue<T>` with a field definition whenever possible. The definition already identifies the field's type and storage location, so it avoids searching for the definition on every access. This is the recommended approach for loops and other performance-sensitive code.
 
-#### Approach 1: Get value with templated type (recommended)
+`GetFieldValueByName<T>` is a convenient alternative when the definition is not readily available, but it searches `FieldInfo` for the definition on every call. Resolve the definition once and reuse it when reading the same field repeatedly.
 
-Use `CompositeField::GetFieldValue<T>(const BaseField& field_)` to get the value of `field_`.
-
-**✅ Advantages:**
-- Mostly type safe (will throw a runtime error if you attempt to extract the wrong type)
-- If you keep a reference to the field definition, no further lookups are required
-- No `std::variant` construction
-
-**⚠️ Disadvantages:**
-- Need to know the type of the requested field at compile time
-
-**Example:**
+#### Access by field definition
 
 ```cpp
 const auto db = LoadJsonDbFile("database/database.json");
-const auto& bestposDef = db.GetMsgDef("BESTPOS");
+const auto &bestposDef = db.GetMsgDef("BESTPOS");
+const auto &bestposFields = bestposDef->fieldInfo.at(bestposDef->latestMessageCrc);
+const auto &latitudeDef = bestposFields->GetFieldDefByName("latitude");
+if (latitudeDef == nullptr) { throw std::runtime_error("latitude field not found"); }
 
-// Get a reference to a field definition
-const auto& latDef = bestposDef->fieldInfo.at(bestposDef->latestMessageCrc)->GetFieldDefByName("latitude");
-if (!latDef) { throw std::runtime_error("Could not find latitude definition!"); }
+CompositeField message;
+eDecoderStatus = clMessageDecoder.Decode(pucFrameBuffer, message, stMetaData);
 
-CompositeField stMessage;
-eDecoderStatus = clMessageDecoder.Decode(pucFrameBuffer, stMessage, stMetaData);
-
-if (eDecoderStatus == STATUS::SUCCESS) {
-    if (stMetaData.usMessageId == 42 /*BESTPOS*/) {
-        auto latVal = stMessage.GetFieldValue<double>(*latDef);
-    }
+if (eDecoderStatus == STATUS::SUCCESS)
+{
+    const auto latitude = message.GetFieldValue<double>(*latitudeDef);
 }
-``````
+```
 
-#### Approach 2: Get value variant (convenient but slower)
+#### Access by field name
 
-Use `CompositeField::GetFieldValueVariant(const BaseField& field_)` to get the value of `field_` wrapped in a `std::variant`.
-
-**✅ Advantages:**
-- Mostly type safe (will throw a `std::bad_variant_access` exception if you attempt to `std::get` the wrong type from `val_`)
-- Do not need to know the field type at compile time; concrete field value can be extracted via `std::visit` or `std::get`
-
-**⚠️ Disadvantages:**
-- Need to construct and copy value to `FieldValueVariant` (slight overhead)
-
-
-**Example:**
+Use `GetFieldValueByName<T>` to lookup a field's definition and get its value in a single step. This is less efficient if you need to repeatedly access a particular field across many messages/field array elements.
 
 ```cpp
-...
+const auto latitude = message.GetFieldValueByName<double>("latitude");
+```
 
-if (eDecoderStatus == STATUS::SUCCESS) {
-    if (stMetaData.usMessageId == 42 /*BESTPOS*/) {
-        FieldValueVariant latVariant = stMessage.GetFieldValueVariant(*latDef);
-        double latValue = std::get<double>(latVariant);
+For repeated access, lookup the definition once and reuse it:
+
+```cpp
+const auto &latitudeDef = bestposFields->GetFieldDefByName("latitude");
+
+for (const auto& bestposMessage : bestposMessages)
+{
+    const auto latitude = bestposMessage.GetFieldValue<double>(*latitudeDef);
+    // Process latitude.
+}
+```
+
+#### Selecting the template type
+
+The template argument `T` is the C++ type returned by `GetFieldValue<T>`:
+
+| Field type | `T` for the complete field |
+| --- | --- |
+| `FIELD_ARRAY` | `FieldArray` |
+| `FIELD_ARRAY` with direct representation access (advanced users) | `CompositeFieldArray` or `FlatFieldArray` |
+| `VARIABLE_LENGTH_ARRAY` | `std::vector<T>` |
+| `FIXED_LENGTH_ARRAY` | `TypedBuffer<T>` |
+| `STRING` or `RESPONSE_STR` | `std::string` |
+| Scalar, enum, or response ID | The corresponding C++ type, such as `bool`, `uint32_t`, `int32_t`, `float`, or `double` |
+
+For an individual variable-length or fixed-length array element, pass the element index as the second argument and use the element type rather than the container type:
+
+```cpp
+const auto variableElement = message.GetFieldValue<float>(*variableArrayDef, elementIndex);
+const auto fixedElement = message.GetFieldValue<uint32_t>(*fixedArrayDef, elementIndex);
+```
+
+Use `TypedBuffer<T>` to inspect a complete fixed-length array without copying it. Use `std::vector<T>` to retrieve a complete variable-length array.
+
+#### Reading field-array elements
+
+Obtain the field-array definition from the database, then read the array as `FieldArray` and iterate over its elements. For best performance, resolve the definitions once before the main loop over the messages:
+
+```cpp
+// Set up EDIE components, i.e. Parser, FileParser, or Framer/HeaderDecoder/Decoder
+
+// Obtain references to all needed message/field definitions
+const auto &pstRangeDef = pclMsgDb->GetMsgDef("RANGE");
+const auto &pstObsDef = pstRangeDef->fieldInfo.at(pstRangeDef->latestMessageCrc)->GetFieldDefByName("obs");
+const auto &pstObsFieldArrayDef = std::dynamic_pointer_cast<const FieldArrayField>(pstObsDef);
+const auto &pstCnoDef = pstObsFieldArrayDef->fieldInfo->GetFieldDefByName("C_No");
+
+STATUS eStatus = STATUS::UNKNOWN;
+while (eStatus != STATUS::STREAM_EMPTY)
+{
+    MetaDataStruct stMetaData;
+    MessageDataStruct stMessageData;
+    CompositeField stMessage;
+    IntermediateHeader stHeader;
+
+    eStatus = clFileParser.ReadIntermediate(stMessageData, stHeader, stMessage, stMetaData);
+    if (eStatus == STATUS::SUCCESS)
+    {
+        for (const auto& obs : stMessage.GetFieldValue<FieldArray>(*pstObsDef))
+        {
+            const auto cno = obs.GetFieldValue<float>(*pstCnoDef);
+            // Process cno.
+        }
     }
 }
-``````
+```
 
-#### Approach 3: Cast to generated struct (specialized use cases)
+The same accesses can use `stMessage.GetFieldValueByName<FieldArray>("obs")` and `obs.GetFieldValueByName<float>("C_No")`, but that performs a definition search for every access and is slower. Advanced users can request `CompositeFieldArray` or `FlatFieldArray` directly when the concrete storage representation matters. `FieldArray` is preferred when code should work with either representation.
 
-If your input data is in the flattened binary format then, after decoding a message's header, you may cast it to the appropriate struct and access its fields as member variables.
+#### Copy to generated struct (specialized use cases)
+
+If your input data is in the flattened binary format then, after decoding a message's header, you may copy it to the appropriate struct and access its fields as member variables.
 Struct definitions are generated by running
 
 ```
@@ -347,24 +386,7 @@ if (eDecoderStatus == STATUS::SUCCESS)
         latitude = bestposLog->latitude;
     }
 }
-``````
-
-#### Iterating over fields
-
-`CompositeField` also provides an interface for iterating over field (definition, value) pairs.
-
-**Example:**
-
-```cpp
-for (const auto& [def, val] : stMessage)
-{
-    if (def->name == "latitude")
-    {
-        double latVal = std::get<double>(val);
-        ...
-    }
-}
-``````
+```
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ Use `GetFieldValue<T>` with a field definition whenever possible. The definition
 
 ```cpp
 const auto db = LoadJsonDbFile("database/database.json");
-const auto &bestposDef = db.GetMsgDef("BESTPOS");
-const auto &bestposFields = bestposDef->fieldInfo.at(bestposDef->latestMessageCrc);
-const auto &latitudeDef = bestposFields->GetFieldDefByName("latitude");
+const auto bestposDef = db->GetMsgDef("BESTPOS");
+const auto bestposFields = bestposDef->fieldInfo.at(bestposDef->latestMessageCrc);
+const auto latitudeDef = bestposFields->GetFieldDefByName("latitude");
 if (latitudeDef == nullptr) { throw std::runtime_error("latitude field not found"); }
 
 CompositeField message;
@@ -284,7 +284,7 @@ const auto latitude = message.GetFieldValueByName<double>("latitude");
 For repeated access, lookup the definition once and reuse it:
 
 ```cpp
-const auto &latitudeDef = bestposFields->GetFieldDefByName("latitude");
+const auto latitudeDef = bestposFields->GetFieldDefByName("latitude");
 
 for (const auto& bestposMessage : bestposMessages)
 {
@@ -302,15 +302,20 @@ The template argument `T` is the C++ type returned by `GetFieldValue<T>`:
 | `FIELD_ARRAY` | `FieldArray` |
 | `FIELD_ARRAY` with direct representation access (advanced users) | `CompositeFieldArray` or `FlatFieldArray` |
 | `VARIABLE_LENGTH_ARRAY` | `std::vector<T>` |
-| `FIXED_LENGTH_ARRAY` | `TypedBuffer<T>` |
+| `FIXED_LENGTH_ARRAY` | `TypedBuffer<T>` (*see below) |
 | `STRING` or `RESPONSE_STR` | `std::string` |
 | Scalar, enum, or response ID | The corresponding C++ type, such as `bool`, `uint32_t`, `int32_t`, `float`, or `double` |
 
-For an individual variable-length or fixed-length array element, you may also pass the element index as the second argument and use the element type rather than the container type:
+*A `TypedBuffer<T>` is a simple read-only wrapper around an array of simple data elements of type `T`. Much like `std::vector`, it supports iteration and element access via `operator[]`, e.g.:
 
-```cpp
-const auto variableElement = message.GetFieldValue<float>(*variableArrayDef, elementIndex);
-const auto fixedElement = message.GetFieldValue<uint32_t>(*fixedArrayDef, elementIndex);
+```
+const auto baseIdVal = bestposMessage.GetFieldValue<TypedBuffer<uint8_t>>(*baseIdDef);
+const auto elem = baseIdVal[0]; // element access via operator[]
+const auto sz = baseIdVal.size(); // get number of elements via size()
+for (const auto c : baseIdVal) // iteration
+{
+    ...
+}
 ```
 
 
@@ -321,11 +326,11 @@ Obtain the field-array definition from the database, then read the array as `Fie
 ```cpp
 // Set up EDIE components, i.e. Parser, FileParser, or Framer/HeaderDecoder/Decoder
 
-// Obtain references to all needed message/field definitions
-const auto &pstRangeDef = pclMsgDb->GetMsgDef("RANGE");
-const auto &pstObsDef = pstRangeDef->fieldInfo.at(pstRangeDef->latestMessageCrc)->GetFieldDefByName("obs");
-const auto &pstObsFieldArrayDef = std::dynamic_pointer_cast<const FieldArrayField>(pstObsDef);
-const auto &pstCnoDef = pstObsFieldArrayDef->fieldInfo->GetFieldDefByName("C_No");
+// Obtain all needed message/field definitions
+const auto pstRangeDef = pclMsgDb->GetMsgDef("RANGE");
+const auto pstObsDef = pstRangeDef->fieldInfo.at(pstRangeDef->latestMessageCrc)->GetFieldDefByName("obs");
+const auto pstObsFieldArrayDef = std::dynamic_pointer_cast<const FieldArrayField>(pstObsDef);
+const auto pstCnoDef = pstObsFieldArrayDef->fieldInfo->GetFieldDefByName("C_No");
 
 STATUS eStatus = STATUS::UNKNOWN;
 while (eStatus != STATUS::STREAM_EMPTY)
@@ -338,7 +343,7 @@ while (eStatus != STATUS::STREAM_EMPTY)
     eStatus = clFileParser.ReadIntermediate(stMessageData, stHeader, stMessage, stMetaData);
     if (eStatus == STATUS::SUCCESS)
     {
-        for (const auto& obs : stMessage.GetFieldValue<FieldArray>(*pstObsDef))
+        for (const auto obs : stMessage.GetFieldValue<FieldArray>(*pstObsDef))
         {
             const auto cno = obs.GetFieldValue<float>(*pstCnoDef);
             // Process cno.
@@ -353,7 +358,7 @@ The same accesses can use `stMessage.GetFieldValueByName<FieldArray>("obs")` and
 > The `CompositeField` that owns a message's data must remain alive for as long as any field values obtained from that message are being used.
 > For example, the following code is unsafe:
 
-```
+```cpp
 FieldArray obsArr;
 if (...)
 {
@@ -362,6 +367,19 @@ if (...)
     obsArr = stMessage.GetFieldValueByName<FieldArray>("obs");
 } // Lifetime of stMessage ends after this block
 obsArr.GetFieldValueByName<float>("C_No"); // BAD - undefined behaviour!
+```
+
+> To avoid this, make sure the `CompositeField` stays alive while its data is being accessed. For example:
+
+```cpp
+CompositeField stMessage;
+FieldArray obsArr;
+if (...)
+{
+    ...
+    obsArr = stMessage.GetFieldValueByName<FieldArray>("obs");
+}
+obsArr.GetFieldValueByName<float>("C_No"); // GOOD - stMessage is still alive
 ```
 
 #### Copy to generated struct (specialized use cases)
@@ -379,7 +397,7 @@ This will generate a header file called `novatel_message_definitions.hpp` in you
 - Direct access to fields via member variables (very fast)
 
 **⚠️ Disadvantages:**
-- Only works with the flattened binary format (if your data is in a different format, you must first encode it to flattened binary)
+- Only works with the flattened binary format (if your data is in a different format, you must first encode it to `ENCODE_FORMAT::FLATTENED_BINARY`)
 - Requires running Python script to generate structs
 - No feedback if you copy data into the wrong message type
 

--- a/docs/composite_field.md
+++ b/docs/composite_field.md
@@ -28,7 +28,7 @@ A `CompositeField` stores the decoded contents of a message. It holds:
 #### Field arrays
 
 - Stored as `FlatFieldArray` if every field has fixed size
-- Stored as `NestedFieldArray = std::vector<CompositeField>` otherwise
+- Stored as `CompositeFieldArray = std::vector<CompositeField>` otherwise
 
 ### Reading fields
 

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -447,22 +447,24 @@ template <typename T>
 class FieldArrayRecordView
 {
   public:
-    struct FlatRecordView
-    {
-            const FixedFieldRegion* region;
-            size_t rowOffset;
-    };
-
-    FieldArrayRecordView(const FixedFieldRegion& region_, size_t rowOffset_)
-        : record(FlatRecordView{&region_, rowOffset_})
+    FieldArrayRecordView(const FixedFieldRegion& region_, size_t rowOffset_, const FieldInfo* fieldInfo_)
+        : ffRegion(&region_), rowOffset(rowOffset_), fieldInfo(fieldInfo_)
     {
     }
-    FieldArrayRecordView(const CompositeField& record_) : record(std::cref(record_)) {}
+
+    FieldArrayRecordView(const CompositeField& record_, const FieldInfo* fieldInfo_) : cfRecord(&record_), fieldInfo(fieldInfo_) {}
 
     template <typename T> [[nodiscard]] T GetFieldValue(const BaseField& field_, size_t elementIndex_ = 0) const;
 
   private:
-    std::variant<FlatRecordView, std::reference_wrapper<const CompositeField>> record;
+    const FieldInfo* fieldInfo = nullptr;
+
+    // Following field is for view of CompositeFieldArray record
+    const CompositeField* cfRecord = nullptr;
+
+    // Following fields are for view of FlatFieldArray record
+    const FixedFieldRegion* ffRegion = nullptr;
+    size_t rowOffset = 0;
 };
 
 // ---------------------------------------------------------------------------
@@ -477,31 +479,31 @@ class FlatFieldArray
 {
   private:
     FixedFieldRegion fields;
-    FieldInfo::ConstPtr fieldInfo;
+    const FieldInfo* fieldInfo;
 
-    static void CheckFieldInfo(FieldInfo::ConstPtr fieldInfo_)
+    static void CheckFieldInfo(const FieldInfo* fieldInfo_)
     {
         if (fieldInfo_ == nullptr) { throw std::runtime_error("FlatFieldArray(): fieldInfo must not be null"); }
         if (fieldInfo_->varFieldCount > 0) { throw std::runtime_error("FlatFieldArray(): fieldInfo must not have variable fields"); }
     }
 
   public:
-    FlatFieldArray(std::vector<std::byte>&& data_, FieldInfo::ConstPtr fieldInfo_) : fields(std::move(data_)), fieldInfo(std::move(fieldInfo_))
+    FlatFieldArray(std::vector<std::byte>&& data_, const FieldInfo* fieldInfo_) : fields(std::move(data_)), fieldInfo(fieldInfo_)
     {
-        CheckFieldInfo(fieldInfo);
-        if (fields.size() % fieldInfo->fixedFieldBytes != 0)
+        CheckFieldInfo(fieldInfo_);
+        if (fields.size() % fieldInfo_->fixedFieldBytes != 0)
         {
             throw std::runtime_error("FlatFieldArray(): data size must be a multiple of fixed field bytes");
         }
     }
 
-    FlatFieldArray(size_t sz_, FieldInfo::ConstPtr fieldInfo_) : fieldInfo(std::move(fieldInfo_))
+    FlatFieldArray(size_t sz_, const FieldInfo* fieldInfo_) : fieldInfo(fieldInfo_)
     {
         CheckFieldInfo(fieldInfo);
         fields = FixedFieldRegion(sz_ * fieldInfo->fixedFieldBytes);
     }
 
-    const FieldInfo::ConstPtr& GetFieldInfo() const { return fieldInfo; }
+    const FieldInfo* GetFieldInfo() const { return fieldInfo; }
 
     // ---------------------------------------------------------------------------
     //! \brief Get the number of fixed-length fields in the FlatFieldArray.
@@ -550,8 +552,7 @@ class FlatFieldArray
     // ---------------------------------------------------------------------------
     [[nodiscard]] FieldArrayRecordView operator[](size_t row_) const
     {
-        if (row_ >= size()) { throw std::runtime_error("FlatFieldArray::operator[](): row index out of bounds"); }
-        return FieldArrayRecordView(fields, row_ * fieldInfo->fixedFieldBytes);
+        return FieldArrayRecordView(fields, row_ * fieldInfo->fixedFieldBytes, fieldInfo);
     }
 
     // ---------------------------------------------------------------------------
@@ -559,9 +560,9 @@ class FlatFieldArray
     //!
     //! \param[in] fieldInfo_ The field info pointer.
     // ---------------------------------------------------------------------------
-    void SetFieldInfo(FieldInfo::ConstPtr fieldInfo_)
+    void SetFieldInfo(const FieldInfo* fieldInfo_)
     {
-        fieldInfo = std::move(fieldInfo_);
+        fieldInfo = fieldInfo_;
         if (fieldInfo) { resize(fieldInfo->fixedFieldBytes); }
     }
 
@@ -849,7 +850,10 @@ class CompositeField
         {
         case FIELD_TYPE::FIXED_LENGTH_ARRAY:
             if constexpr (is_specialization_of_v<T, TypedBuffer>) { return LoadFixedField<T>(fixedFields, field_); }
-            else if constexpr (std::is_trivially_copyable_v<T>) { return LoadFixedFieldElement<T>(fixedFields, elementIndex_, field_); }
+            else if constexpr (std::is_trivially_copyable_v<T> && !std::is_same_v<T, FieldArray>)
+            {
+                return LoadFixedFieldElement<T>(fixedFields, elementIndex_, field_);
+            }
             else { throw std::runtime_error("GetFieldValue<T>(): incorrect type given for FIXED_LENGTH_ARRAY"); }
         case FIELD_TYPE::VARIABLE_LENGTH_ARRAY:
             if constexpr (is_specialization_of_v<T, std::vector>) { return std::get<T>(varFields[field_.index]); }
@@ -862,7 +866,7 @@ class CompositeField
                 }
                 return static_cast<bool>(vec[elementIndex_]);
             }
-            else if constexpr (std::is_trivially_copyable_v<T>)
+            else if constexpr (std::is_trivially_copyable_v<T> && !std::is_same_v<T, FieldArray>)
             {
                 const auto& vec = std::get<std::vector<T>>(varFields[field_.index]);
                 if (elementIndex_ >= vec.size())
@@ -880,25 +884,16 @@ class CompositeField
             if constexpr (std::is_same_v<T, FieldArray>)
             {
                 const auto* fieldArrayDef = dynamic_cast<const FieldArrayField*>(&field_);
-                return std::visit(
-                    [&](const auto& value) -> FieldArray {
-                        using ValueT = std::decay_t<decltype(value)>;
-                        if constexpr (std::is_same_v<ValueT, FlatFieldArray> || std::is_same_v<ValueT, CompositeFieldArray>)
-                        {
-                            return FieldArray(value, fieldArrayDef != nullptr ? fieldArrayDef->fieldInfo : nullptr);
-                        }
-                        else { throw std::runtime_error("GetFieldValue<T>(): field array storage is not a FlatFieldArray or CompositeFieldArray"); }
-                    },
-                    varFields[field_.index]);
+                if (fieldArrayDef == nullptr) { throw std::runtime_error("GetFieldValue<T>(): missing field array metadata"); }
+                return FieldArray(varFields[field_.index], fieldArrayDef->fieldInfo.get());
             }
-            else
-            if constexpr (std::is_same_v<T, FlatFieldArray> || std::is_same_v<T, CompositeFieldArray>)
+            else if constexpr (std::is_same_v<T, FlatFieldArray> || std::is_same_v<T, CompositeFieldArray>)
             {
                 return std::get<T>(varFields[field_.index]);
             }
             else { throw std::runtime_error("GetFieldValue<T>(): incorrect type given for FIELD_ARRAY"); }
         default:
-            if constexpr (std::is_trivially_copyable_v<T>)
+            if constexpr (std::is_trivially_copyable_v<T> && !std::is_same_v<T, FieldArray>)
             {
                 if (elementIndex_ != 0) { throw std::runtime_error("GetFieldValue<T>(): element index must be zero for scalar field"); }
                 return LoadScalarField<T>(fixedFields, field_);
@@ -1375,32 +1370,29 @@ class CompositeField
 
 template <typename T> inline T FieldArrayRecordView::GetFieldValue(const BaseField& field_, size_t elementIndex_) const
 {
-    return std::visit(
-        [&](const auto& record_) -> T {
-            using RecordT = std::decay_t<decltype(record_)>;
-            if constexpr (std::is_same_v<RecordT, FlatRecordView>)
-            {
-                if constexpr (std::is_trivially_copyable_v<T> || is_specialization_of_v<T, TypedBuffer>)
-                {
-                    if constexpr (is_specialization_of_v<T, TypedBuffer>)
-                    {
-                        return LoadFixedField<T>(*record_.region, field_, record_.rowOffset);
-                    }
-                    else if (field_.type == FIELD_TYPE::FIXED_LENGTH_ARRAY)
-                    {
-                        return LoadFixedFieldElement<T>(*record_.region, elementIndex_, field_, record_.rowOffset);
-                    }
-                    else { return LoadFixedField<T>(*record_.region, field_, record_.rowOffset); }
-                }
-                else
-                {
-                    throw std::runtime_error("FieldArrayRecordView::GetFieldValue<T>(): type T must be trivially copyable or TypedBuffer specialization");
-                }
-            }
-            else { return record_.get().GetFieldValue<T>(field_, elementIndex_); }
-        },
-        record);
+    if (cfRecord != nullptr) { return cfRecord->GetFieldValue<T>(field_, elementIndex_); }
+
+    if (ffRegion != nullptr)
+    {
+        if constexpr (std::is_trivially_copyable_v<T> || is_specialization_of_v<T, TypedBuffer>)
+        {
+            if constexpr (is_specialization_of_v<T, TypedBuffer>) { return LoadFixedField<T>(*ffRegion, field_, rowOffset); }
+            else if (field_.type == FIELD_TYPE::FIXED_LENGTH_ARRAY) { return LoadFixedFieldElement<T>(*ffRegion, elementIndex_, field_, rowOffset); }
+            else { return LoadFixedField<T>(*ffRegion, field_, rowOffset); }
+        }
+        else
+        {
+            throw std::runtime_error("FieldArrayRecordView::GetFieldValue<T>(): type T must be trivially copyable or TypedBuffer specialization");
+        }
+    }
+
+    throw std::runtime_error("FieldArrayRecordView::GetFieldValue<T>(): record storage is not initialized");
 }
+
+// template <typename T> inline T FieldArrayRecordView::GetFieldValueByName(std::string_view name, size_t elementIndex_) const
+// {
+
+// }
 
 // ---------------------------------------------------------------------------
 //! \class FieldArray
@@ -1414,40 +1406,22 @@ template <typename T> inline T FieldArrayRecordView::GetFieldValue(const BaseFie
 class FieldArray
 {
   public:
-    FieldArray(const FlatFieldArray& fieldArray_, FieldInfo::ConstPtr fieldInfo_ = nullptr)
-        : fieldArray(&fieldArray_), fieldInfo(fieldInfo_ != nullptr ? std::move(fieldInfo_) : fieldArray_.GetFieldInfo())
-    {
-    }
-
-    FieldArray(const CompositeFieldArray& fieldArray_, FieldInfo::ConstPtr fieldInfo_ = nullptr)
-        : fieldArray(&fieldArray_), fieldInfo(std::move(fieldInfo_))
-    {
-    }
+    FieldArray(const FieldValueVariant& fieldArray_, const FieldInfo* fieldInfo_ = nullptr) : fieldArray(&fieldArray_), fieldInfo(fieldInfo_) {}
 
     [[nodiscard]] size_t size() const
     {
         return std::visit(
-            [](const auto* value_) -> size_t { return value_->size(); },
-            fieldArray);
+            [](const auto& value_) -> size_t {
+                using ValueT = std::decay_t<decltype(value_)>;
+                if constexpr (std::is_same_v<ValueT, FlatFieldArray> || std::is_same_v<ValueT, CompositeFieldArray>) { return value_.size(); }
+                else { throw std::runtime_error("FieldArray::size(): underlying storage is not a FlatFieldArray or CompositeFieldArray"); }
+            },
+            *fieldArray);
     }
 
     [[nodiscard]] bool empty() const { return size() == 0; }
 
-    [[nodiscard]] FieldInfo::ConstPtr GetFieldInfo() const
-    {
-        return std::visit(
-            [&](const auto* value_) -> FieldInfo::ConstPtr {
-                using ValueT = std::remove_cv_t<std::remove_pointer_t<decltype(value_)>>;
-                if constexpr (std::is_same_v<ValueT, FlatFieldArray>) { return value_->GetFieldInfo(); }
-                else
-                {
-                    if (fieldInfo != nullptr) { return fieldInfo; }
-                    if (value_->empty()) { return nullptr; }
-                    return (*value_)[0].GetFieldInfo();
-                }
-            },
-            fieldArray);
-    }
+    [[nodiscard]] const FieldInfo* GetFieldInfo() const { return fieldInfo; }
 
     template <typename T> [[nodiscard]] T GetFieldValue(const BaseField& field_, size_t index_, size_t elementIndex_ = 0) const
     {
@@ -1456,11 +1430,12 @@ class FieldArray
 
     [[nodiscard]] FieldArrayRecordView operator[](size_t index_) const
     {
-        return std::visit(
-            [&](const auto* value_) -> FieldArrayRecordView {
-                return FieldArrayRecordView((*value_)[index_]);
-            },
-            fieldArray);
+        if (const auto* flatArray = std::get_if<FlatFieldArray>(fieldArray)) { return (*flatArray)[index_]; }
+        if (const auto* compositeArray = std::get_if<CompositeFieldArray>(fieldArray))
+        {
+            return FieldArrayRecordView((*compositeArray)[index_], fieldInfo);
+        }
+        throw std::runtime_error("FieldArray::operator[]: underlying storage is not a FlatFieldArray or CompositeFieldArray");
     }
 
     struct const_iterator
@@ -1491,8 +1466,8 @@ class FieldArray
     [[nodiscard]] const_iterator end() const { return const_iterator(this, size()); }
 
   private:
-    std::variant<const FlatFieldArray*, const CompositeFieldArray*> fieldArray;
-    FieldInfo::ConstPtr fieldInfo;
+    const FieldValueVariant* fieldArray;
+    const FieldInfo* fieldInfo;
 };
 
 //============================================================================

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -260,7 +260,7 @@ class FixedFieldRegion
     // ---------------------------------------------------------------------------
     template <typename T> [[nodiscard]] T Load(size_t byteOffset_) const
     {
-        static_assert(std::is_trivially_copyable_v<T>, "Load only supports trivially copyable types");
+        static_assert(std::is_trivially_copyable_v<T> && !is_specialization_of_v<T, TypedBuffer>, "Load only supports trivially copyable types");
         T value;
         std::memcpy(&value, data() + byteOffset_, sizeof(T));
         return value;
@@ -348,7 +348,8 @@ class FixedFieldRegion
 // ---------------------------------------------------------------------------
 template <typename T> [[nodiscard]] inline T LoadScalarField(const FixedFieldRegion& region_, const BaseField& field_, size_t baseIndex_ = 0)
 {
-    static_assert(std::is_trivially_copyable_v<T>, "LoadScalarField only supports trivially copyable types");
+    static_assert(std::is_trivially_copyable_v<T> && !is_specialization_of_v<T, TypedBuffer>,
+                  "LoadScalarField only supports trivially copyable types");
 #ifndef NDEBUG
     AssertFixedFieldType<T>(field_);
 #endif
@@ -454,11 +455,23 @@ class FieldArrayRecordView
 
     FieldArrayRecordView(const CompositeField& record_, const FieldInfo* fieldInfo_) : fieldInfo(fieldInfo_), cfRecord(&record_) {}
 
-    template <typename T> [[nodiscard]] T GetFieldValue(const BaseField& field_, size_t elementIndex_ = 0) const;
-
     [[nodiscard]] const FieldInfo* GetFieldInfo() const { return fieldInfo; }
 
-    template <typename T> inline T GetFieldValueByName(const std::string& name_, size_t elementIndex_) const
+    // ---------------------------------------------------------------------------
+    //! \brief Get a field value by its definition.
+    //!
+    //! \param[in] field_ The definition of the field to retrieve.
+    //! \param[in] elementIndex_ The index of the element within the field to
+    //!     retrieve. Ignored if field is not FIXED/VARIABLE_LENGTH_ARRAY.
+    //! \return A FieldValueVariant containing the field value.
+    // ---------------------------------------------------------------------------
+    template <typename T> [[nodiscard]] T GetFieldValue(const BaseField& field_, size_t elementIndex_ = 0) const;
+
+    // ---------------------------------------------------------------------------
+    //! \brief Get a field value by its name.
+    //! \see FieldArrayRecordView::GetFieldValue
+    // ---------------------------------------------------------------------------
+    template <typename T> inline T GetFieldValueByName(const std::string& name_, size_t elementIndex_ = 0) const
     {
         if (fieldInfo == nullptr) { throw std::runtime_error("FieldArrayRecordView::GetFieldValueByName(): field info is not set"); }
         const auto field = fieldInfo->GetFieldDefByName(name_);
@@ -554,6 +567,10 @@ class FlatFieldArray
         return LoadFixedField<T>(fields, field_, index_ * fieldInfo->fixedFieldBytes);
     }
 
+    // ---------------------------------------------------------------------------
+    //! \brief Get a field value at the given index by its name.
+    //! \see FlatFieldArray::GetFieldValue
+    // ---------------------------------------------------------------------------
     template <typename T> [[nodiscard]] T GetFieldValueByName(const std::string& name_, size_t index_) const
     {
         if (fieldInfo == nullptr) { throw std::runtime_error("FlatFieldArray::GetFieldValueByName(): field info is not set"); }
@@ -884,7 +901,7 @@ class CompositeField
                 }
                 return static_cast<bool>(vec[elementIndex_]);
             }
-            else if constexpr (std::is_trivially_copyable_v<T> && !std::is_same_v<T, FieldArray>)
+            else if constexpr (std::is_trivially_copyable_v<T> && !std::is_same_v<T, FieldArray> && !is_specialization_of_v<T, TypedBuffer>)
             {
                 const auto& vec = std::get<std::vector<T>>(varFields[field_.index]);
                 if (elementIndex_ >= vec.size())
@@ -911,15 +928,18 @@ class CompositeField
             }
             else { throw std::runtime_error("GetFieldValue<T>(): incorrect type given for FIELD_ARRAY"); }
         default:
-            if constexpr (std::is_trivially_copyable_v<T> && !std::is_same_v<T, FieldArray>)
+            if constexpr (std::is_trivially_copyable_v<T> && !std::is_same_v<T, FieldArray> && !is_specialization_of_v<T, TypedBuffer>)
             {
-                if (elementIndex_ != 0) { throw std::runtime_error("GetFieldValue<T>(): element index must be zero for scalar field"); }
                 return LoadScalarField<T>(fixedFields, field_);
             }
             else { throw std::runtime_error("GetFieldValue<T>(): incorrect type T for given FIELD_TYPE"); }
         }
     }
 
+    // ---------------------------------------------------------------------------
+    //! \brief Get a field value by its name.
+    //! \see CompositeField::GetFieldValue
+    // ---------------------------------------------------------------------------
     template <typename T> [[nodiscard]] T GetFieldValueByName(const std::string& name_, size_t elementIndex_ = 0) const
     {
         if (fieldInfo == nullptr) { throw std::runtime_error("CompositeField::GetFieldValueByName(): field info is not set"); }
@@ -1444,11 +1464,24 @@ class FieldArray
 
     [[nodiscard]] const FieldInfo* GetFieldInfo() const { return fieldInfo; }
 
+    // ---------------------------------------------------------------------------
+    //! \brief Get a field value by its definition.
+    //!
+    //! \param[in] field_ The definition of the field to retrieve.
+    //! \param[in] index_ The index of the row in the field array.
+    //! \param[in] elementIndex_ The index of the element within the field to
+    //!     retrieve. Ignored if field is not FIXED/VARIABLE_LENGTH_ARRAY.
+    //! \return A FieldValueVariant containing the field value.
+    // ---------------------------------------------------------------------------
     template <typename T> [[nodiscard]] T GetFieldValue(const BaseField& field_, size_t index_, size_t elementIndex_ = 0) const
     {
         return (*this)[index_].GetFieldValue<T>(field_, elementIndex_);
     }
 
+    // ---------------------------------------------------------------------------
+    //! \brief Get a field value by its name.
+    //! \see FieldArray::GetFieldValue
+    // ---------------------------------------------------------------------------
     template <typename T> [[nodiscard]] T GetFieldValueByName(const std::string& name_, size_t index_, size_t elementIndex_ = 0) const
     {
         if (fieldInfo == nullptr) { throw std::runtime_error("FieldArray::GetFieldValueByName(): field info is not set"); }

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -456,6 +456,10 @@ class FieldArrayRecordView
 
     template <typename T> [[nodiscard]] T GetFieldValue(const BaseField& field_, size_t elementIndex_ = 0) const;
 
+    [[nodiscard]] const FieldInfo* GetFieldInfo() const { return fieldInfo; }
+
+    template <typename T> [[nodiscard]] T GetFieldValueByName(const std::string& name_, size_t elementIndex_ = 0) const;
+
   private:
     const FieldInfo* fieldInfo = nullptr;
 
@@ -542,6 +546,14 @@ class FlatFieldArray
     template <typename T> T GetFieldValue(const BaseField& field_, size_t index_) const
     {
         return LoadFixedField<T>(fields, field_, index_ * fieldInfo->fixedFieldBytes);
+    }
+
+    template <typename T> [[nodiscard]] T GetFieldValueByName(const std::string& name_, size_t index_) const
+    {
+        if (fieldInfo == nullptr) { throw std::runtime_error("FlatFieldArray::GetFieldValueByName(): field info is not set"); }
+        const auto field = fieldInfo->GetFieldDefByName(name_);
+        if (field == nullptr) { throw std::runtime_error("FlatFieldArray::GetFieldValueByName(): field not found: " + name_); }
+        return GetFieldValue<T>(*field, index_);
     }
 
     // ---------------------------------------------------------------------------
@@ -900,6 +912,14 @@ class CompositeField
             }
             else { throw std::runtime_error("GetFieldValue<T>(): incorrect type T for given FIELD_TYPE"); }
         }
+    }
+
+    template <typename T> [[nodiscard]] T GetFieldValueByName(const std::string& name_, size_t elementIndex_ = 0) const
+    {
+        if (fieldInfo == nullptr) { throw std::runtime_error("CompositeField::GetFieldValueByName(): field info is not set"); }
+        const auto field = fieldInfo->GetFieldDefByName(name_);
+        if (field == nullptr) { throw std::runtime_error("CompositeField::GetFieldValueByName(): field not found: " + name_); }
+        return GetFieldValue<T>(*field, elementIndex_);
     }
 
     // ---------------------------------------------------------------------------
@@ -1389,10 +1409,13 @@ template <typename T> inline T FieldArrayRecordView::GetFieldValue(const BaseFie
     throw std::runtime_error("FieldArrayRecordView::GetFieldValue<T>(): record storage is not initialized");
 }
 
-// template <typename T> inline T FieldArrayRecordView::GetFieldValueByName(std::string_view name, size_t elementIndex_) const
-// {
-
-// }
+template <typename T> inline T FieldArrayRecordView::GetFieldValueByName(const std::string& name_, size_t elementIndex_) const
+{
+    if (fieldInfo == nullptr) { throw std::runtime_error("FieldArrayRecordView::GetFieldValueByName(): field info is not set"); }
+    const auto field = fieldInfo->GetFieldDefByName(name_);
+    if (field == nullptr) { throw std::runtime_error("FieldArrayRecordView::GetFieldValueByName(): field not found: " + name_); }
+    return GetFieldValue<T>(*field, elementIndex_);
+}
 
 // ---------------------------------------------------------------------------
 //! \class FieldArray
@@ -1426,6 +1449,14 @@ class FieldArray
     template <typename T> [[nodiscard]] T GetFieldValue(const BaseField& field_, size_t index_, size_t elementIndex_ = 0) const
     {
         return (*this)[index_].GetFieldValue<T>(field_, elementIndex_);
+    }
+
+    template <typename T> [[nodiscard]] T GetFieldValueByName(const std::string& name_, size_t index_, size_t elementIndex_ = 0) const
+    {
+        if (fieldInfo == nullptr) { throw std::runtime_error("FieldArray::GetFieldValueByName(): field info is not set"); }
+        const auto field = fieldInfo->GetFieldDefByName(name_);
+        if (field == nullptr) { throw std::runtime_error("FieldArray::GetFieldValueByName(): field not found: " + name_); }
+        return GetFieldValue<T>(*field, index_, elementIndex_);
     }
 
     [[nodiscard]] FieldArrayRecordView operator[](size_t index_) const

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -458,7 +458,13 @@ class FieldArrayRecordView
 
     [[nodiscard]] const FieldInfo* GetFieldInfo() const { return fieldInfo; }
 
-    template <typename T> [[nodiscard]] T GetFieldValueByName(const std::string& name_, size_t elementIndex_ = 0) const;
+    template <typename T> inline T GetFieldValueByName(const std::string& name_, size_t elementIndex_) const
+    {
+        if (fieldInfo == nullptr) { throw std::runtime_error("FieldArrayRecordView::GetFieldValueByName(): field info is not set"); }
+        const auto field = fieldInfo->GetFieldDefByName(name_);
+        if (field == nullptr) { throw std::runtime_error("FieldArrayRecordView::GetFieldValueByName(): field not found: " + name_); }
+        return GetFieldValue<T>(*field, elementIndex_);
+    }
 
   private:
     const FieldInfo* fieldInfo = nullptr;
@@ -1407,14 +1413,6 @@ template <typename T> inline T FieldArrayRecordView::GetFieldValue(const BaseFie
     }
 
     throw std::runtime_error("FieldArrayRecordView::GetFieldValue<T>(): record storage is not initialized");
-}
-
-template <typename T> inline T FieldArrayRecordView::GetFieldValueByName(const std::string& name_, size_t elementIndex_) const
-{
-    if (fieldInfo == nullptr) { throw std::runtime_error("FieldArrayRecordView::GetFieldValueByName(): field info is not set"); }
-    const auto field = fieldInfo->GetFieldDefByName(name_);
-    if (field == nullptr) { throw std::runtime_error("FieldArrayRecordView::GetFieldValueByName(): field not found: " + name_); }
-    return GetFieldValue<T>(*field, elementIndex_);
 }
 
 // ---------------------------------------------------------------------------

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -30,6 +30,7 @@
 #include <cassert>
 #include <charconv>
 #include <cstring>
+#include <functional>
 #include <limits>
 #include <optional>
 #include <stdexcept>
@@ -59,6 +60,8 @@ template <template <typename...> class Template, typename... Args> struct is_spe
 template <typename T, template <typename...> class Template> inline constexpr bool is_specialization_of_v = is_specialization_of<T, Template>::value;
 
 class CompositeField;
+class FieldArray;
+class FieldArrayRecordView;
 using CompositeFieldArray = std::vector<CompositeField>;
 
 // ---------------------------------------------------------------------------
@@ -435,34 +438,39 @@ template <typename T>
 }
 
 // ---------------------------------------------------------------------------
-//! \class FixedRecordView
-//! \brief A lightweight, non-owning view over a single fixed-size record (row)
-//!     within a FixedFieldRegion. Combines a row base offset with the schema so
-//!     individual fields of the row can be read without threading a base index
-//!     through the general accessor APIs.
+//! \class FieldArrayRecordView
+//! \brief A lightweight, non-owning view over a single FIELD_ARRAY element.
+//!
+//! \details Wraps either a flat fixed-field row (FixedFieldRegion + row offset)
+//!     or a CompositeField reference behind one read-only interface.
 // ---------------------------------------------------------------------------
-class FixedRecordView
+class FieldArrayRecordView
 {
   public:
-    FixedRecordView(const FixedFieldRegion& region_, size_t rowOffset_) : region(&region_), rowOffset(rowOffset_) {}
-
-    // ---------------------------------------------------------------------------
-    //! \brief Read a field of this record.
-    //!
-    //! \tparam T The value type (trivially copyable, or a TypedBuffer<E> view).
-    //! \param[in] field_ The field definition (offset relative to the row start).
-    //! \param[in] elementIndex_ Element index for fixed-length array fields.
-    // ---------------------------------------------------------------------------
-    template <typename T> [[nodiscard]] T GetFieldValue(const BaseField& field_, size_t elementIndex_ = 0) const
+    struct FlatRecordView
     {
-        if constexpr (is_specialization_of_v<T, TypedBuffer>) { return LoadFixedField<T>(*region, field_, rowOffset); }
-        else if (field_.type == FIELD_TYPE::FIXED_LENGTH_ARRAY) { return LoadFixedFieldElement<T>(*region, elementIndex_, field_, rowOffset); }
-        else { return LoadFixedField<T>(*region, field_, rowOffset); }
+            const FixedFieldRegion* region;
+            size_t rowOffset;
+            FieldInfo::ConstPtr fieldInfo;
+    };
+
+    class const_iterator;
+
+    FieldArrayRecordView(const FixedFieldRegion& region_, size_t rowOffset_, FieldInfo::ConstPtr fieldInfo_)
+        : record(FlatRecordView{&region_, rowOffset_, std::move(fieldInfo_)})
+    {
     }
+    FieldArrayRecordView(const CompositeField& record_) : record(std::cref(record_)) {}
+
+    template <typename T> [[nodiscard]] T GetFieldValue(const BaseField& field_, size_t elementIndex_ = 0) const;
+
+    [[nodiscard]] const FieldInfo::ConstPtr& GetFieldInfo() const;
+
+    [[nodiscard]] const_iterator begin() const;
+    [[nodiscard]] const_iterator end() const;
 
   private:
-    const FixedFieldRegion* region;
-    size_t rowOffset;
+    std::variant<FlatRecordView, std::reference_wrapper<const CompositeField>> record;
 };
 
 // ---------------------------------------------------------------------------
@@ -546,12 +554,12 @@ class FlatFieldArray
     //! \brief Return a non-owning view over a single row of the flat array.
     //!
     //! \param[in] row_ The row index.
-    //! \return A FixedRecordView anchored at the row's byte offset.
+    //! \return A FieldArrayRecordView anchored at the row's byte offset.
     // ---------------------------------------------------------------------------
-    [[nodiscard]] FixedRecordView operator[](size_t row_) const
+    [[nodiscard]] FieldArrayRecordView operator[](size_t row_) const
     {
         if (row_ >= size()) { throw std::runtime_error("FlatFieldArray::operator[](): row index out of bounds"); }
-        return FixedRecordView(fields, row_ * fieldInfo->fixedFieldBytes);
+        return FieldArrayRecordView(fields, row_ * fieldInfo->fixedFieldBytes, fieldInfo);
     }
 
     // ---------------------------------------------------------------------------
@@ -637,7 +645,7 @@ class FlatFieldArray
 
     struct const_iterator
     {
-        using value_type = FixedRecordView;
+        using value_type = FieldArrayRecordView;
         using reference = value_type;
         using difference_type = std::ptrdiff_t;
         using iterator_category = std::forward_iterator_tag;
@@ -669,8 +677,6 @@ using FieldValueVariant =
                  TypedBuffer<int64_t>, TypedBuffer<uint64_t>, TypedBuffer<float>, TypedBuffer<double>, std::vector<int8_t>, std::vector<int16_t>,
                  std::vector<int32_t>, std::vector<int64_t>, std::vector<uint8_t>, std::vector<uint16_t>, std::vector<uint32_t>,
                  std::vector<uint64_t>, std::vector<float>, std::vector<double>, std::string, FlatFieldArray, CompositeFieldArray>;
-
-using FieldValueEntry = std::pair<BaseField::ConstPtr, FieldValueVariant>;
 
 //! Shared implementation for the LoadVariant overloads: select the concrete element type from the
 //! schema via SimpleTypeVisitor and let the caller-supplied loader build the variant payload.
@@ -879,6 +885,21 @@ class CompositeField
             if constexpr (std::is_same_v<T, std::string>) { return std::get<std::string>(varFields[field_.index]); }
             else { throw std::runtime_error("GetFieldValue<T>(): non-string type provided for string field"); }
         case FIELD_TYPE::FIELD_ARRAY:
+            if constexpr (std::is_same_v<T, FieldArray>)
+            {
+                const auto* fieldArrayDef = dynamic_cast<const FieldArrayField*>(&field_);
+                return std::visit(
+                    [&](const auto& value) -> FieldArray {
+                        using ValueT = std::decay_t<decltype(value)>;
+                        if constexpr (std::is_same_v<ValueT, FlatFieldArray> || std::is_same_v<ValueT, CompositeFieldArray>)
+                        {
+                            return FieldArray(value, fieldArrayDef != nullptr ? fieldArrayDef->fieldInfo : nullptr);
+                        }
+                        else { throw std::runtime_error("GetFieldValue<T>(): field array storage is not a FlatFieldArray or CompositeFieldArray"); }
+                    },
+                    varFields[field_.index]);
+            }
+            else
             if constexpr (std::is_same_v<T, FlatFieldArray> || std::is_same_v<T, CompositeFieldArray>)
             {
                 return std::get<T>(varFields[field_.index]);
@@ -1321,7 +1342,7 @@ class CompositeField
 
     struct const_iterator
     {
-        using value_type = FieldValueEntry;
+        using value_type = std::pair<BaseField::ConstPtr, FieldValueVariant>;
         using reference = value_type;
         using difference_type = std::ptrdiff_t;
         using iterator_category = std::forward_iterator_tag;
@@ -1358,6 +1379,216 @@ class CompositeField
         if (fieldInfo == nullptr) { throw std::runtime_error("end(): field definitions not set"); }
         return const_iterator(this, fieldInfo->messageOrderedFields.size());
     }
+};
+
+class FieldArrayRecordView::const_iterator
+{
+  public:
+    using value_type = std::pair<BaseField::ConstPtr, FieldValueVariant>;
+    using reference = value_type;
+    using difference_type = std::ptrdiff_t;
+    using iterator_category = std::forward_iterator_tag;
+
+  private:
+    const FieldArrayRecordView* recordView;
+    size_t index;
+
+    const_iterator(const FieldArrayRecordView* recordView_, size_t index_) : recordView(recordView_), index(index_) {}
+
+    friend class FieldArrayRecordView;
+
+  public:
+    reference operator*() const
+    {
+        const auto& fieldInfo = recordView->GetFieldInfo();
+        if (fieldInfo == nullptr)
+        {
+            throw std::runtime_error("FieldArrayRecordView::const_iterator::operator*(): field definitions not set");
+        }
+        if (index >= fieldInfo->messageOrderedFields.size())
+        {
+            throw std::runtime_error("FieldArrayRecordView::const_iterator::operator*(): iterator out of bounds");
+        }
+
+        const auto& fieldDef = fieldInfo->messageOrderedFields[index];
+        const auto value = std::visit(
+            [&](const auto& record_) -> FieldValueVariant {
+                using RecordT = std::decay_t<decltype(record_)>;
+                if constexpr (std::is_same_v<RecordT, FieldArrayRecordView::FlatRecordView>)
+                {
+                    const auto* fieldPtr = record_.region->data() + record_.rowOffset + fieldDef->index;
+                    if (fieldDef->type == FIELD_TYPE::FIXED_LENGTH_ARRAY)
+                    {
+                        const auto* arrayField = dynamic_cast<const ArrayField*>(fieldDef.get());
+                        if (arrayField == nullptr)
+                        {
+                            throw std::runtime_error("FieldArrayRecordView::const_iterator::operator*(): missing fixed array metadata");
+                        }
+                        return LoadVariant(*arrayField, fieldPtr);
+                    }
+                    return LoadVariant(*fieldDef, fieldPtr);
+                }
+                else { return record_.get().GetFieldValueVariant(*fieldDef); }
+            },
+            recordView->record);
+
+        return {fieldDef, value};
+    }
+
+    const_iterator& operator++()
+    {
+        ++index;
+        return *this;
+    }
+
+    bool operator==(const const_iterator& other) const { return recordView == other.recordView && index == other.index; }
+
+    bool operator!=(const const_iterator& other) const { return !(*this == other); }
+};
+
+inline FieldArrayRecordView::const_iterator FieldArrayRecordView::begin() const
+{
+    return const_iterator(this, 0);
+}
+
+inline FieldArrayRecordView::const_iterator FieldArrayRecordView::end() const
+{
+    const auto& fieldInfo = GetFieldInfo();
+    if (fieldInfo == nullptr) { throw std::runtime_error("FieldArrayRecordView::end(): field definitions not set"); }
+    return const_iterator(this, fieldInfo->messageOrderedFields.size());
+}
+
+template <typename T> inline T FieldArrayRecordView::GetFieldValue(const BaseField& field_, size_t elementIndex_) const
+{
+    return std::visit(
+        [&](const auto& record_) -> T {
+            using RecordT = std::decay_t<decltype(record_)>;
+            if constexpr (std::is_same_v<RecordT, FlatRecordView>)
+            {
+                if constexpr (std::is_trivially_copyable_v<T> || is_specialization_of_v<T, TypedBuffer>)
+                {
+                    if constexpr (is_specialization_of_v<T, TypedBuffer>)
+                    {
+                        return LoadFixedField<T>(*record_.region, field_, record_.rowOffset);
+                    }
+                    else if (field_.type == FIELD_TYPE::FIXED_LENGTH_ARRAY)
+                    {
+                        return LoadFixedFieldElement<T>(*record_.region, elementIndex_, field_, record_.rowOffset);
+                    }
+                    else { return LoadFixedField<T>(*record_.region, field_, record_.rowOffset); }
+                }
+                else
+                {
+                    throw std::runtime_error("FieldArrayRecordView::GetFieldValue<T>(): type T must be trivially copyable or TypedBuffer specialization");
+                }
+            }
+            else { return record_.get().GetFieldValue<T>(field_, elementIndex_); }
+        },
+        record);
+}
+
+inline const FieldInfo::ConstPtr& FieldArrayRecordView::GetFieldInfo() const
+{
+    return std::visit(
+        [](const auto& record_) -> const FieldInfo::ConstPtr& {
+            using RecordT = std::decay_t<decltype(record_)>;
+            if constexpr (std::is_same_v<RecordT, FlatRecordView>) { return record_.fieldInfo; }
+            else { return record_.get().GetFieldInfo(); }
+        },
+        record);
+}
+
+// ---------------------------------------------------------------------------
+//! \class FieldArray
+//! \brief A lightweight, non-owning wrapper over either FIELD_ARRAY storage
+//!     representation.
+//!
+//! \details This lets callers read FIELD_ARRAY contents without knowing
+//!     whether the underlying representation is FlatFieldArray or
+//!     CompositeFieldArray.
+// ---------------------------------------------------------------------------
+class FieldArray
+{
+  public:
+    FieldArray(const FlatFieldArray& fieldArray_, FieldInfo::ConstPtr fieldInfo_ = nullptr)
+        : fieldArray(&fieldArray_), fieldInfo(fieldInfo_ != nullptr ? std::move(fieldInfo_) : fieldArray_.GetFieldInfo())
+    {
+    }
+
+    FieldArray(const CompositeFieldArray& fieldArray_, FieldInfo::ConstPtr fieldInfo_ = nullptr)
+        : fieldArray(&fieldArray_), fieldInfo(std::move(fieldInfo_))
+    {
+    }
+
+    [[nodiscard]] size_t size() const
+    {
+        return std::visit(
+            [](const auto* value_) -> size_t { return value_->size(); },
+            fieldArray);
+    }
+
+    [[nodiscard]] bool empty() const { return size() == 0; }
+
+    [[nodiscard]] FieldInfo::ConstPtr GetFieldInfo() const
+    {
+        return std::visit(
+            [&](const auto* value_) -> FieldInfo::ConstPtr {
+                using ValueT = std::remove_cv_t<std::remove_pointer_t<decltype(value_)>>;
+                if constexpr (std::is_same_v<ValueT, FlatFieldArray>) { return value_->GetFieldInfo(); }
+                else
+                {
+                    if (fieldInfo != nullptr) { return fieldInfo; }
+                    if (value_->empty()) { return nullptr; }
+                    return (*value_)[0].GetFieldInfo();
+                }
+            },
+            fieldArray);
+    }
+
+    template <typename T> [[nodiscard]] T GetFieldValue(const BaseField& field_, size_t index_, size_t elementIndex_ = 0) const
+    {
+        return (*this)[index_].GetFieldValue<T>(field_, elementIndex_);
+    }
+
+    [[nodiscard]] FieldArrayRecordView operator[](size_t index_) const
+    {
+        return std::visit(
+            [&](const auto* value_) -> FieldArrayRecordView {
+                return FieldArrayRecordView((*value_)[index_]);
+            },
+            fieldArray);
+    }
+
+    struct const_iterator
+    {
+        using value_type = FieldArrayRecordView;
+        using reference = value_type;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::forward_iterator_tag;
+
+        const FieldArray* fieldArray;
+        size_t index;
+
+        const_iterator(const FieldArray* fieldArray_, size_t index_ = 0) : fieldArray(fieldArray_), index(index_) {}
+
+        reference operator*() const { return (*fieldArray)[index]; }
+
+        const_iterator& operator++()
+        {
+            ++index;
+            return *this;
+        }
+
+        bool operator==(const const_iterator& other) const { return fieldArray == other.fieldArray && index == other.index; }
+        bool operator!=(const const_iterator& other) const { return !(*this == other); }
+    };
+
+    [[nodiscard]] const_iterator begin() const { return const_iterator(this); }
+    [[nodiscard]] const_iterator end() const { return const_iterator(this, size()); }
+
+  private:
+    std::variant<const FlatFieldArray*, const CompositeFieldArray*> fieldArray;
+    FieldInfo::ConstPtr fieldInfo;
 };
 
 //============================================================================

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -448,11 +448,11 @@ class FieldArrayRecordView
 {
   public:
     FieldArrayRecordView(const FixedFieldRegion& region_, size_t rowOffset_, const FieldInfo* fieldInfo_)
-        : ffRegion(&region_), rowOffset(rowOffset_), fieldInfo(fieldInfo_)
+        : fieldInfo(fieldInfo_), ffRegion(&region_), rowOffset(rowOffset_)
     {
     }
 
-    FieldArrayRecordView(const CompositeField& record_, const FieldInfo* fieldInfo_) : cfRecord(&record_), fieldInfo(fieldInfo_) {}
+    FieldArrayRecordView(const CompositeField& record_, const FieldInfo* fieldInfo_) : fieldInfo(fieldInfo_), cfRecord(&record_) {}
 
     template <typename T> [[nodiscard]] T GetFieldValue(const BaseField& field_, size_t elementIndex_ = 0) const;
 
@@ -897,7 +897,7 @@ class CompositeField
             {
                 const auto* fieldArrayDef = dynamic_cast<const FieldArrayField*>(&field_);
                 if (fieldArrayDef == nullptr) { throw std::runtime_error("GetFieldValue<T>(): missing field array metadata"); }
-                return FieldArray(varFields[field_.index], fieldArrayDef->fieldInfo.get());
+                return T(varFields[field_.index], fieldArrayDef->fieldInfo.get());
             }
             else if constexpr (std::is_same_v<T, FlatFieldArray> || std::is_same_v<T, CompositeFieldArray>)
             {

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -66,8 +66,8 @@ using CompositeFieldArray = std::vector<CompositeField>;
 
 // ---------------------------------------------------------------------------
 //! \class TypedBuffer
-//! \brief A lightweight wrapper around a byte buffer that allows for typed access to its elements.
-//!     Used for fixed-length array fields in the message body.
+//! \brief A lightweight wrapper around a byte buffer that allows for typed
+//!     access to its elements. Used for fields of type FIXED_LENGTH_ARRAY.
 // ---------------------------------------------------------------------------
 template <typename T> class TypedBuffer
 {

--- a/include/novatel_edie/decoders/common/message_decoder.hpp
+++ b/include/novatel_edie/decoders/common/message_decoder.hpp
@@ -451,23 +451,15 @@ class FieldArrayRecordView
     {
             const FixedFieldRegion* region;
             size_t rowOffset;
-            FieldInfo::ConstPtr fieldInfo;
     };
 
-    class const_iterator;
-
-    FieldArrayRecordView(const FixedFieldRegion& region_, size_t rowOffset_, FieldInfo::ConstPtr fieldInfo_)
-        : record(FlatRecordView{&region_, rowOffset_, std::move(fieldInfo_)})
+    FieldArrayRecordView(const FixedFieldRegion& region_, size_t rowOffset_)
+        : record(FlatRecordView{&region_, rowOffset_})
     {
     }
     FieldArrayRecordView(const CompositeField& record_) : record(std::cref(record_)) {}
 
     template <typename T> [[nodiscard]] T GetFieldValue(const BaseField& field_, size_t elementIndex_ = 0) const;
-
-    [[nodiscard]] const FieldInfo::ConstPtr& GetFieldInfo() const;
-
-    [[nodiscard]] const_iterator begin() const;
-    [[nodiscard]] const_iterator end() const;
 
   private:
     std::variant<FlatRecordView, std::reference_wrapper<const CompositeField>> record;
@@ -559,7 +551,7 @@ class FlatFieldArray
     [[nodiscard]] FieldArrayRecordView operator[](size_t row_) const
     {
         if (row_ >= size()) { throw std::runtime_error("FlatFieldArray::operator[](): row index out of bounds"); }
-        return FieldArrayRecordView(fields, row_ * fieldInfo->fixedFieldBytes, fieldInfo);
+        return FieldArrayRecordView(fields, row_ * fieldInfo->fixedFieldBytes);
     }
 
     // ---------------------------------------------------------------------------
@@ -1381,83 +1373,6 @@ class CompositeField
     }
 };
 
-class FieldArrayRecordView::const_iterator
-{
-  public:
-    using value_type = std::pair<BaseField::ConstPtr, FieldValueVariant>;
-    using reference = value_type;
-    using difference_type = std::ptrdiff_t;
-    using iterator_category = std::forward_iterator_tag;
-
-  private:
-    const FieldArrayRecordView* recordView;
-    size_t index;
-
-    const_iterator(const FieldArrayRecordView* recordView_, size_t index_) : recordView(recordView_), index(index_) {}
-
-    friend class FieldArrayRecordView;
-
-  public:
-    reference operator*() const
-    {
-        const auto& fieldInfo = recordView->GetFieldInfo();
-        if (fieldInfo == nullptr)
-        {
-            throw std::runtime_error("FieldArrayRecordView::const_iterator::operator*(): field definitions not set");
-        }
-        if (index >= fieldInfo->messageOrderedFields.size())
-        {
-            throw std::runtime_error("FieldArrayRecordView::const_iterator::operator*(): iterator out of bounds");
-        }
-
-        const auto& fieldDef = fieldInfo->messageOrderedFields[index];
-        const auto value = std::visit(
-            [&](const auto& record_) -> FieldValueVariant {
-                using RecordT = std::decay_t<decltype(record_)>;
-                if constexpr (std::is_same_v<RecordT, FieldArrayRecordView::FlatRecordView>)
-                {
-                    const auto* fieldPtr = record_.region->data() + record_.rowOffset + fieldDef->index;
-                    if (fieldDef->type == FIELD_TYPE::FIXED_LENGTH_ARRAY)
-                    {
-                        const auto* arrayField = dynamic_cast<const ArrayField*>(fieldDef.get());
-                        if (arrayField == nullptr)
-                        {
-                            throw std::runtime_error("FieldArrayRecordView::const_iterator::operator*(): missing fixed array metadata");
-                        }
-                        return LoadVariant(*arrayField, fieldPtr);
-                    }
-                    return LoadVariant(*fieldDef, fieldPtr);
-                }
-                else { return record_.get().GetFieldValueVariant(*fieldDef); }
-            },
-            recordView->record);
-
-        return {fieldDef, value};
-    }
-
-    const_iterator& operator++()
-    {
-        ++index;
-        return *this;
-    }
-
-    bool operator==(const const_iterator& other) const { return recordView == other.recordView && index == other.index; }
-
-    bool operator!=(const const_iterator& other) const { return !(*this == other); }
-};
-
-inline FieldArrayRecordView::const_iterator FieldArrayRecordView::begin() const
-{
-    return const_iterator(this, 0);
-}
-
-inline FieldArrayRecordView::const_iterator FieldArrayRecordView::end() const
-{
-    const auto& fieldInfo = GetFieldInfo();
-    if (fieldInfo == nullptr) { throw std::runtime_error("FieldArrayRecordView::end(): field definitions not set"); }
-    return const_iterator(this, fieldInfo->messageOrderedFields.size());
-}
-
 template <typename T> inline T FieldArrayRecordView::GetFieldValue(const BaseField& field_, size_t elementIndex_) const
 {
     return std::visit(
@@ -1483,17 +1398,6 @@ template <typename T> inline T FieldArrayRecordView::GetFieldValue(const BaseFie
                 }
             }
             else { return record_.get().GetFieldValue<T>(field_, elementIndex_); }
-        },
-        record);
-}
-
-inline const FieldInfo::ConstPtr& FieldArrayRecordView::GetFieldInfo() const
-{
-    return std::visit(
-        [](const auto& record_) -> const FieldInfo::ConstPtr& {
-            using RecordT = std::decay_t<decltype(record_)>;
-            if constexpr (std::is_same_v<RecordT, FlatRecordView>) { return record_.fieldInfo; }
-            else { return record_.get().GetFieldInfo(); }
         },
         record);
 }

--- a/src/decoders/common/src/message_decoder.cpp
+++ b/src/decoders/common/src/message_decoder.cpp
@@ -340,7 +340,7 @@ MessageDecoderBase::DecodeBinary(const FieldInfo& vMsgDefFields_, const unsigned
                 // Store flat FIELD_ARRAY directly as std::vector<std::byte>
                 std::vector<std::byte> flatFieldData(reinterpret_cast<const std::byte*>(*ppucLogBuf_),
                                                      reinterpret_cast<const std::byte*>(*ppucLogBuf_) + totalBytes);
-                clCompField_.SetFieldValue(*field, FlatFieldArray(std::move(flatFieldData), subFieldDefinitions->fieldInfo));
+                clCompField_.SetFieldValue(*field, FlatFieldArray(std::move(flatFieldData), subFieldDefinitions->fieldInfo.get()));
                 *ppucLogBuf_ += totalBytes;
             }
             else

--- a/src/decoders/common/test/message_decoder_unit_test.cpp
+++ b/src/decoders/common/test/message_decoder_unit_test.cpp
@@ -457,7 +457,7 @@ TEST(MessageDecoderContainerTypesTest, FlatFieldArrayIteratorBuildsExpectedMessa
     auto f1 = std::make_shared<BaseField>("i16", FIELD_TYPE::SIMPLE, "%hd", DATA_TYPE::SHORT);
 
     const auto fieldInfo = BuildFieldInfo({f0, f1});
-    FlatFieldArray fieldArray(2, fieldInfo);
+    FlatFieldArray fieldArray(2, fieldInfo.get());
 
     fieldArray.SetFieldValue<uint32_t>(0, *f0, 11U);
     fieldArray.SetFieldValue<int16_t>(0, *f1, static_cast<int16_t>(-7));
@@ -475,42 +475,6 @@ TEST(MessageDecoderContainerTypesTest, FlatFieldArrayIteratorBuildsExpectedMessa
     EXPECT_EQ(row1.GetFieldValue<int16_t>(*f1), static_cast<int16_t>(9));
 }
 
-TEST(MessageDecoderContainerTypesTest, FieldArrayRecordViewIteratorTraversesFlatBackedRowInDefinitionOrder)
-{
-    auto f0 = std::make_shared<BaseField>("u32", FIELD_TYPE::SIMPLE, "%u", DATA_TYPE::UINT);
-    auto f1 = std::make_shared<BaseField>("i16", FIELD_TYPE::SIMPLE, "%hd", DATA_TYPE::SHORT);
-
-    const auto fieldInfo = BuildFieldInfo({f0, f1});
-    FlatFieldArray fieldArray(1, fieldInfo);
-    fieldArray.SetFieldValue<uint32_t>(0, *f0, 11U);
-    fieldArray.SetFieldValue<int16_t>(0, *f1, static_cast<int16_t>(-7));
-
-    const FieldArrayRecordView row = fieldArray[0];
-    auto it = row.begin();
-
-    auto fieldValue = *it;
-    EXPECT_EQ(fieldValue.first, f0);
-    EXPECT_EQ(std::get<uint32_t>(fieldValue.second), 11U);
-
-    ++it;
-    fieldValue = *it;
-    EXPECT_EQ(fieldValue.first, f1);
-    EXPECT_EQ(std::get<int16_t>(fieldValue.second), static_cast<int16_t>(-7));
-
-    ++it;
-    EXPECT_EQ(it, row.end());
-}
-
-TEST(MessageDecoderContainerTypesTest, FlatFieldArrayIteratorEndDereferenceThrows)
-{
-    auto f0 = std::make_shared<BaseField>("u32", FIELD_TYPE::SIMPLE, "%u", DATA_TYPE::UINT);
-    const auto fieldInfo = BuildFieldInfo({f0});
-    FlatFieldArray fieldArray(1, fieldInfo);
-
-    auto it = fieldArray.end();
-    EXPECT_THROW(*it, std::runtime_error);
-}
-
 TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperReadsFlatBackedFieldArray)
 {
     auto nestedU32 = std::make_shared<BaseField>("u32", FIELD_TYPE::SIMPLE, "%u", DATA_TYPE::UINT);
@@ -520,7 +484,7 @@ TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperReadsFlatBackedFieldArra
     auto fieldArrayField = std::make_shared<FieldArrayField>("fa", FIELD_TYPE::FIELD_ARRAY, "", DATA_TYPE::UNKNOWN, 2, nestedFieldInfo);
     const auto rootFieldInfo = BuildFieldInfo({fieldArrayField});
 
-    FlatFieldArray stored(2, nestedFieldInfo);
+    FlatFieldArray stored(2, nestedFieldInfo.get());
     stored.SetFieldValue<uint32_t>(0, *nestedU32, 11U);
     stored.SetFieldValue<int16_t>(0, *nestedI16, static_cast<int16_t>(-7));
     stored.SetFieldValue<uint32_t>(1, *nestedU32, 22U);
@@ -531,7 +495,7 @@ TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperReadsFlatBackedFieldArra
 
     const FieldArray wrapped = body.GetFieldValue<FieldArray>(*fieldArrayField);
     ASSERT_EQ(wrapped.size(), 2U);
-    EXPECT_EQ(wrapped.GetFieldInfo(), nestedFieldInfo);
+    EXPECT_EQ(wrapped.GetFieldInfo(), nestedFieldInfo.get());
     EXPECT_EQ(wrapped.GetFieldValue<uint32_t>(*nestedU32, 0), 11U);
     EXPECT_EQ(wrapped.GetFieldValue<int16_t>(*nestedI16, 1), static_cast<int16_t>(9));
 
@@ -571,7 +535,7 @@ TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperReadsCompositeBackedFiel
 
     const FieldArray wrapped = body.GetFieldValue<FieldArray>(*fieldArrayField);
     ASSERT_EQ(wrapped.size(), 2U);
-    EXPECT_EQ(wrapped.GetFieldInfo(), nestedFieldInfo);
+    EXPECT_EQ(wrapped.GetFieldInfo(), nestedFieldInfo.get());
     EXPECT_EQ(wrapped.GetFieldValue<uint32_t>(*nestedU32, 0), 10U);
     EXPECT_EQ(wrapped.GetFieldValue<std::string>(*nestedStr, 1), "twenty");
 
@@ -583,32 +547,6 @@ TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperReadsCompositeBackedFiel
     EXPECT_EQ((*it).GetFieldValue<uint32_t>(*nestedU32), 10U);
     ++it;
     EXPECT_EQ((*it).GetFieldValue<std::string>(*nestedStr), "twenty");
-}
-
-TEST(MessageDecoderContainerTypesTest, FieldArrayRecordViewIteratorDelegatesToCompositeFieldIterator)
-{
-    auto nestedU32 = std::make_shared<BaseField>("u32", FIELD_TYPE::SIMPLE, "%u", DATA_TYPE::UINT);
-    auto nestedStr = std::make_shared<BaseField>("str", FIELD_TYPE::STRING, "%s", DATA_TYPE::UNKNOWN);
-    const auto nestedFieldInfo = BuildFieldInfo({nestedU32, nestedStr});
-
-    CompositeField row(nestedFieldInfo);
-    row.SetFieldValue(*nestedU32, 10U);
-    row.SetFieldValue(*nestedStr, std::string("ten"));
-
-    const FieldArrayRecordView rowView(row);
-    auto it = rowView.begin();
-
-    auto fieldValue = *it;
-    EXPECT_EQ(fieldValue.first, nestedU32);
-    EXPECT_EQ(std::get<uint32_t>(fieldValue.second), 10U);
-
-    ++it;
-    fieldValue = *it;
-    EXPECT_EQ(fieldValue.first, nestedStr);
-    EXPECT_EQ(std::get<std::string>(fieldValue.second), "ten");
-
-    ++it;
-    EXPECT_EQ(it, rowView.end());
 }
 
 TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperPreservesSchemaForEmptyCompositeFieldArray)
@@ -625,7 +563,7 @@ TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperPreservesSchemaForEmptyC
 
     const FieldArray wrapped = body.GetFieldValue<FieldArray>(*fieldArrayField);
     EXPECT_TRUE(wrapped.empty());
-    EXPECT_EQ(wrapped.GetFieldInfo(), nestedFieldInfo);
+    EXPECT_EQ(wrapped.GetFieldInfo(), nestedFieldInfo.get());
 }
 
 TEST(MessageDecoderContainerTypesTest, MessageBodyIteratorTraversesFieldValuesInDefinitionOrder)

--- a/src/decoders/common/test/message_decoder_unit_test.cpp
+++ b/src/decoders/common/test/message_decoder_unit_test.cpp
@@ -545,8 +545,14 @@ TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperReadsCompositeBackedFiel
 
     auto it = wrapped.begin();
     EXPECT_EQ((*it).GetFieldValue<uint32_t>(*nestedU32), 10U);
+    EXPECT_EQ((*it).GetFieldValue<std::string>(*nestedStr), "ten");
+    
     ++it;
+    EXPECT_EQ((*it).GetFieldValue<uint32_t>(*nestedU32), 20U);
     EXPECT_EQ((*it).GetFieldValue<std::string>(*nestedStr), "twenty");
+
+    ++it;
+    EXPECT_EQ(it, wrapped.end());
 }
 
 TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperPreservesSchemaForEmptyCompositeFieldArray)
@@ -675,4 +681,42 @@ TEST(MessageDecoderContainerTypesTest, MessageBodyIteratorRequiresFieldInfo)
     CompositeField body;
     EXPECT_THROW(body.begin(), std::runtime_error);
     EXPECT_THROW(body.end(), std::runtime_error);
+}
+
+TEST(MessageDecoderContainerTypesTest, CompositeFieldGetFieldValueByName)
+{
+    auto f0 = std::make_shared<BaseField>("u32", FIELD_TYPE::SIMPLE, "%u", DATA_TYPE::UINT);
+    auto f1 = std::make_shared<BaseField>("str", FIELD_TYPE::STRING, "%s", DATA_TYPE::UNKNOWN);
+
+    const auto fieldInfo = BuildFieldInfo({f0, f1});
+    CompositeField stMessage(fieldInfo);
+
+    stMessage.SetFieldValue(*f0, uint32_t{10});
+    stMessage.SetFieldValue(*f1, std::string("ten"));
+
+    EXPECT_EQ(stMessage.GetFieldValueByName<uint32_t>("u32"), 10);
+    EXPECT_EQ(stMessage.GetFieldValueByName<std::string>("str"), "ten");
+    EXPECT_THROW((void)stMessage.GetFieldValueByName<uint8_t>("error"), std::runtime_error);
+}
+
+TEST(MessageDecoderContainerTypesTest, FlatFieldArrayRecordViewGetFieldValueByName)
+{
+    auto f0 = std::make_shared<BaseField>("u32", FIELD_TYPE::SIMPLE, "%u", DATA_TYPE::UINT);
+    auto f1 = std::make_shared<ArrayField>("arr", FIELD_TYPE::FIXED_LENGTH_ARRAY, "%s", DATA_TYPE::UCHAR, 7);
+    const auto fieldInfo = BuildFieldInfo({f0, f1});
+
+    FlatFieldArray ffa(2, fieldInfo.get());
+    ffa.SetFieldValue(0, *f0, 10U);
+    ffa.SetFieldValue(0, *f1, std::string("ten"));
+    ffa.SetFieldValue(1, *f0, 20U);
+    ffa.SetFieldValue(1, *f1, std::string("twenty"));
+
+    auto tenStr = std::string("ten");
+    auto twentyStr = std::string("twenty");
+    EXPECT_EQ(ffa[0].GetFieldValueByName<uint32_t>("u32"), 10);
+    const auto arr1 = ffa[0].GetFieldValueByName<TypedBuffer<uint8_t>>("arr");
+    for (size_t i = 0; i < tenStr.size(); i++) { EXPECT_EQ(arr1[i], static_cast<uint8_t>(tenStr[i])); }
+    EXPECT_EQ(ffa[1].GetFieldValueByName<uint32_t>("u32"), 20);
+    const auto arr2 = ffa[1].GetFieldValueByName<TypedBuffer<uint8_t>>("arr");
+    for (size_t i = 0; i < twentyStr.size(); i++) { EXPECT_EQ(arr2[i], static_cast<uint8_t>(twentyStr[i])); }
 }

--- a/src/decoders/common/test/message_decoder_unit_test.cpp
+++ b/src/decoders/common/test/message_decoder_unit_test.cpp
@@ -493,7 +493,7 @@ TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperReadsFlatBackedFieldArra
     CompositeField body(rootFieldInfo);
     body.SetFieldValue(*fieldArrayField, stored);
 
-    const FieldArray wrapped = body.GetFieldValue<FieldArray>(*fieldArrayField);
+    const auto wrapped = body.GetFieldValue<FieldArray>(*fieldArrayField);
     ASSERT_EQ(wrapped.size(), 2U);
     EXPECT_EQ(wrapped.GetFieldInfo(), nestedFieldInfo.get());
     EXPECT_EQ(wrapped.GetFieldValue<uint32_t>(*nestedU32, 0), 11U);
@@ -533,7 +533,7 @@ TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperReadsCompositeBackedFiel
     CompositeField body(rootFieldInfo);
     body.SetFieldValue(*fieldArrayField, CompositeFieldArray{row0, row1});
 
-    const FieldArray wrapped = body.GetFieldValue<FieldArray>(*fieldArrayField);
+    const auto wrapped = body.GetFieldValue<FieldArray>(*fieldArrayField);
     ASSERT_EQ(wrapped.size(), 2U);
     EXPECT_EQ(wrapped.GetFieldInfo(), nestedFieldInfo.get());
     EXPECT_EQ(wrapped.GetFieldValue<uint32_t>(*nestedU32, 0), 10U);
@@ -561,7 +561,7 @@ TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperPreservesSchemaForEmptyC
     CompositeField body(rootFieldInfo);
     body.SetFieldValue(*fieldArrayField, CompositeFieldArray{});
 
-    const FieldArray wrapped = body.GetFieldValue<FieldArray>(*fieldArrayField);
+    const auto wrapped = body.GetFieldValue<FieldArray>(*fieldArrayField);
     EXPECT_TRUE(wrapped.empty());
     EXPECT_EQ(wrapped.GetFieldInfo(), nestedFieldInfo.get());
 }

--- a/src/decoders/common/test/message_decoder_unit_test.cpp
+++ b/src/decoders/common/test/message_decoder_unit_test.cpp
@@ -465,14 +465,40 @@ TEST(MessageDecoderContainerTypesTest, FlatFieldArrayIteratorBuildsExpectedMessa
     fieldArray.SetFieldValue<int16_t>(1, *f1, static_cast<int16_t>(9));
 
     auto it = fieldArray.begin();
-    const FixedRecordView row0 = *it;
+    const FieldArrayRecordView row0 = *it;
     EXPECT_EQ(row0.GetFieldValue<uint32_t>(*f0), 11U);
     EXPECT_EQ(row0.GetFieldValue<int16_t>(*f1), static_cast<int16_t>(-7));
 
     ++it;
-    const FixedRecordView row1 = *it;
+    const FieldArrayRecordView row1 = *it;
     EXPECT_EQ(row1.GetFieldValue<uint32_t>(*f0), 22U);
     EXPECT_EQ(row1.GetFieldValue<int16_t>(*f1), static_cast<int16_t>(9));
+}
+
+TEST(MessageDecoderContainerTypesTest, FieldArrayRecordViewIteratorTraversesFlatBackedRowInDefinitionOrder)
+{
+    auto f0 = std::make_shared<BaseField>("u32", FIELD_TYPE::SIMPLE, "%u", DATA_TYPE::UINT);
+    auto f1 = std::make_shared<BaseField>("i16", FIELD_TYPE::SIMPLE, "%hd", DATA_TYPE::SHORT);
+
+    const auto fieldInfo = BuildFieldInfo({f0, f1});
+    FlatFieldArray fieldArray(1, fieldInfo);
+    fieldArray.SetFieldValue<uint32_t>(0, *f0, 11U);
+    fieldArray.SetFieldValue<int16_t>(0, *f1, static_cast<int16_t>(-7));
+
+    const FieldArrayRecordView row = fieldArray[0];
+    auto it = row.begin();
+
+    auto fieldValue = *it;
+    EXPECT_EQ(fieldValue.first, f0);
+    EXPECT_EQ(std::get<uint32_t>(fieldValue.second), 11U);
+
+    ++it;
+    fieldValue = *it;
+    EXPECT_EQ(fieldValue.first, f1);
+    EXPECT_EQ(std::get<int16_t>(fieldValue.second), static_cast<int16_t>(-7));
+
+    ++it;
+    EXPECT_EQ(it, row.end());
 }
 
 TEST(MessageDecoderContainerTypesTest, FlatFieldArrayIteratorEndDereferenceThrows)
@@ -483,6 +509,123 @@ TEST(MessageDecoderContainerTypesTest, FlatFieldArrayIteratorEndDereferenceThrow
 
     auto it = fieldArray.end();
     EXPECT_THROW(*it, std::runtime_error);
+}
+
+TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperReadsFlatBackedFieldArray)
+{
+    auto nestedU32 = std::make_shared<BaseField>("u32", FIELD_TYPE::SIMPLE, "%u", DATA_TYPE::UINT);
+    auto nestedI16 = std::make_shared<BaseField>("i16", FIELD_TYPE::SIMPLE, "%hd", DATA_TYPE::SHORT);
+    const auto nestedFieldInfo = BuildFieldInfo({nestedU32, nestedI16});
+
+    auto fieldArrayField = std::make_shared<FieldArrayField>("fa", FIELD_TYPE::FIELD_ARRAY, "", DATA_TYPE::UNKNOWN, 2, nestedFieldInfo);
+    const auto rootFieldInfo = BuildFieldInfo({fieldArrayField});
+
+    FlatFieldArray stored(2, nestedFieldInfo);
+    stored.SetFieldValue<uint32_t>(0, *nestedU32, 11U);
+    stored.SetFieldValue<int16_t>(0, *nestedI16, static_cast<int16_t>(-7));
+    stored.SetFieldValue<uint32_t>(1, *nestedU32, 22U);
+    stored.SetFieldValue<int16_t>(1, *nestedI16, static_cast<int16_t>(9));
+
+    CompositeField body(rootFieldInfo);
+    body.SetFieldValue(*fieldArrayField, stored);
+
+    const FieldArray wrapped = body.GetFieldValue<FieldArray>(*fieldArrayField);
+    ASSERT_EQ(wrapped.size(), 2U);
+    EXPECT_EQ(wrapped.GetFieldInfo(), nestedFieldInfo);
+    EXPECT_EQ(wrapped.GetFieldValue<uint32_t>(*nestedU32, 0), 11U);
+    EXPECT_EQ(wrapped.GetFieldValue<int16_t>(*nestedI16, 1), static_cast<int16_t>(9));
+
+    auto it = wrapped.begin();
+    const FieldArrayRecordView row0 = *it;
+    EXPECT_EQ(row0.GetFieldValue<uint32_t>(*nestedU32), 11U);
+    EXPECT_EQ(row0.GetFieldValue<int16_t>(*nestedI16), static_cast<int16_t>(-7));
+
+    ++it;
+    const FieldArrayRecordView row1 = *it;
+    EXPECT_EQ(row1.GetFieldValue<uint32_t>(*nestedU32), 22U);
+    EXPECT_EQ(row1.GetFieldValue<int16_t>(*nestedI16), static_cast<int16_t>(9));
+
+    ++it;
+    EXPECT_EQ(it, wrapped.end());
+}
+
+TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperReadsCompositeBackedFieldArray)
+{
+    auto nestedU32 = std::make_shared<BaseField>("u32", FIELD_TYPE::SIMPLE, "%u", DATA_TYPE::UINT);
+    auto nestedStr = std::make_shared<BaseField>("str", FIELD_TYPE::STRING, "%s", DATA_TYPE::UNKNOWN);
+    const auto nestedFieldInfo = BuildFieldInfo({nestedU32, nestedStr});
+
+    auto fieldArrayField = std::make_shared<FieldArrayField>("fa", FIELD_TYPE::FIELD_ARRAY, "", DATA_TYPE::UNKNOWN, 4, nestedFieldInfo);
+    const auto rootFieldInfo = BuildFieldInfo({fieldArrayField});
+
+    CompositeField row0(nestedFieldInfo);
+    row0.SetFieldValue(*nestedU32, 10U);
+    row0.SetFieldValue(*nestedStr, std::string("ten"));
+
+    CompositeField row1(nestedFieldInfo);
+    row1.SetFieldValue(*nestedU32, 20U);
+    row1.SetFieldValue(*nestedStr, std::string("twenty"));
+
+    CompositeField body(rootFieldInfo);
+    body.SetFieldValue(*fieldArrayField, CompositeFieldArray{row0, row1});
+
+    const FieldArray wrapped = body.GetFieldValue<FieldArray>(*fieldArrayField);
+    ASSERT_EQ(wrapped.size(), 2U);
+    EXPECT_EQ(wrapped.GetFieldInfo(), nestedFieldInfo);
+    EXPECT_EQ(wrapped.GetFieldValue<uint32_t>(*nestedU32, 0), 10U);
+    EXPECT_EQ(wrapped.GetFieldValue<std::string>(*nestedStr, 1), "twenty");
+
+    const FieldArrayRecordView firstRow = wrapped[0];
+    EXPECT_EQ(firstRow.GetFieldValue<uint32_t>(*nestedU32), 10U);
+    EXPECT_EQ(firstRow.GetFieldValue<std::string>(*nestedStr), "ten");
+
+    auto it = wrapped.begin();
+    EXPECT_EQ((*it).GetFieldValue<uint32_t>(*nestedU32), 10U);
+    ++it;
+    EXPECT_EQ((*it).GetFieldValue<std::string>(*nestedStr), "twenty");
+}
+
+TEST(MessageDecoderContainerTypesTest, FieldArrayRecordViewIteratorDelegatesToCompositeFieldIterator)
+{
+    auto nestedU32 = std::make_shared<BaseField>("u32", FIELD_TYPE::SIMPLE, "%u", DATA_TYPE::UINT);
+    auto nestedStr = std::make_shared<BaseField>("str", FIELD_TYPE::STRING, "%s", DATA_TYPE::UNKNOWN);
+    const auto nestedFieldInfo = BuildFieldInfo({nestedU32, nestedStr});
+
+    CompositeField row(nestedFieldInfo);
+    row.SetFieldValue(*nestedU32, 10U);
+    row.SetFieldValue(*nestedStr, std::string("ten"));
+
+    const FieldArrayRecordView rowView(row);
+    auto it = rowView.begin();
+
+    auto fieldValue = *it;
+    EXPECT_EQ(fieldValue.first, nestedU32);
+    EXPECT_EQ(std::get<uint32_t>(fieldValue.second), 10U);
+
+    ++it;
+    fieldValue = *it;
+    EXPECT_EQ(fieldValue.first, nestedStr);
+    EXPECT_EQ(std::get<std::string>(fieldValue.second), "ten");
+
+    ++it;
+    EXPECT_EQ(it, rowView.end());
+}
+
+TEST(MessageDecoderContainerTypesTest, FieldArrayWrapperPreservesSchemaForEmptyCompositeFieldArray)
+{
+    auto nestedU32 = std::make_shared<BaseField>("u32", FIELD_TYPE::SIMPLE, "%u", DATA_TYPE::UINT);
+    auto nestedStr = std::make_shared<BaseField>("str", FIELD_TYPE::STRING, "%s", DATA_TYPE::UNKNOWN);
+    const auto nestedFieldInfo = BuildFieldInfo({nestedU32, nestedStr});
+
+    auto fieldArrayField = std::make_shared<FieldArrayField>("fa", FIELD_TYPE::FIELD_ARRAY, "", DATA_TYPE::UNKNOWN, 4, nestedFieldInfo);
+    const auto rootFieldInfo = BuildFieldInfo({fieldArrayField});
+
+    CompositeField body(rootFieldInfo);
+    body.SetFieldValue(*fieldArrayField, CompositeFieldArray{});
+
+    const FieldArray wrapped = body.GetFieldValue<FieldArray>(*fieldArrayField);
+    EXPECT_TRUE(wrapped.empty());
+    EXPECT_EQ(wrapped.GetFieldInfo(), nestedFieldInfo);
 }
 
 TEST(MessageDecoderContainerTypesTest, MessageBodyIteratorTraversesFieldValuesInDefinitionOrder)


### PR DESCRIPTION
## Summary

- Field arrays can now be accessed through the `FieldArray` type, which transparently handles type dispatch on the underlying storage (either `FlatFieldArray` or `CompositeFieldArray`)
- Adds the `GetFieldValueByName` function to `CompositeField` and `FieldArrayRecordView`, which looks up a field's definition and then retrieves its value
- Updates `README.md` with more detailed instructions about accessing field values

## More details

Previously, accessing a field array required either compile-time knowledge of the underlying storage type (`FlatFieldArray` or `CompositeFieldArray`), e.g.

```
obsArray = stMessage.GetFieldValue<FlatFieldArray>(*obsDef);
// OR
obsArray = stMessage.GetFieldValue<CompositeFieldArray>(*obsDef);
```

or using `std::visit`, e.g.

```
std::visit([](auto& arr) {
    using ArrT = std::decay_t<decltype(arr)>;
    if constexpr (std::is_same_v<ArrT, FlatFieldArray> || std::is_same_v<ArrT, CompositeFieldArray>)
    { ... }
}, stMessage.GetVarFields()[obsDef->index]);
```

The new `FieldArray` type gives a consistent way to access either kind of field array transparently:

```
obsArray = stMessage.GetFieldValue<FieldArray>(*obsDef);
```

### Access by field name

The new `GetFieldValueByName` method can be used to obtain a field's value directly using its name. This is less computationally efficient than caching a definition and reusing it for subsequent lookups, as the field's definition must be found via linear search through `FieldInfo::messageOrderedFields`. I've added more detail to the readme to explain how to access field values in more detail and to recommend by-definition lookup when possible.